### PR TITLE
Increase max-height for sub menus

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -1228,7 +1228,7 @@ button.menu-toggle {
 
 				&.toggled-on {
 					visibility: visible;
-					max-height: 1750px;
+					max-height: 9999px;
 					opacity: 1;
 				}
 			}
@@ -1248,7 +1248,7 @@ button.menu-toggle {
 	.handheld-navigation,
 	.menu > ul:not( .nav-menu ),
 	ul[aria-expanded=true] {
-		max-height: 1750px;
+		max-height: 9999px;
 	}
 }
 


### PR DESCRIPTION
Previously max height on sub menus was set to `1750px`. Sites with a large menus were only showing a portion of the items.

This PR increases that number to `9999px`. 

The enhancements to the menu added in #669 also make this issue unlikely to be a problem again, since sub menus are hidden by default.

Closes #798. 
