### PR TITLE
update reference to function name in comment

### DIFF
--- a/content-single.php
+++ b/content-single.php
@@ -23,7 +23,7 @@
 	do_action( 'storefront_single_post' );
 
 	/**
-	 * Functions hooked in to storefront_single_post_after action
+	 * Functions hooked in to storefront_single_post_bottom action
 	 *
 	 * @hooked storefront_post_nav         - 10
 	 * @hooked storefront_display_comments - 20


### PR DESCRIPTION
The function name in the comment appears to be incorrect.
"storefront_single_post_after" is also referenced in single.php, but I'm not entirely sure what it's relationship to "storefront_single_post_bottom" might be.