### PR TITLE
Remove non-standard outdated CSS

### DIFF
--- a/assets/sass/admin/plugin-install.scss
+++ b/assets/sass/admin/plugin-install.scss
@@ -5,8 +5,6 @@
 			content: "\f463";
 			font: normal 19px/1 'dashicons';
 			margin: 0 5px 0 -2px;
-			-webkit-font-smoothing: antialiased;
-			-moz-osx-font-smoothing: grayscale;
 			vertical-align: bottom;
 			-webkit-animation: rotation 2s infinite linear;
 			animation: rotation 2s infinite linear;


### PR DESCRIPTION
Removed `-moz-osx-font-smoothing: grayscale;` and `-webkit-font-smoothing: antialiased;`, as suggested in #698