### PR TITLE
Remove non-standard outdated CSS

### DIFF
--- a/assets/sass/utils/_mixins.scss
+++ b/assets/sass/utils/_mixins.scss
@@ -93,7 +93,6 @@
 	display: inline-block;
 	outline: none;
 	-webkit-appearance: none;
-	-webkit-font-smoothing: antialiased;
 	border-radius: 0;
 	box-shadow:
 		inset 0 -1px 0 rgba(#000,.3);


### PR DESCRIPTION
Removed `-moz-osx-font-smoothing: grayscale;` and `-webkit-font-smoothing: antialiased;`, as suggested in #698