### PR TITLE
Header Mini cart scroll issue fix using js ref #613

### DIFF
--- a/assets/js/woocommerce/header-cart.js
+++ b/assets/js/woocommerce/header-cart.js
@@ -20,6 +20,11 @@
 		}
 
 		cart.addEventListener( 'mouseover', function() {
+            var cart = document.querySelector( '.site-header-cart' );
+
+            var windowHeight  = window.outerHeight,
+                cartBottomPos = cart.querySelector( '.widget_shopping_cart_content' ).getBoundingClientRect().bottom + cart.offsetHeight,
+                cartList      = cart.querySelector( '.cart_list' );
 
 			if ( cartBottomPos > windowHeight ) {
 				cartList.style.maxHeight = '15em';


### PR DESCRIPTION
fixes -613 

When add_to_cart call it renders new html to mini cart so below variable becomes undefined or null so we have to redefine variable on mouseover as well.

```
var cart = document.querySelector( '.site-header-cart' );

            var windowHeight  = window.outerHeight,
                cartBottomPos = cart.querySelector( '.widget_shopping_cart_content' ).getBoundingClientRect().bottom + cart.offsetHeight,
                cartList      = cart.querySelector( '.cart_list' );
```
I have redefine it in js file and it worked for me . Hope this works :)

Thanks