### PR TITLE
doctype in lowercase

### DIFF
--- a/header.php
+++ b/header.php
@@ -7,7 +7,7 @@
  * @package storefront
  */
 
-?><!DOCTYPE html>
+?><!doctype html>
 <html <?php language_attributes(); ?>>
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">


### PR DESCRIPTION
html5bp changed doctype and here's their reasoning https://github.com/h5bp/html5-boilerplate/issues/1522

laravel also changed it few days ago https://github.com/laravel/laravel/pull/4241