### PR TITLE
No jquery dependency on client-side code.

### DIFF
--- a/assets/js/homepage.js
+++ b/assets/js/homepage.js
@@ -16,6 +16,7 @@
 			return;
 		}
 		var siteMain = document.querySelector('.site-main');
+		var htmlDirValue = document.documentElement.getAttribute('dir');
 		var updateDimensions = function() {
 			if (updateDimensions._tick) {
 				cancelAnimationFrame(updateDimensions._tick);
@@ -24,7 +25,7 @@
 				updateDimensions._tick = null;
 				// Make the homepage content full width and centrally aligned.
 				homepageContent.style.width = window.innerWidth + 'px';
-				if (document.documentElement.getAttribute('dir') !== 'rtl') {
+				if (htmlDirValue !== 'rtl') {
 					homepageContent.style.marginLeft = -siteMain.getBoundingClientRect().left + 'px';
 				} else {
 					homepageContent.style.marginRight = -siteMain.getBoundingClientRect().left + 'px';

--- a/assets/js/homepage.js
+++ b/assets/js/homepage.js
@@ -3,74 +3,74 @@
  *
  * Handles behaviour of the homepage featured image
  */
-(function() {
+( function() {
 
 	/**
 	 * Set hero content dimensions / layout
 	 * Run adaptive backgrounds and set colors
 	 */
-	document.addEventListener('DOMContentLoaded', function() {
-		var homepageContent = document.querySelector('.page-template-template-homepage .type-page.has-post-thumbnail');
-		if (!homepageContent) {
+	document.addEventListener( 'DOMContentLoaded', function() {
+		var homepageContent = document.querySelector( '.page-template-template-homepage .type-page.has-post-thumbnail' );
+		if ( !homepageContent ) {
 			// Only apply layout to the homepage content component if it exists on the page
 			return;
 		}
-		var siteMain = document.querySelector('.site-main');
-		var htmlDirValue = document.documentElement.getAttribute('dir');
+		var siteMain = document.querySelector( '.site-main' );
+		var htmlDirValue = document.documentElement.getAttribute( 'dir' );
 		var updateDimensions = function() {
-			if (updateDimensions._tick) {
-				cancelAnimationFrame(updateDimensions._tick);
+			if ( updateDimensions._tick ) {
+				cancelAnimationFrame( updateDimensions._tick );
 			}
-			updateDimensions._tick = requestAnimationFrame(function() {
+			updateDimensions._tick = requestAnimationFrame( function() {
 				updateDimensions._tick = null;
 				// Make the homepage content full width and centrally aligned.
 				homepageContent.style.width = window.innerWidth + 'px';
-				if (htmlDirValue !== 'rtl') {
+				if ( htmlDirValue !== 'rtl' ) {
 					homepageContent.style.marginLeft = -siteMain.getBoundingClientRect().left + 'px';
 				} else {
 					homepageContent.style.marginRight = -siteMain.getBoundingClientRect().left + 'px';
 				}
-			});
+			} );
 		};
 		// On window resize, set hero content dimensions / layout.
-		window.addEventListener('resize', updateDimensions);
+		window.addEventListener( 'resize', updateDimensions );
 		updateDimensions();
 
-		var img = homepageContent.getAttribute('data-featured-image').replace(/url\(\"(.*)\"\)/gi, '$1');
+		var img = homepageContent.getAttribute( 'data-featured-image' ).replace( /url\(\"(.*)\"\)/gi, '$1' );
 
-		window.RGBaster.colors(img, {
+		window.RGBaster.colors( img, {
 			paletteSize: 1,
 			success: function(payload) {
 				var rgb = payload.dominant;
-				var colors = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);
+				var colors = rgb.match( /^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/ );
 
 				var r = colors[1];
 				var g = colors[2];
 				var b = colors[3];
 				var brightness = 1;
 				// Get the average rgb value.
-				var overall = Math.round(((parseInt(r, 10) * 299) + (parseInt(g, 10) * 587) + (parseInt(b, 10) * 114)) / 1000);
-				if (overall > 230) {
+				var overall = Math.round( ( ( parseInt( r, 10 ) * 299 ) + ( parseInt( g, 10 ) * 587 ) + ( parseInt( b, 10 ) * 114 ) ) / 1000 );
+				if ( overall > 230 ) {
 					brightness = 0; // Black.
 				} else {
 					brightness = 30; // White.
 				}
 
-				var newr = Math.floor((255 - r) * brightness);
-				var newg = Math.floor((255 - g) * brightness);
-				var newb = Math.floor((255 - b) * brightness);
+				var newr = Math.floor( ( 255 - r ) * brightness );
+				var newg = Math.floor( ( 255 - g ) * brightness );
+				var newb = Math.floor( ( 255 - b ) * brightness );
 				var color = 'rgb(' + newr + ', ' + newg + ', ' + newb + ')';
 
 				homepageContent.style.color = color;
-				homepageContent.querySelectorAll('h1').forEach(function(h1) {
+				homepageContent.querySelectorAll( 'h1' ).forEach( function(h1) {
 					h1.style.color = color;
-				});
-				homepageContent.querySelectorAll('.entry-title, .entry-content').forEach(function(el) {
-					el.classList.add('loaded');
+				} );
+				homepageContent.querySelectorAll( '.entry-title, .entry-content' ).forEach( function(el) {
+					el.classList.add( 'loaded' );
 					el.style.textShadow = brightness >= 30 ? '0 4px 30px rgba(0,0,0,.9)' : '';
-				});
+				} );
 			}
-		});
-	});
+		} );
+	} );
 
-})();
+} )();

--- a/assets/js/homepage.js
+++ b/assets/js/homepage.js
@@ -40,7 +40,7 @@
 
 		window.RGBaster.colors( img, {
 			paletteSize: 1,
-			success: function(payload) {
+			success: function( payload ) {
 				var rgb = payload.dominant;
 				var colors = rgb.match( /^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/ );
 
@@ -62,10 +62,10 @@
 				var color = 'rgb(' + newr + ', ' + newg + ', ' + newb + ')';
 
 				homepageContent.style.color = color;
-				homepageContent.querySelectorAll( 'h1' ).forEach( function(h1) {
+				homepageContent.querySelectorAll( 'h1' ).forEach( function( h1 ) {
 					h1.style.color = color;
 				} );
-				homepageContent.querySelectorAll( '.entry-title, .entry-content' ).forEach( function(el) {
+				homepageContent.querySelectorAll( '.entry-title, .entry-content' ).forEach( function( el ) {
 					el.classList.add( 'loaded' );
 					el.style.textShadow = brightness >= 30 ? '0 4px 30px rgba(0,0,0,.9)' : '';
 				} );

--- a/assets/js/homepage.js
+++ b/assets/js/homepage.js
@@ -3,81 +3,73 @@
  *
  * Handles behaviour of the homepage featured image
  */
-( function() {
-
-	var homepageContent = '.page-template-template-homepage .type-page.has-post-thumbnail';
-
-	if ( ! jQuery( homepageContent ).length ) {
-		// Only apply layout to the homepage content component if it exists on the page
-		return;
-	}
+(function() {
 
 	/**
-	 * Set the hero component dimensions and positioning
-	 */
-	function homepageContentDimensions() {
-		var windowWidth	    = jQuery( window ).width();
-		var offset          = jQuery( '.site-main' ).offset();
-
-		// Make the homepage content full width and centrally aligned.
-		if ( jQuery( 'html' ).attr( 'dir' ) !== 'rtl' ) {
-			jQuery( homepageContent ).css( 'width', windowWidth ).css( 'margin-left', -offset.left );
-		} else {
-			jQuery( homepageContent ).css( 'width', windowWidth ).css( 'margin-right', -offset.left );
-		}
-	}
-
-	/**
-	 * On document ready
 	 * Set hero content dimensions / layout
 	 * Run adaptive backgrounds and set colors
 	 */
-	jQuery( document ).ready( function() {
-		homepageContentDimensions();
+	document.addEventListener('DOMContentLoaded', function() {
+		var homepageContent = document.querySelector('.page-template-template-homepage .type-page.has-post-thumbnail');
+		if (!homepageContent) {
+			// Only apply layout to the homepage content component if it exists on the page
+			return;
+		}
+		var siteMain = document.querySelector('.site-main');
+		var updateDimensions = function() {
+			if (updateDimensions._tick) {
+				cancelAnimationFrame(updateDimensions._tick);
+			}
+			updateDimensions._tick = requestAnimationFrame(function() {
+				updateDimensions._tick = null;
+				// Make the homepage content full width and centrally aligned.
+				homepageContent.style.width = window.innerWidth + 'px';
+				if (document.documentElement.getAttribute('dir') !== 'rtl') {
+					homepageContent.style.marginLeft = -siteMain.getBoundingClientRect().left + 'px';
+				} else {
+					homepageContent.style.marginRight = -siteMain.getBoundingClientRect().left + 'px';
+				}
+			});
+		};
+		// On window resize, set hero content dimensions / layout.
+		window.addEventListener('resize', updateDimensions);
+		updateDimensions();
 
-		var img = jQuery( '.page-template-template-homepage .type-page.has-post-thumbnail' ).data( 'featured-image' );
-			img = img.replace( 'url(', '' ).replace( ')', '' ).replace( /\"/gi, '' );
+		var img = homepageContent.getAttribute('data-featured-image').replace(/url\(\"(.*)\"\)/gi, '$1');
 
-		var RGBaster = window.RGBaster;
-
-		RGBaster.colors( img, {
+		window.RGBaster.colors(img, {
 			paletteSize: 1,
-			success: function( payload ) {
-				var rgb        = payload.dominant;
-				var colors     = rgb.match( /^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/ );
+			success: function(payload) {
+				var rgb = payload.dominant;
+				var colors = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);
 
-				// Get the average rgb value.
-				var overall    = Math.round( ( ( parseInt( colors[1], 10 ) * 299 ) + ( parseInt( colors[2], 10 ) * 587 ) + ( parseInt( colors[3], 10 ) * 114 ) ) /1000 );
-				var r          = colors[1];
-				var g          = colors[2];
-				var b          = colors[3];
+				var r = colors[1];
+				var g = colors[2];
+				var b = colors[3];
 				var brightness = 1;
-
-				if ( overall > 230 ) {
+				// Get the average rgb value.
+				var overall = Math.round(((parseInt(r, 10) * 299) + (parseInt(g, 10) * 587) + (parseInt(b, 10) * 114)) / 1000);
+				if (overall > 230) {
 					brightness = 0; // Black.
 				} else {
 					brightness = 30; // White.
 				}
 
-				var newr = Math.floor( ( 255 - r ) * brightness );
-				var newg = Math.floor( ( 255 - g ) * brightness );
-				var newb = Math.floor( ( 255 - b ) * brightness );
+				var newr = Math.floor((255 - r) * brightness);
+				var newg = Math.floor((255 - g) * brightness);
+				var newb = Math.floor((255 - b) * brightness);
+				var color = 'rgb(' + newr + ', ' + newg + ', ' + newb + ')';
 
-				jQuery( homepageContent + ', .page-template-template-homepage .type-page.has-post-thumbnail h1' ).css( 'color', 'rgb(' + newr + ', ' + newg + ', ' + newb + ')' );
-				jQuery( '.page-template-template-homepage .type-page.has-post-thumbnail .entry-title, .page-template-template-homepage .type-page.has-post-thumbnail .entry-content' ).addClass( 'loaded' );
-
-				if ( brightness >= 30 ) {
-					jQuery( '.page-template-template-homepage .type-page.has-post-thumbnail .entry-title, .page-template-template-homepage .type-page.has-post-thumbnail .entry-content' ).css( 'text-shadow', '0 4px 30px rgba(0,0,0,.9)' );
-				}
+				homepageContent.style.color = color;
+				homepageContent.querySelectorAll('h1').forEach(function(h1) {
+					h1.style.color = color;
+				});
+				homepageContent.querySelectorAll('.entry-title, .entry-content').forEach(function(el) {
+					el.classList.add('loaded');
+					el.style.textShadow = brightness >= 30 ? '0 4px 30px rgba(0,0,0,.9)' : '';
+				});
 			}
 		});
 	});
 
-	/**
-	 * On window resize
-	 * Set hero content dimensions / layout
-	 */
-	jQuery( window ).resize( function() {
-		homepageContentDimensions();
-	});
-} )();
+})();

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -5,63 +5,63 @@
  * Also adds a focus class to parent li's for accessibility.
  * Finally adds a class required to reveal the search in the handheld footer bar.
  */
-(function() {
+( function() {
 	// Wait for DOM to be ready.
-	document.addEventListener('DOMContentLoaded', function() {
-		var container = document.getElementById('site-navigation');
-		if (!container) {
+	document.addEventListener( 'DOMContentLoaded', function() {
+		var container = document.getElementById( 'site-navigation' );
+		if ( !container ) {
 			return;
 		}
 
-		var button = container.querySelector('button');
-		if (!button) {
+		var button = container.querySelector( 'button' );
+		if ( !button ) {
 			return;
 		}
 
-		var menu = container.querySelector('ul');
+		var menu = container.querySelector( 'ul' );
 		// Hide menu toggle button if menu is empty and return early.
-		if (!menu) {
+		if ( !menu ) {
 			button.style.display = 'none';
 			return;
 		}
 
-		button.setAttribute('aria-expanded', 'false');
-		menu.setAttribute('aria-expanded', 'false');
-		menu.classList.add('nav-menu');
+		button.setAttribute( 'aria-expanded', 'false' );
+		menu.setAttribute( 'aria-expanded', 'false' );
+		menu.classList.add( 'nav-menu' );
 
-		button.addEventListener('click', function() {
-			container.classList.toggle('toggled');
-			var expanded = container.classList.contains('toggled') ? 'true' : 'false';
-			button.setAttribute('aria-expanded', expanded);
-			menu.setAttribute('aria-expanded', expanded);
-		});
+		button.addEventListener( 'click', function() {
+			container.classList.toggle( 'toggled' );
+			var expanded = container.classList.contains( 'toggled' ) ? 'true' : 'false';
+			button.setAttribute( 'aria-expanded', expanded );
+			menu.setAttribute( 'aria-expanded', expanded );
+		} );
 
 		// Add class to footer search when clicked.
-		document.querySelectorAll('.storefront-handheld-footer-bar .search > a').forEach(function(anchor) {
-			anchor.addEventListener('click', function(event) {
-				anchor.parentElement.classList.toggle('active');
+		document.querySelectorAll( '.storefront-handheld-footer-bar .search > a' ).forEach( function(anchor) {
+			anchor.addEventListener( 'click', function(event) {
+				anchor.parentElement.classList.toggle( 'active' );
 				event.preventDefault();
-			});
-		});
+			} );
+		} );
 
 		// Add focus class to parents of sub-menu anchors.
-		document.querySelectorAll('.site-header .menu-item > a, .site-header .page_item > a, .site-header-cart a').forEach(function(anchor) {
+		document.querySelectorAll( '.site-header .menu-item > a, .site-header .page_item > a, .site-header-cart a' ).forEach( function(anchor) {
 			var li = anchor.parentNode;
-			anchor.addEventListener('focus', function() {
-				li.classList.add('focus');
-			});
-			anchor.addEventListener('blur', function() {
-				li.classList.remove('focus');
-			});
-		});
+			anchor.addEventListener( 'focus', function() {
+				li.classList.add( 'focus' );
+			} );
+			anchor.addEventListener( 'blur', function() {
+				li.classList.remove( 'focus' );
+			} );
+		} );
 
 		// Add an identifying class to dropdowns when on a touch device
 		// This is required to switch the dropdown hiding method from a negative `left` value to `display: none`.
-		if (('ontouchstart' in window || navigator.maxTouchPoints) && window.innerWidth > 767) {
-			document.querySelectorAll('.site-header ul ul, .site-header-cart .widget_shopping_cart').forEach(function(element) {
-				element.classList.add('sub-menu--is-touch-device');
-			});
+		if ( ( 'ontouchstart' in window || navigator.maxTouchPoints ) && window.innerWidth > 767 ) {
+			document.querySelectorAll( '.site-header ul ul, .site-header-cart .widget_shopping_cart' ).forEach( function(element) {
+				element.classList.add( 'sub-menu--is-touch-device' );
+			} );
 		}
-	});
+	} );
 
-})();
+} )();

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -12,13 +12,13 @@
 		if (!container) {
 			return;
 		}
-
-		var button = container.querySelector('button.menu-toggle');
+		
+		var button = container.querySelector('button');
 		if (!button) {
 			return;
 		}
-
-		var menu = document.getElementById('menu-navigation');
+		
+		var menu = container.querySelector('ul');
 		// Hide menu toggle button if menu is empty and return early.
 		if (!menu) {
 			button.style.display = 'none';

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -12,12 +12,12 @@
 		if (!container) {
 			return;
 		}
-		
+
 		var button = container.querySelector('button');
 		if (!button) {
 			return;
 		}
-		
+
 		var menu = container.querySelector('ul');
 		// Hide menu toggle button if menu is empty and return early.
 		if (!menu) {

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -37,15 +37,15 @@
 		} );
 
 		// Add class to footer search when clicked.
-		document.querySelectorAll( '.storefront-handheld-footer-bar .search > a' ).forEach( function(anchor) {
-			anchor.addEventListener( 'click', function(event) {
+		document.querySelectorAll( '.storefront-handheld-footer-bar .search > a' ).forEach( function( anchor ) {
+			anchor.addEventListener( 'click', function( event ) {
 				anchor.parentElement.classList.toggle( 'active' );
 				event.preventDefault();
 			} );
 		} );
 
 		// Add focus class to parents of sub-menu anchors.
-		document.querySelectorAll( '.site-header .menu-item > a, .site-header .page_item > a, .site-header-cart a' ).forEach( function(anchor) {
+		document.querySelectorAll( '.site-header .menu-item > a, .site-header .page_item > a, .site-header-cart a' ).forEach( function( anchor ) {
 			var li = anchor.parentNode;
 			anchor.addEventListener( 'focus', function() {
 				li.classList.add( 'focus' );
@@ -58,7 +58,7 @@
 		// Add an identifying class to dropdowns when on a touch device
 		// This is required to switch the dropdown hiding method from a negative `left` value to `display: none`.
 		if ( ( 'ontouchstart' in window || navigator.maxTouchPoints ) && window.innerWidth > 767 ) {
-			document.querySelectorAll( '.site-header ul ul, .site-header-cart .widget_shopping_cart' ).forEach( function(element) {
+			document.querySelectorAll( '.site-header ul ul, .site-header-cart .widget_shopping_cart' ).forEach( function( element ) {
 				element.classList.add( 'sub-menu--is-touch-device' );
 			} );
 		}

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -5,108 +5,63 @@
  * Also adds a focus class to parent li's for accessibility.
  * Finally adds a class required to reveal the search in the handheld footer bar.
  */
-( function() {
-	// Add class to footer search when clicked
-	jQuery( window ).load( function() {
-		jQuery( '.storefront-handheld-footer-bar .search > a' ).click( function(e) {
-			jQuery( this ).parent().toggleClass( 'active' );
-			e.preventDefault();
-		});
-	});
-
-	var container, button, menu;
-
-	container = document.getElementById( 'site-navigation' );
-	if ( ! container ) {
-		return;
-	}
-
-	button = container.getElementsByTagName( 'button' )[0];
-	if ( 'undefined' === typeof button ) {
-		return;
-	}
-
-	menu = container.getElementsByTagName( 'ul' )[0];
-
-	// Hide menu toggle button if menu is empty and return early.
-	if ( 'undefined' === typeof menu ) {
-		button.style.display = 'none';
-		return;
-	}
-
-	menu.setAttribute( 'aria-expanded', 'false' );
-
-	if ( -1 === menu.className.indexOf( 'nav-menu' ) ) {
-		menu.className += ' nav-menu';
-	}
-
-	button.onclick = function() {
-		if ( -1 !== container.className.indexOf( 'toggled' ) ) {
-			container.className = container.className.replace( ' toggled', '' );
-			button.setAttribute( 'aria-expanded', 'false' );
-			menu.setAttribute( 'aria-expanded', 'false' );
-		} else {
-			container.className += ' toggled';
-			button.setAttribute( 'aria-expanded', 'true' );
-			menu.setAttribute( 'aria-expanded', 'true' );
+(function() {
+	// Wait for DOM to be ready.
+	document.addEventListener('DOMContentLoaded', function() {
+		var container = document.getElementById('site-navigation');
+		if (!container) {
+			return;
 		}
-	};
 
-	// Sub-menu access from touchscreens
-		var masthead       = jQuery( '#masthead' );
-		var siteNavigation = masthead.find( '.main-navigation > div > ul' );
+		var button = container.querySelector('button.menu-toggle');
+		if (!button) {
+			return;
+		}
 
-		function toggleFocusClassTouchScreen() {
+		var menu = document.getElementById('menu-navigation');
+		// Hide menu toggle button if menu is empty and return early.
+		if (!menu) {
+			button.style.display = 'none';
+			return;
+		}
 
-			// Ensure the dropdowns close when user taps outside the site header
-			jQuery( document.body ).on( 'touchstart.storefront', function( e ) {
-				if ( ! jQuery( e.target ).closest( '.main-navigation li' ).length ) {
-					jQuery( '.main-navigation li' ).removeClass( 'focus' );
-				}
+		button.setAttribute('aria-expanded', 'false');
+		menu.setAttribute('aria-expanded', 'false');
+		menu.classList.add('nav-menu');
+
+		button.addEventListener('click', function() {
+			container.classList.toggle('toggled');
+			var expanded = container.classList.contains('toggled') ? 'true' : 'false';
+			button.setAttribute('aria-expanded', expanded);
+			menu.setAttribute('aria-expanded', expanded);
+		});
+
+		// Add class to footer search when clicked.
+		document.querySelectorAll('.storefront-handheld-footer-bar .search > a').forEach(function(anchor) {
+			anchor.addEventListener('click', function(event) {
+				anchor.parentElement.classList.toggle('active');
+				event.preventDefault();
 			});
-
-			// Disables the link from working on the first touch of a menu with children
-			siteNavigation.find( '.menu-item-has-children > a, .page_item_has_children > a' )
-				.on( 'touchstart.storefront', function( e ) {
-					var el = jQuery( this ).parent( 'li' );
-
-					if ( ! el.hasClass( 'focus' ) ) {
-						e.preventDefault();
-						el.toggleClass( 'focus' );
-						el.siblings( '.focus' ).removeClass( 'focus' );
-					}
-				});
-		}
-		// Add Focus Class for parents of sub-menus
-		siteNavigation.find( 'a' ).on( 'focus.storefront blur.storefront', function() {
-			jQuery( this ).parents( '.menu-item, .page_item' ).toggleClass( 'focus' );
 		});
 
-		// Triggers toggleFocusClassTouchScreen on touchscreen devices
-		if ( 'ontouchstart' in window ) {
-			jQuery( window ).on( 'resize.storefront', toggleFocusClassTouchScreen );
-			toggleFocusClassTouchScreen();
-		}
-
-	// Add focus to cart dropdown
-	jQuery( window ).load( function() {
-		jQuery( '.site-header-cart' ).find( 'a' ).on( 'focus.storefront blur.storefront', function() {
-			jQuery( this ).parents().toggleClass( 'focus' );
+		// Add focus class to parents of sub-menu anchors.
+		document.querySelectorAll('.site-header .menu-item > a, .site-header .page_item > a, .site-header-cart a').forEach(function(anchor) {
+			var li = anchor.parentNode;
+			anchor.addEventListener('focus', function() {
+				li.classList.add('focus');
+			});
+			anchor.addEventListener('blur', function() {
+				li.classList.remove('focus');
+			});
 		});
-	});
 
-	if ( is_touch_device() && jQuery( window ).width() > 767 ) {
 		// Add an identifying class to dropdowns when on a touch device
 		// This is required to switch the dropdown hiding method from a negative `left` value to `display: none`.
-		jQuery( '.main-navigation ul ul, .secondary-navigation ul ul, .site-header-cart .widget_shopping_cart' ).addClass( 'sub-menu--is-touch-device' );
+		if (('ontouchstart' in window || navigator.maxTouchPoints) && window.innerWidth > 767) {
+			document.querySelectorAll('.site-header ul ul, .site-header-cart .widget_shopping_cart').forEach(function(element) {
+				element.classList.add('sub-menu--is-touch-device');
+			});
+		}
+	});
 
-	}
-
-	/**
-	 * Check if the device is touch enabled
-	 * @return Boolean
-	 */
-	function is_touch_device() {
-		return 'ontouchstart' in window || navigator.maxTouchPoints;
-	}
-} )();
+})();

--- a/assets/js/woocommerce/checkout.js
+++ b/assets/js/woocommerce/checkout.js
@@ -25,7 +25,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 			var tallestPaymentBox = -1;
 			var currentPaymentBox = -1;
-			document.querySelectorAll( '.payment_box' ).forEach( function(box) {
+			document.querySelectorAll( '.payment_box' ).forEach( function( box ) {
 				var boxHeight = box.offsetHeight;
 				tallestPaymentBox = Math.max( tallestPaymentBox, boxHeight );
 				if ( box.querySelector( 'input:checked' ) ) {

--- a/assets/js/woocommerce/checkout.js
+++ b/assets/js/woocommerce/checkout.js
@@ -38,27 +38,24 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				termsHeight = 216; // This is static and set by WooCommerce core + 16px margin added by Storefront
 			}
 			var expandedHeight = review.offsetHeight + termsHeight + ( tallestPaymentBox - currentPaymentBox + 30 );
-
-			// If we're in desktop orientation and the order review column is taller than the customer details column and smaller than the window height
-			if ( details.offsetHeight > expandedHeight && window.innerWidth > 768 && window.innerHeight > expandedHeight ) {
-				if ( document.body.scrollTop > heading.getBoundingClientRect().top ) {
-					var paymentWidth = review.offsetWidth;
-					var paymentOffset = checkout.offsetWidth - paymentWidth;
-					review.classList.add( 'payment-fixed' );
-					review.style.width = paymentWidth + 'px';
-					// Compute only once rtl.
-					if ( review._isRTL === undefined ) {
-						review._isRTL = getComputedStyle( review ).direction === 'rtl';
-					}
-					if ( review._isRTL ) {
-						review.style.marginRight = paymentOffset + 'px';
-					} else {
-						review.style.marginLeft = paymentOffset + 'px';
-					}
-				} else {
-					review.classList.remove( 'payment-fixed' );
-					review.removeAttribute( 'style' );
+			// Ensure user can always see Place order when customer details and order review are side by side.
+			if ( details.offsetLeft < heading.offsetLeft && heading.getBoundingClientRect().top <= 0 && window.innerHeight > expandedHeight ) {
+				var paymentWidth = review.offsetWidth;
+				var paymentOffset = checkout.offsetWidth - paymentWidth;
+				review.classList.add( 'payment-fixed' );
+				review.style.width = paymentWidth + 'px';
+				// Compute only once rtl.
+				if ( review._isRTL === undefined ) {
+					review._isRTL = getComputedStyle( review ).direction === 'rtl';
 				}
+				if ( review._isRTL ) {
+					review.style.marginRight = paymentOffset + 'px';
+				} else {
+					review.style.marginLeft = paymentOffset + 'px';
+				}
+			} else {
+				review.classList.remove( 'payment-fixed' );
+				review.removeAttribute( 'style' );
 			}
 		} );
 	}

--- a/assets/js/woocommerce/checkout.js
+++ b/assets/js/woocommerce/checkout.js
@@ -1,65 +1,65 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener( 'DOMContentLoaded', function() {
 
 	// Do sticky on scroll
-	document.addEventListener('scroll', stickyPayment);
+	document.addEventListener( 'scroll', stickyPayment );
 	// Do sticky on window resize
-	window.addEventListener('resize', stickyPayment);
+	window.addEventListener( 'resize', stickyPayment );
 
 	/**
 	 * Make the order review element stick to the top of the browser window.
 	 */
 	function stickyPayment() {
-		if (stickyPayment._tick) {
-			cancelAnimationFrame(stickyPayment._tick);
+		if ( stickyPayment._tick ) {
+			cancelAnimationFrame( stickyPayment._tick );
 		}
-		stickyPayment._tick = requestAnimationFrame(function() {
+		stickyPayment._tick = requestAnimationFrame( function() {
 			stickyPayment._tick = null;
 
-			var review = document.querySelector('#order_review');
-			var heading = document.querySelector('#order_review_heading');
-			var checkout = document.querySelector('form.woocommerce-checkout');
-			var details = document.querySelector('#customer_details');
-			if (!heading || !checkout || !details) {
+			var review = document.querySelector( '#order_review' );
+			var heading = document.querySelector( '#order_review_heading' );
+			var checkout = document.querySelector( 'form.woocommerce-checkout' );
+			var details = document.querySelector( '#customer_details' );
+			if ( !heading || !checkout || !details ) {
 				return;
 			}
 
 			var tallestPaymentBox = -1;
 			var currentPaymentBox = -1;
-			document.querySelectorAll('.payment_box').forEach(function(box) {
+			document.querySelectorAll( '.payment_box' ).forEach( function(box) {
 				var boxHeight = box.offsetHeight;
-				tallestPaymentBox = Math.max(tallestPaymentBox, boxHeight);
-				if (box.querySelector('input:checked')) {
+				tallestPaymentBox = Math.max( tallestPaymentBox, boxHeight );
+				if ( box.querySelector( 'input:checked' ) ) {
 					currentPaymentBox = boxHeight;
 				}
-			});
+			} );
 
 			var termsHeight = 0; // If terms aren't being displayed don't include their height in calculations
-			if (document.querySelector('.wc-terms-and-conditions')) {
+			if ( document.querySelector( '.wc-terms-and-conditions' ) ) {
 				termsHeight = 216; // This is static and set by WooCommerce core + 16px margin added by Storefront
 			}
-			var expandedHeight = review.offsetHeight + termsHeight + (tallestPaymentBox - currentPaymentBox + 30);
+			var expandedHeight = review.offsetHeight + termsHeight + ( tallestPaymentBox - currentPaymentBox + 30 );
 
 			// If we're in desktop orientation and the order review column is taller than the customer details column and smaller than the window height
-			if (details.offsetHeight > expandedHeight && window.innerWidth > 768 && window.innerHeight > expandedHeight) {
-				if (document.body.scrollTop > heading.getBoundingClientRect().top) {
+			if ( details.offsetHeight > expandedHeight && window.innerWidth > 768 && window.innerHeight > expandedHeight ) {
+				if ( document.body.scrollTop > heading.getBoundingClientRect().top ) {
 					var paymentWidth = review.offsetWidth;
 					var paymentOffset = checkout.offsetWidth - paymentWidth;
-					review.classList.add('payment-fixed');
+					review.classList.add( 'payment-fixed' );
 					review.style.width = paymentWidth + 'px';
 					// Compute only once rtl.
-					if (review._isRTL === undefined) {
-						review._isRTL = getComputedStyle(review).direction === 'rtl';
+					if ( review._isRTL === undefined ) {
+						review._isRTL = getComputedStyle( review ).direction === 'rtl';
 					}
-					if (review._isRTL) {
+					if ( review._isRTL ) {
 						review.style.marginRight = paymentOffset + 'px';
 					} else {
 						review.style.marginLeft = paymentOffset + 'px';
 					}
 				} else {
-					review.classList.remove('payment-fixed');
-					review.removeAttribute('style');
+					review.classList.remove( 'payment-fixed' );
+					review.removeAttribute( 'style' );
 				}
 			}
-		});
+		} );
 	}
-});
+} );

--- a/assets/js/woocommerce/checkout.js
+++ b/assets/js/woocommerce/checkout.js
@@ -36,7 +36,7 @@ document.addEventListener('DOMContentLoaded', function() {
 			var gutter = checkoutWidth - addressWidth - paymentWidth;
 			var paymentOffset = addressWidth + gutter;
 			var currentPaymentInput = document.querySelector('.wc_payment_method input:checked');
-			var currentPaymentBox = currentPaymentInput.closest('.payment_box').offsetHeight;
+			var currentPaymentBox = currentPaymentInput.closest('.wc_payment_method').querySelector('.payment_box').offsetHeight;
 			var termsHeight = 0; // If terms aren't being displayed don't include their height in calculations
 			if (document.querySelector('.wc-terms-and-conditions')) {
 				termsHeight = 216; // This is static and set by WooCommerce core + 16px margin added by Storefront

--- a/assets/js/woocommerce/checkout.js
+++ b/assets/js/woocommerce/checkout.js
@@ -24,29 +24,26 @@ document.addEventListener('DOMContentLoaded', function() {
 			}
 
 			var tallestPaymentBox = -1;
+			var currentPaymentBox = -1;
 			document.querySelectorAll('.payment_box').forEach(function(box) {
-				tallestPaymentBox = Math.max(tallestPaymentBox, box.offsetHeight);
+				var boxHeight = box.offsetHeight;
+				tallestPaymentBox = Math.max(tallestPaymentBox, boxHeight);
+				if (box.querySelector('input:checked')) {
+					currentPaymentBox = boxHeight;
+				}
 			});
 
-			var topDistance = document.scrollTop;
-			var paymentWidth = review.offsetWidth;
-			var paymentHeight = review.offsetHeight;
-			var checkoutWidth = checkout.offsetWidth;
-			var addressWidth = details.offsetWidth;
-			var gutter = checkoutWidth - addressWidth - paymentWidth;
-			var paymentOffset = addressWidth + gutter;
-			var currentPaymentInput = document.querySelector('.wc_payment_method input:checked');
-			var currentPaymentBox = currentPaymentInput.closest('.wc_payment_method').querySelector('.payment_box').offsetHeight;
 			var termsHeight = 0; // If terms aren't being displayed don't include their height in calculations
 			if (document.querySelector('.wc-terms-and-conditions')) {
 				termsHeight = 216; // This is static and set by WooCommerce core + 16px margin added by Storefront
 			}
-			var expandedHeight = paymentHeight + termsHeight + (tallestPaymentBox - currentPaymentBox + 30);
-			var customerDetailsHeight = details.offsetHeight;
+			var expandedHeight = review.offsetHeight + termsHeight + (tallestPaymentBox - currentPaymentBox + 30);
 
 			// If we're in desktop orientation and the order review column is taller than the customer details column and smaller than the window height
-			if (customerDetailsHeight > expandedHeight && window.innerWidth > 768 && window.innerHeight > expandedHeight) {
-				if (topDistance > heading.getBoundingClientRect().top) {
+			if (details.offsetHeight > expandedHeight && window.innerWidth > 768 && window.innerHeight > expandedHeight) {
+				if (document.body.scrollTop > heading.getBoundingClientRect().top) {
+					var paymentWidth = review.offsetWidth;
+					var paymentOffset = checkout.offsetWidth - paymentWidth;
 					review.classList.add('payment-fixed');
 					review.style.width = paymentWidth + 'px';
 					// Compute only once rtl.

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -245,12 +245,12 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 */
 			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
-			wp_enqueue_script( 'storefront-navigation', get_template_directory_uri() . '/assets/js/navigation' . $suffix . '.js', array(), '20120206', true );
+			wp_enqueue_script( 'storefront-navigation', get_template_directory_uri() . '/assets/js/navigation' . $suffix . '.js', array(), $storefront_version, true );
 			wp_enqueue_script( 'storefront-skip-link-focus-fix', get_template_directory_uri() . '/assets/js/skip-link-focus-fix' . $suffix . '.js', array(), '20130115', true );
 
 			if ( is_page_template( 'template-homepage.php' ) && has_post_thumbnail() ) {
 				wp_enqueue_script( 'storefront-rgbaster', get_template_directory_uri() . '/assets/js/vendor/rgbaster.min.js', array(), '1.1.0', true );
-				wp_enqueue_script( 'storefront-homepage', get_template_directory_uri() . '/assets/js/homepage' . $suffix . '.js', array(), '20120206', true );
+				wp_enqueue_script( 'storefront-homepage', get_template_directory_uri() . '/assets/js/homepage' . $suffix . '.js', array(), $storefront_version, true );
 			}
 
 			if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -245,12 +245,12 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 */
 			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
-			wp_enqueue_script( 'storefront-navigation', get_template_directory_uri() . '/assets/js/navigation' . $suffix . '.js', array( 'jquery' ), '20120206', true );
+			wp_enqueue_script( 'storefront-navigation', get_template_directory_uri() . '/assets/js/navigation' . $suffix . '.js', array(), '20120206', true );
 			wp_enqueue_script( 'storefront-skip-link-focus-fix', get_template_directory_uri() . '/assets/js/skip-link-focus-fix' . $suffix . '.js', array(), '20130115', true );
 
 			if ( is_page_template( 'template-homepage.php' ) && has_post_thumbnail() ) {
-				wp_enqueue_script( 'storefront-rgbaster', get_template_directory_uri() . '/assets/js/vendor/rgbaster.min.js', array( 'jquery' ), '1.1.0', true );
-				wp_enqueue_script( 'storefront-homepage', get_template_directory_uri() . '/assets/js/homepage' . $suffix . '.js', array( 'jquery' ), '20120206', true );
+				wp_enqueue_script( 'storefront-rgbaster', get_template_directory_uri() . '/assets/js/vendor/rgbaster.min.js', array(), '1.1.0', true );
+				wp_enqueue_script( 'storefront-homepage', get_template_directory_uri() . '/assets/js/homepage' . $suffix . '.js', array(), '20120206', true );
 			}
 
 			if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -101,7 +101,7 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			wp_register_script( 'storefront-header-cart', get_template_directory_uri() . '/assets/js/woocommerce/header-cart' . $suffix . '.js', array(), $storefront_version, true );
 			wp_enqueue_script( 'storefront-header-cart' );
 
-			wp_register_script( 'storefront-sticky-payment', get_template_directory_uri() . '/assets/js/woocommerce/checkout' . $suffix . '.js', array('jquery'), $storefront_version, true );
+			wp_register_script( 'storefront-sticky-payment', get_template_directory_uri() . '/assets/js/woocommerce/checkout' . $suffix . '.js', array(), $storefront_version, true );
 
 			if ( is_checkout() && apply_filters( 'storefront_sticky_order_review', true ) ) {
 				wp_enqueue_script( 'storefront-sticky-payment' );
@@ -114,15 +114,17 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 		 * @since 1.6.0
 		 */
 		public function star_rating_script() {
-			if ( wp_script_is( 'jquery', 'done' ) && is_product() ) {
+			if ( is_product() ) {
 		?>
 			<script type="text/javascript">
-				jQuery( function( $ ) {
-					$( 'body' ).on( 'click', '#respond p.stars a', function() {
-						var $container = $( this ).closest( '.stars' );
-						$container.addClass( 'selected' );
+				var starsEl = document.querySelector('#respond p.stars');
+				if (starsEl) {
+					starsEl.addEventListener('click', function(event) {
+						if (event.target.tagName === 'A') {
+							starsEl.classList.add('selected');
+						}
 					});
-				});
+				}
 			</script>
 		<?php
 			}

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -117,13 +117,13 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			if ( is_product() ) {
 		?>
 			<script type="text/javascript">
-				var starsEl = document.querySelector('#respond p.stars');
-				if (starsEl) {
-					starsEl.addEventListener('click', function(event) {
-						if (event.target.tagName === 'A') {
-							starsEl.classList.add('selected');
+				var starsEl = document.querySelector( '#respond p.stars' );
+				if ( starsEl ) {
+					starsEl.addEventListener( 'click', function( event ) {
+						if ( event.target.tagName === 'A' ) {
+							starsEl.classList.add( 'selected' );
 						}
-					});
+					} );
 				}
 			</script>
 		<?php


### PR DESCRIPTION
Fixes #631 
Remove jquery dependency from client side code.
This PR applies 2 fixes:
- replace jQuery APIs with native DOM APIs, some examples:
  - `jQuery(document).ready(...` => `document.addEventListener('DOMContentLoaded', ...`
  - `jQuery(element).on('click', ...` => `element.addEventListener('click', ...`
  - `jQuery(document).find(...` => `document.querySelectorAll(...`
- improve performance on `scroll/resize` events by debouncing callback to next animation frame

The admin client has been purposefully left untouched in this PR, since wordpress itself relies on jQuery.

The PR relies on `NodeList.forEach` to loop through elements, but that's not implemented in Internet Explorer, though a polyfill can be used in that case https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach#Polyfill - let me know if that's needed.