### PR TITLE
Overlap with side widget fixed

### DIFF
--- a/assets/sass/woocommerce/woocommerce.scss
+++ b/assets/sass/woocommerce/woocommerce.scss
@@ -56,6 +56,7 @@
 
 	.widget_shopping_cart {
 		display: none;
+		padding-right: 15px;
 
 		.woocommerce-mini-cart__empty-message {
 			margin: ms(2);
@@ -159,7 +160,8 @@
 				}
 			}
 
-			&.cart {
+			&.
+			{
 				.count {
 					text-indent: 0;
 					display: block;


### PR DESCRIPTION
**Problem:**  CSS in cart overlaps with right-sidebar widget as shown in issue [683](https://github.com/woocommerce/storefront/issues/683).  This is right before the mobile breakpoint by only a couple pixels.

Screenshot
![image](https://user-images.githubusercontent.com/5580479/35539896-3d6b83dc-0508-11e8-9149-3f7a631de0e2.png)

**Solution**:  Modified `woocommerce.scss` to give a slight amount more room on the right side so that there's not overlap with the right sidebar widget.  

Result Screenshot:
![image](https://user-images.githubusercontent.com/5580479/35539959-85bba34c-0508-11e8-8046-1a8387fc4b4d.png)



**Caveat:** 
CSS fixed to give the table of the cart more room so that the side widget doesn't overlap.  Please note that other themes may overwrite this in their CSS.  This is especially the case with TwentySixteen and TwentyFifteen so far.