### PR TITLE
WooCommerce 3.3 columns & rows

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -120,8 +120,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 					'default_rows'    => 4,
 					'min_columns'     => 1,
 					'max_columns'     => 6,
-					'min_rows'        => 1,
-					'max_rows'        => ''
+					'min_rows'        => 1
 				)
 			) ) );
 

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -115,6 +115,14 @@ if ( ! class_exists( 'Storefront' ) ) :
 			add_theme_support( 'woocommerce', apply_filters( 'storefront_woocommerce_args', array(
 				'single_image_width'    => 416,
 				'thumbnail_image_width' => 324,
+				'product_grid'          => array(
+					'default_columns' => 3,
+					'default_rows'    => 4,
+					'min_columns'     => 1,
+					'max_columns'     => 6,
+					'min_rows'        => 1,
+					'max_rows'        => ''
+				)
 			) ) );
 
 			add_theme_support( 'wc-product-gallery-zoom' );

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -163,11 +163,18 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 		/**
 		 * Products per page
 		 *
-		 * @return integer number of products
 		 * @since  1.0.0
+		 * @param  integer $number number of products
+		 * @return integer         number of products
 		 */
-		public function products_per_page() {
-			return intval( apply_filters( 'storefront_products_per_page', 12 ) );
+		public function products_per_page( $number ) {
+
+			// Default number of products if < WooCommerce 3.3.
+			if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.3', '<' ) ) {
+				$number = 12;
+			}
+
+			return absint( apply_filters( 'storefront_products_per_page', $number ) );
 		}
 
 		/**

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -185,7 +185,13 @@ if ( ! function_exists( 'storefront_loop_columns' ) ) {
 	 * @since  1.0.0
 	 */
 	function storefront_loop_columns() {
-		return apply_filters( 'storefront_loop_columns', 3 ); // 3 products per row
+		$columns = 3; // 3 products per row
+
+		if ( function_exists( 'wc_get_default_products_per_row' ) ) {
+			$columns = wc_get_default_products_per_row();
+		}
+
+		return apply_filters( 'storefront_loop_columns', $columns );
 	}
 }
 

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -173,7 +173,7 @@ if ( ! function_exists( 'storefront_product_columns_wrapper' ) ) {
 	 */
 	function storefront_product_columns_wrapper() {
 		$columns = storefront_loop_columns();
-		echo '<div class="columns-' . intval( $columns ) . '">';
+		echo '<div class="columns-' . absint( $columns ) . '">';
 	}
 }
 

--- a/inc/woocommerce/storefront-woocommerce-template-hooks.php
+++ b/inc/woocommerce/storefront-woocommerce-template-hooks.php
@@ -38,8 +38,6 @@ add_action( 'woocommerce_after_shop_loop',        'woocommerce_pagination',     
 add_action( 'woocommerce_after_shop_loop',        'storefront_sorting_wrapper_close',         31 );
 add_action( 'woocommerce_after_shop_loop',        'storefront_product_columns_wrapper_close', 40 );
 
-add_filter( 'loop_shop_columns',                  'storefront_loop_columns' );
-
 add_action( 'woocommerce_before_shop_loop',       'storefront_sorting_wrapper',               9 );
 add_action( 'woocommerce_before_shop_loop',       'woocommerce_catalog_ordering',             10 );
 add_action( 'woocommerce_before_shop_loop',       'woocommerce_result_count',                 20 );
@@ -48,6 +46,11 @@ add_action( 'woocommerce_before_shop_loop',       'storefront_sorting_wrapper_cl
 add_action( 'woocommerce_before_shop_loop',       'storefront_product_columns_wrapper',       40 );
 
 add_action( 'storefront_footer',                  'storefront_handheld_footer_bar',           999 );
+
+// Legacy WooCommerce columns filter.
+if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.3', '<' ) ) {
+	add_filter( 'loop_shop_columns', 'storefront_loop_columns' );
+}
 
 /**
  * Products


### PR DESCRIPTION
Adds support for WooCommerce 3.3 default, min, and max columns and rows and ensures backwards compatibility with older versions.

Closes #680.