### PR TITLE
Remove Sass extend from icons

### DIFF
--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -12,13 +12,10 @@
 @import '../sass/vendors/font-awesome/fa-solid';
 @import '../sass/vendors/modular-scale';
 
-%fas {
-	@extend .fas;
-}
-
 @mixin sf-fa-icon {
 	@include fa-icon;
-	@extend %fas;
+	font-family: 'Font Awesome 5 Free';
+	font-weight: 900;
 	line-height: inherit;
 	vertical-align: baseline;
 }


### PR DESCRIPTION
This PR changes the way the CSS is compiled for the `icons.scss` file, fixing the issues reported in #853.

Fixes #853.