### PR TITLE
Woocommerce Brands Integration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,7 +43,9 @@ module.exports = function( grunt ) {
 				'assets/js/admin/*.js',
 				'!assets/js/admin/*.min.js',
 				'assets/js/woocommerce/*.js',
-				'!assets/js/woocommerce/*.min.js'
+				'!assets/js/woocommerce/*.min.js',
+				'assets/js/woocommerce/extensions/*.js',
+				'!assets/js/woocommerce/extensions/*.min.js'
 			]
 		},
 
@@ -96,6 +98,18 @@ module.exports = function( grunt ) {
 						'!*.min.js'
 					],
 					dest: 'assets/js/woocommerce/',
+					ext: '.min.js'
+				}]
+			},
+			extensions: {
+				files: [{
+					expand: true,
+					cwd: 'assets/js/woocommerce/extensions/',
+					src: [
+						'*.js',
+						'!*.min.js'
+					],
+					dest: 'assets/js/woocommerce/extensions/',
 					ext: '.min.js'
 				}]
 			},
@@ -226,6 +240,10 @@ module.exports = function( grunt ) {
 					// WooCommerce js
 					'assets/js/woocommerce/*js',
 					'!assets/js/woocommerce/*.min.js',
+
+					// Extensions js
+					'assets/js/woocommerce/extensions/*js',
+					'!assets/js/woocommerce/extensions/*.min.js',
 
 					// Welcome screen js
 					'assets/js/admin/welcome-screen/*js',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -201,6 +201,7 @@ module.exports = function( grunt ) {
 					'style.scss',
 					'assets/css/admin/welcome-screen/*.scss',
 					'assets/css/woocommerce/*.scss',
+					'assets/css/woocommerce/extensions/*.scss',
 					'assets/css/jetpack/*.scss',
 					'assets/css/base/*.scss',
 					'assets/css/components/*.scss',

--- a/assets/css/woocommerce/extensions/brands.scss
+++ b/assets/css/woocommerce/extensions/brands.scss
@@ -90,6 +90,14 @@ div#brands_a_z {
 	}
 }
 
+.storefront-wc-brands-single-product {
+	margin: 0 0 ms( -3 );
+
+	img {
+		max-height: ms( 4 );
+	}
+}
+
 @include susy-media($desktop) {
 	div#brands_a_z {
 		ul.brands_index {

--- a/assets/css/woocommerce/extensions/brands.scss
+++ b/assets/css/woocommerce/extensions/brands.scss
@@ -11,6 +11,9 @@
 @import '../../../../node_modules/susy/sass/susy';
 @import '../../sass/vendors/modular-scale';
 
+/**
+ * Header region
+ */
 .header-widget-region {
 	.widget_brand_thumbnails {
 		ul.brand-thumbnails {
@@ -29,6 +32,44 @@
 					display: block;
 				}
 			}
+		}
+	}
+}
+
+/**
+ * WooCommerce Brand Layered Nav
+ */
+.widget_brand_nav {
+	ul {
+		li {
+			.count {
+				float: right;
+			}
+		}
+	}
+}
+
+/**
+ * WooCommerce Brand Archive
+ */
+.tax-product_brand {
+	.woocommerce-products-header {
+		display: flex;
+		flex-direction: column;
+		margin: 0 0 ms( 4 );
+		text-align: center;
+
+		.brand-thumbnail {
+			margin: 0 0 ms( 1 );
+			width: auto;
+			max-height: ms( 4 );
+			align-self: center;
+			order: 1;
+		}
+
+		.woocommerce-products-header__title,
+		.term-description {
+			order: 2;
 		}
 	}
 }
@@ -90,6 +131,9 @@ div#brands_a_z {
 	}
 }
 
