### PR TITLE
Fix .storefront-primary-navigation width in Opera

### DIFF
--- a/assets/sass/base/_layout.scss
+++ b/assets/sass/base/_layout.scss
@@ -17,7 +17,7 @@
 	.site-header {
 		padding-top: ms(5);
 		padding-bottom: 0;
-		overflow: hidden;
+		overflow-x: hidden;
 
 		.site-branding {
 			display: block;

--- a/assets/sass/base/_layout.scss
+++ b/assets/sass/base/_layout.scss
@@ -17,6 +17,7 @@
 	.site-header {
 		padding-top: ms(5);
 		padding-bottom: 0;
+		overflow: hidden;
 
 		.site-branding {
 			display: block;


### PR DESCRIPTION
CSS for `.storefront-primary-navigation` was causing it to become extremely wide in Opera. This caused the horizontal scroll bar to appear needlessly. Setting `overflow: hidden;` to `.site-header` fixes the problem. `overflow-x: hidden;` would also be sufficient.