### PR TITLE
Style other action buttons in the widget cart

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -838,11 +838,17 @@ a.reset_variations {
 	}
 
 	.buttons {
-		.button {
+		a {
 			display: block;
+			margin-bottom: ms( -2 );
 
-			&:nth-child( odd ) {
-				margin-bottom: ms(-2);
+			&:last-child {
+				margin-bottom: 0;
+			}
+
+			img {
+				margin-left: auto;
+				margin-right: auto;
 			}
 		}
 	}


### PR DESCRIPTION
Before:

![screen shot 2018-03-16 at 19 29 30](https://user-images.githubusercontent.com/1177726/37540834-6151b1f6-2950-11e8-8387-7e0f1f7ace54.png)

After:

![screen shot 2018-03-16 at 19 27 34](https://user-images.githubusercontent.com/1177726/37540794-313536dc-2950-11e8-84d7-889ed7872efe.png)

Fixes #782.