### PR TITLE
Hide homepage content section if empty title and content

### DIFF
--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -845,8 +845,12 @@ if ( ! function_exists( 'storefront_homepage_content' ) ) {
 		while ( have_posts() ) {
 			the_post();
 
-			get_template_part( 'content', 'homepage' );
+			$title   = get_the_title( get_the_ID() );
+			$content = get_the_content( get_the_ID() );
 
+			if ( '' !== $title || '' !== $content ) {
+				get_template_part( 'content', 'homepage' );
+			}
 		} // end of the loop.
 	}
 }


### PR DESCRIPTION
To test, edit the page with the "Homepage" template. If there's no content and title, the homepage section should not display in the frontend.

Fixes #673.