### PR TITLE
Remove hardcoded Jetpack infinite scroll setting.

### DIFF
--- a/inc/jetpack/class-storefront-jetpack.php
+++ b/inc/jetpack/class-storefront-jetpack.php
@@ -38,7 +38,6 @@ if ( ! class_exists( 'Storefront_Jetpack' ) ) :
 			add_theme_support( 'infinite-scroll', apply_filters( 'storefront_jetpack_infinite_scroll_args', array(
 				'container'      => 'main',
 				'footer'         => 'page',
-				'type'           => 'click',
 				'posts_per_page' => '12',
 				'render'         => array( $this, 'jetpack_infinite_scroll_loop' ),
 				'footer_widgets' => array(


### PR DESCRIPTION
At the moment Jetpack infinite scroll options are not being honoured because the theme is manually set to only allow the "button" option.

Closes #689.