+/**
+ * WooCommerce Brand single product
+ */
 .storefront-wc-brands-single-product {
 	margin: 0 0 ms( -3 );
 
@@ -102,6 +146,7 @@ div#brands_a_z {
 	div#brands_a_z {
 		ul.brands_index {
 			@include span(3 of 12);
+			transition: all 0.5s ease;
 		}
 	}
 

--- a/assets/css/woocommerce/extensions/brands.scss
+++ b/assets/css/woocommerce/extensions/brands.scss
@@ -8,6 +8,8 @@
 @import 'bourbon';
 @import '../../sass/utils/variables';
 @import '../../sass/utils/mixins';
+@import '../../../../node_modules/susy/sass/susy';
+@import '../../sass/vendors/modular-scale';
 
 .header-widget-region {
 	.widget_brand_thumbnails {
@@ -28,5 +30,89 @@
 				}
 			}
 		}
+	}
+}
+
+div#brands_a_z {
+	@include clearfix;
+
+	ul.brands_index {
+		margin-left: 0;
+		padding: 0;
+
+		li {
+			float: none;
+			display: inline-block;
+			margin: 0 ms( -5 ) ms( -6 ) 0;
+			padding: 0;
+			text-transform: uppercase;
+
+			a,
+			span {
+				float: none;
+				display: block;
+				border: 0;
+				padding: ms( -4 );
+				min-width: ms( 3 );
+				text-align: center;
+				background-color: #eeeeee;
+				color: $color_body;
+				line-height: 1;
+			}
+
+			span {
+				opacity: 0.3;
+			}
+		}
+	}
+
+	h3 {
+		text-transform: uppercase;
+	}
+
+	a.top {
+		padding: ms( -2 );
+		background-color: #eeeeee;
+		color: $color_body;
+		border: 0;
+		line-height: 1;
+	}
+
+	ul.brands {
+		margin-left: 0;
+		list-style-position: inside;
+
+		li {
+			margin: 0 0 ms( -4 );
+			padding: 0 0 ms( -4 );
+			border-bottom: 1px solid $color_border;
+		}
+	}
+}
+
+@include susy-media($desktop) {
+	div#brands_a_z {
+		ul.brands_index {
+			@include span(3 of 12);
+		}
+	}
+
+	h3 {
+		@include span(last 9 of 12);
+		clear: right;
+		text-transform: uppercase;
+
+		&:first-of-type {
+			margin-top: 0;
+		}
+	}
+
+	a.top {
+		clear: right;
+	}
+
+	ul.brands {
+		@include span(last 9 of 12);
+		clear: right;
 	}
 }

