### PR TITLE
Remove non-standard outdated CSS

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -341,7 +341,6 @@ if ( ! class_exists( 'Storefront' ) ) :
 					border: 0 !important;
 					border-radius: 3px !important;
 					font-family: "Source Sans Pro", "Open Sans", sans-serif !important;
-					-webkit-font-smoothing: antialiased;
 					background-color: <?php echo esc_html( storefront_adjust_color_brightness( $background_color, -7 ) ); ?> !important;
 				}
 


### PR DESCRIPTION
Removed `-moz-osx-font-smoothing: grayscale;` and `-webkit-font-smoothing: antialiased;`, as suggested in #698