### PR TITLE
Revert "hotfix header overlay-x"

### DIFF
--- a/assets/sass/base/_base.scss
+++ b/assets/sass/base/_base.scss
@@ -268,8 +268,6 @@ body {
 
 .site {
 	overflow-x: hidden;
-	position: relative;
-	display: initial;
 }
 
 .site-content,


### PR DESCRIPTION
This reverts commit 3b5c6da496da5a2bf3bc39a8c433362a968f8a21.

Fixes https://github.com/woocommerce/storefront/issues/738.