### PR TITLE
Tweak product grid to align Add to cart buttons

### DIFF
--- a/assets/sass/woocommerce/woocommerce.scss
+++ b/assets/sass/woocommerce/woocommerce.scss
@@ -278,12 +278,18 @@ table.shop_table_responsive {
  * Products
  */
 ul.products {
+	display: flex;
+	flex-wrap: wrap;
 	margin-left: 0;
 	margin-bottom: 0;
 	clear: both;
 	@include clearfix;
 
 	li.product {
+		align-items: center;
+  		display: flex;
+  		flex-direction: column;
+  		justify-content: space-between;
 		list-style: none;
 		margin-left: 0;
 		margin-bottom: ms(7);


### PR DESCRIPTION
Currently on a product grid, when the title of a product takes several lines, it creates a gap between the different *Add to cart* buttons. These few declarations tweak that glitch simply, using flexbox.

Here is a before/after comparison:

![tweak_product-grid](https://user-images.githubusercontent.com/6014433/32400143-bff337a0-c0fc-11e7-8f25-5cdf4160f361.gif)