--- a/assets/js/woocommerce/extensions/brands.js
+++ b/assets/js/woocommerce/extensions/brands.js
@@ -1,0 +1,32 @@
+/**
+ * brands.js
+ *
+ * Adds sticky functionality to the brands index.
+ */
+ ( function() {
+ 	document.addEventListener( 'DOMContentLoaded', function() {
+		var brandsAZ = document.getElementsByClassName( 'brands_index' );
+
+		if ( ! brandsAZ.length ) {
+			return;
+		}
+
+		var adminBar              = document.body.classList.contains( 'admin-bar' ) ? 32 : 0,
+			brandsContainerHeight = document.getElementById( 'brands_a_z' ).scrollHeight,
+			brandsAZHeight        = brandsAZ[0].scrollHeight + 40;
+
+		var stickyBrandsAZ = function() {
+			if ( window.innerWidth > 768 && brandsAZ[0].getBoundingClientRect().top < 0 ) {
+				brandsAZ[0].style.paddingTop = Math.min( ( Math.abs( brandsAZ[0].getBoundingClientRect().top ) + 20 + adminBar ), brandsContainerHeight - brandsAZHeight ) + 'px';
+			} else {
+				brandsAZ[0].style.paddingTop = 0;
+			}
+		};
+
+		stickyBrandsAZ();
+
+		window.addEventListener( 'scroll', function() {
+			stickyBrandsAZ();
+		} );
+ 	} );
+} )();

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -196,6 +196,10 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 		 * @return void
 		 */
 		public function woocommerce_integrations_scripts() {
+			global $storefront_version;
+
+			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+
 			/**
 			 * Bookings
 			 */
@@ -210,6 +214,8 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			if ( $this->is_woocommerce_extension_activated( 'WC_Brands' ) ) {
 				wp_enqueue_style( 'storefront-woocommerce-brands-style', get_template_directory_uri() . '/assets/css/woocommerce/extensions/brands.css', 'storefront-woocommerce-style' );
 				wp_style_add_data( 'storefront-woocommerce-brands-style', 'rtl', 'replace' );
+
+				wp_enqueue_script( 'storefront-woocommerce-brands', get_template_directory_uri() . '/assets/js/woocommerce/extensions/brands' . $suffix . '.js', array(), $storefront_version, true );
 			}
 
 			/**

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -372,6 +372,72 @@ if ( ! function_exists( 'storefront_handheld_footer_bar_account_link' ) ) {
 	}
 }
 
+if ( ! function_exists( 'storefront_woocommerce_brands_homepage_section' ) ) {
+	/**
+	 * Display WooCommerce Brands
+	 * Hooked into the `homepage` action in the homepage template.
+	 * Requires WooCommerce Brands.
+	 *
+	 * @since  2.3.0
+	 * @link   https://woocommerce.com/products/brands/
+	 * @uses   apply_filters()
+	 * @uses   storefront_do_shortcode()
+	 * @uses   wp_kses_post()
+	 * @uses   do_action()
+	 * @return void
+	 */
+	function storefront_woocommerce_brands_homepage_section() {
+		$args = apply_filters( 'storefront_woocommerce_brands_args', array(
+			'number'     => 6,
+			'columns'    => 4,
+			'orderby'    => 'name',
+			'show_empty' => false,
+			'title'      => __( 'Shop by Brand', 'storefront' ),
+		) );
+
+		$shortcode_content = storefront_do_shortcode( 'product_brand_thumbnails', apply_filters( 'storefront_woocommerce_brands_shortcode_args', array(
+			'number'     => absint( $args['number'] ),
+			'columns'    => absint( $args['columns'] ),
+			'orderby'    => esc_attr( $args['orderby'] ),
+			'show_empty' => (bool) $args['show_empty'],
+		) ) );
+
+		echo '<section class="storefront-product-section storefront-woocommerce-brands" aria-label="' . esc_attr__( 'Product Brands', 'storefront' ) . '">';
+
+		do_action( 'storefront_homepage_before_woocommerce_brands' );
+
+		echo '<h2 class="section-title">' . wp_kses_post( $args['title'] ) . '</h2>';
+
+		do_action( 'storefront_homepage_after_woocommerce_brands_title' );
+
+		echo $shortcode_content;
+
+		do_action( 'storefront_homepage_after_woocommerce_brands' );
+
+		echo '</section>';
+	}
+}
+
+if ( ! function_exists( 'storefront_woocommerce_brands_archive' ) ) {
+	/**
+	 * Display brand image on brand archives
+	 * Requires WooCommerce Brands.
+	 *
+	 * @since  2.3.0
+	 * @link   https://woocommerce.com/products/brands/
+	 * @uses   is_tax()
+	 * @uses   wp_kses_post()
+	 * @uses   get_brand_thumbnail_image()
+	 * @uses   get_queried_object()
+	 * @return void
+	 */
+	function storefront_woocommerce_brands_archive() {
+		if ( is_tax( 'product_brand' ) ) {
+			echo wp_kses_post( get_brand_thumbnail_image( get_queried_object() ) );
+		}
+	}
+}
+
 if ( ! function_exists( 'storefront_woocommerce_brands_single' ) ) {
 	/**
 	 * Output product brand image for use on single product pages

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -371,3 +371,31 @@ if ( ! function_exists( 'storefront_handheld_footer_bar_account_link' ) ) {
 		echo '<a href="' . esc_url( get_permalink( get_option( 'woocommerce_myaccount_page_id' ) ) ) . '">' . esc_attr__( 'My Account', 'storefront' ) . '</a>';
 	}
 }
+
+if ( ! function_exists( 'storefront_woocommerce_brands_single' ) ) {
+	/**
+	 * Output product brand image for use on single product pages
+	 * Requires WooCommerce Brands.
+	 *
+	 * @since  2.3.0
+	 * @link   https://woocommerce.com/products/brands/
+	 * @uses   storefront_do_shortcode()
+	 * @uses   wp_kses_post()
+	 * @return void
+	 */
+	function storefront_woocommerce_brands_single() {
+		$brand = storefront_do_shortcode( 'product_brand', array(
+			'class' => ''
+		) );
+
+		if ( empty( $brand ) ) {
+			return;
+		}
+
+		?>
+		<div class="storefront-wc-brands-single-product">
+			<?php echo wp_kses_post( $brand ); ?>
+		</div>
+		<?php
+	}
+}

