### PR TITLE
Remove non-standard outdated CSS

### DIFF
--- a/assets/sass/admin/admin.scss
+++ b/assets/sass/admin/admin.scss
@@ -79,8 +79,6 @@
 			content: "\f463";
 			font: normal 20px/1 'dashicons';
 			margin: 3px 5px 0 -2px;
-			-webkit-font-smoothing: antialiased;
-			-moz-osx-font-smoothing: grayscale;
 			vertical-align: bottom;
 			-webkit-animation: rotation 2s infinite linear;
 			animation: rotation 2s infinite linear;


### PR DESCRIPTION
Removed `-moz-osx-font-smoothing: grayscale;` and `-webkit-font-smoothing: antialiased;`, as suggested in #698