### PR TITLE
Increase size of branding section if secondary navigation not used

### DIFF
--- a/assets/css/base/_layout.scss
+++ b/assets/css/base/_layout.scss
@@ -20,12 +20,12 @@
 
 		.site-branding {
 			display: block;
-			@include span(3 of 12);
+			@include span(12 of 12);
 			clear: both;
 
 			img {
 				height: auto;
-				max-width: 100%;
+				max-width: 230px;
 				max-height: none;
 			}
 		}
@@ -33,8 +33,12 @@
 
 	.woocommerce-active {
 		.site-header {
-			.secondary-navigation {
-				@include span(6 of 12);
+			.site-branding {
+				@include span(9 of 12);
+
+				img {
+					max-width: 100%;
+				}
 			}
 
 			.site-search {
@@ -50,6 +54,31 @@
 			.site-header-cart {
 				@include span(last 3 of 12);
 				margin-bottom: 0;
+			}
+		}
+	}
+
+	.storefront-secondary-navigation {
+		.site-header {
+			.site-branding {
+				@include span(5 of 12);
+			}
+
+			.secondary-navigation {
+				@include span(last 7 of 12);
+			}
+		}
+
+		&.woocommerce-active {
+			.site-header {
+				.site-branding {
+					@include span(3 of 12);
+
+				}
+
+				.secondary-navigation {
+					@include span(6 of 12);
+				}
 			}
 		}
 	}

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -330,6 +330,11 @@ if ( ! class_exists( 'Storefront' ) ) :
 				$classes[] = 'has-post-thumbnail';
 			}
 
+			// Add class when Secondary Navigation is in use
+			if ( has_nav_menu( 'secondary' ) ) {
+				$classes[] = 'storefront-secondary-navigation';
+			}
+
 			return $classes;
 		}
 


### PR DESCRIPTION
This PR makes a few changes to the header section, increasing the size of the site branding section when the secondary navigation is not in use.

It also increases the size of the branding section if WooCommerce is not in use, taking up space from other elements that are only visible when the plugin is in use.

See issue for more context.

Closes #793.