### PR TITLE
Remove gallery negative margin

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -409,14 +409,6 @@ ul.products {
 				margin-bottom: ms(3);
 			}
 
-			.woocommerce-product-gallery__wrapper {
-				.woocommerce-product-gallery__image {
-					&:not( :only-child ):not( .flex-active-slide ) {
-						margin-left: 1px;
-					}
-				}
-			}
-
 			.flex-control-thumbs {
 				@include clearfix;
 				margin: 0;


### PR DESCRIPTION
This PR reverts https://github.com/woocommerce/storefront/pull/749.

Since in the end this is an issue with Flexslider, I'll open an issue there.

Closes #810.