### PR TITLE
Css code added for Header Mini cart scroll effect.. ref #613

### DIFF
--- a/assets/sass/base/_base.scss
+++ b/assets/sass/base/_base.scss
@@ -312,6 +312,18 @@ body {
 		margin-bottom: 0;
 	}
 }
+.site-header-cart{
+	li{
+		.widget{
+			.widget_shopping_cart_content{
+				.woocommerce-mini-cart{
+					max-height: 16em;
+					overflow-y: auto;
+				}
+			}
+		}
+	}
+}
 
 .home.blog,
 .home.page:not(.page-template-template-homepage),


### PR DESCRIPTION
@stuartduff , @jameskoster ,

Using css fix worked for me to auto add scroll when product increase more then 3 in mini cart . so please check for the same and let me know if any changes required.

```
.site-header-cart li .widget .widget_shopping_cart_content .woocommerce-mini-cart {
    max-height: 16em;
    overflow-y: auto;
}
```

Thanks,