### PR TITLE
Update storefront-template-functions.php

### DIFF
--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -965,7 +965,8 @@ if ( ! function_exists( 'storefront_init_structured_data' ) ) {
 			if ( $image ) {
 				$json['image'] = array(
 					'@type'  => 'ImageObject',
-					'url'    => $image[0],
+					'representativeOfPage'	=> 'true',
+					'contentUrl'    => $image[0],
 					'width'  => $image[1],
 					'height' => $image[2],
 				);


### PR DESCRIPTION
Issue #620 updates issue with one attribute.

https://github.com/woocommerce/storefront/blob/master/inc/storefront-template-functions.php#L966
```
if ( $image ) {
				$json['image'] = array(
					'@type'  => 'ImageObject',
					'representativeOfPage'	=> 'true',
                                        'thumbnail' => //This needs to be nested with another ImageObject see http://schema.org/thumbnail
					'contentUrl'    => $image[0],
					'width'  => $image[1],
					'height' => $image[2],
				);
			}