### PR TITLE
Remove non-standard outdated CSS

### DIFF
--- a/assets/sass/vendors/font-awesome/_core.scss
+++ b/assets/sass/vendors/font-awesome/_core.scss
@@ -6,7 +6,4 @@
   font: normal normal normal #{$fa-font-size-base}/#{$fa-line-height-base} FontAwesome; // shortening font declaration
   font-size: inherit; // can't have font-size inherit on line above, so need to override
   text-rendering: auto; // optimizelegibility throws things off #1094
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-
 }


### PR DESCRIPTION
Removed `-moz-osx-font-smoothing: grayscale;` and `-webkit-font-smoothing: antialiased;`, as suggested in #698