--- a/inc/woocommerce/storefront-woocommerce-template-hooks.php
+++ b/inc/woocommerce/storefront-woocommerce-template-hooks.php
@@ -55,7 +55,7 @@ if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.3', '<' ) ) {
 /**
  * Products
  *
- * @see  storefront_upsell_display()
+ * @see storefront_upsell_display()
  */
 remove_action( 'woocommerce_after_single_product_summary', 'woocommerce_upsell_display',               15 );
 add_action( 'woocommerce_after_single_product_summary',    'storefront_upsell_display',                15 );
@@ -65,8 +65,8 @@ add_action( 'woocommerce_after_shop_loop_item_title',      'woocommerce_show_pro
 /**
  * Header
  *
- * @see  storefront_product_search()
- * @see  storefront_header_cart()
+ * @see storefront_product_search()
+ * @see storefront_header_cart()
  */
 add_action( 'storefront_header', 'storefront_product_search', 40 );
 add_action( 'storefront_header', 'storefront_header_cart',    60 );
@@ -80,4 +80,13 @@ if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '2.3', '>=' ) ) {
 	add_filter( 'woocommerce_add_to_cart_fragments', 'storefront_cart_link_fragment' );
 } else {
 	add_filter( 'add_to_cart_fragments', 'storefront_cart_link_fragment' );
+}
+
+/**
+ * Integrations
+ *
+ * @see storefront_woocommerce_brands_single()
+ */
+if ( class_exists( 'WC_Brands' ) ) {
+	add_action( 'woocommerce_single_product_summary', 'storefront_woocommerce_brands_single', 4 );
 }

--- a/inc/woocommerce/storefront-woocommerce-template-hooks.php
+++ b/inc/woocommerce/storefront-woocommerce-template-hooks.php
@@ -85,8 +85,12 @@ if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '2.3', '>=' ) ) {
 /**
  * Integrations
  *
+ * @see storefront_woocommerce_brands_archive()
  * @see storefront_woocommerce_brands_single()
+ * @see storefront_woocommerce_brands_homepage_section()
  */
 if ( class_exists( 'WC_Brands' ) ) {
+	add_action( 'woocommerce_archive_description', 'storefront_woocommerce_brands_archive', 5 );
 	add_action( 'woocommerce_single_product_summary', 'storefront_woocommerce_brands_single', 4 );
+	add_action( 'homepage', 'storefront_woocommerce_brands_homepage_section', 80 );
 }


### PR DESCRIPTION
To test:

* Install WooCommerce Brands
* Create a few brands and assign product to them
* On the homepage, you should see a new "Brands" section
* On single product pages, you should see the brand image above the logo
* On archive pages, you should see the brand + brand description.

Designs: https://cloudup.com/c5wszle3RFk 

Closes #627.