### PR TITLE
Custom sidebar hook facility

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -165,6 +165,8 @@ if ( ! class_exists( 'Storefront' ) ) :
 					);
 				}
 			}
+			
+			$sidebar_args = apply_filters( 'storefront_sidebar_args', $sidebar_args );
 
 			foreach ( $sidebar_args as $sidebar => $args ) {
 				$widget_tags = array(


### PR DESCRIPTION
childtheme or plugin can hook to add extra sidebar without writing extra widget init hook and also this will work the same way other sidebar work

So, I suggest before sidebar register loop starts put a hook
$sidebar_args = apply_filters( 'storefront_sidebar_args', $sidebar_args );