### PR TITLE
[2.3] Improve sticky button behavior with non-core product types

### DIFF
--- a/assets/js/sticky-add-to-cart.js
+++ b/assets/js/sticky-add-to-cart.js
@@ -1,3 +1,4 @@
+/*global storefront_sticky_add_to_cart_params */
 ( function() {
 	document.addEventListener( 'DOMContentLoaded', function() {
 		var stickyAddToCart = document.getElementsByClassName( 'storefront-sticky-add-to-cart' );
@@ -6,7 +7,11 @@
 			return;
 		}
 
-		var trigger = document.getElementsByClassName( 'entry-summary' );
+		if ( typeof storefront_sticky_add_to_cart_params === 'undefined' ) {
+			return;
+		}
+
+		var trigger = document.getElementsByClassName( storefront_sticky_add_to_cart_params.trigger_class );
 
 		if ( trigger.length > 0 ) {
 			var stickyAddToCartToggle = function() {

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -445,7 +445,7 @@ if ( ! function_exists( 'storefront_sticky_single_add_to_cart' ) ) {
 							<?php echo wp_kses_post( wc_get_rating_html( $product->get_average_rating() ) ); ?>
 						</div>
 						<a href="<?php echo esc_url( $product->add_to_cart_url() ); ?>" class="storefront-sticky-add-to-cart__content-button button alt">
-							<?php echo $product->is_type( 'variable' ) ? esc_attr__( 'Select options', 'storefront' ) : esc_attr( $product->single_add_to_cart_text() ); ?>
+							<?php echo esc_attr( $product->add_to_cart_text() ); ?>
 						</a>
 					</div>
 				</div>

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -433,6 +433,12 @@ if ( ! function_exists( 'storefront_sticky_single_add_to_cart' ) ) {
 			return;
 		}
 
+		$params = apply_filters( 'storefront_sticky_add_to_cart_params', array(
+			'trigger_class' => 'entry-summary'
+		) );
+
+		wp_localize_script( 'storefront-sticky-add-to-cart', 'storefront_sticky_add_to_cart_params', $params );
+
 		wp_enqueue_script( 'storefront-sticky-add-to-cart' );
 		?>
 			<section class="storefront-sticky-add-to-cart">


### PR DESCRIPTION
Because the sticky button element is now on by default, it might make sense to ensure it works reliably with non-core product types. I did some tests and found a couple issues -- hopefully this PR addresses them well. 

1. The sticky button text is not generic enough. A more suitable method to populate it might be `add_to_cart_text`. My feeling is it works a bit better than the existing conditional logic that uses `single_add_to_cart_text`. It produces the expected result with all product types I tested.
2. Allow customizing the "trigger" element. Some product types may include options to display add-to-cart form content after the 'entry-summary' element. In such cases, the sticky-button behavior should be customizable (ideally) to work reliably.