### PR TITLE
Path error for child theme languages

### DIFF
--- a/languages/README.md
+++ b/languages/README.md
@@ -5,7 +5,7 @@ Any translation files placed here will be deleted when you update Storefront.
 ## Translating Storefront
 Put any custom Storefront translation files in your WordPress language directory: `/wp-content/languages/themes/storefront-it_IT.mo`.
 
-Alternatively you can put translations in your child theme: `/wp-content/themes/your-child-theme/languages/storefront-it_IT.mo`.
+Alternatively you can put translations in your child theme: `/wp-content/themes/your-child-theme/languages/it_IT.mo`.
 
 ## Contributing your translations back to Storefront
 If you would like to help out translating Storefront, please contribute on our translation page at [Transifex](https://www.transifex.com/projects/p/storefront-1/)


### PR DESCRIPTION
The correct path does not include the theme name in the filename of the language.
