### PR TITLE
WordPress 4.9.6 + GDPR

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -880,6 +880,10 @@ input[type='submit'],
 input[type='checkbox'],
 input[type='radio'] {
 	padding: 0; /* Addresses excess padding in IE8/9 */
+
+	& + label {
+		margin: 0 0 0 ms(-4);
+	}
 }
 
 input[type='search']::-webkit-search-decoration { /* Corrects inner padding displayed oddly in S5, Chrome on OSX */

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -455,6 +455,14 @@ body {
 
 .site-info {
 	padding: ms(5) 0;
+
+	span[role=separator] {
+		padding: 0 ms(-6) 0 ms(-5);
+
+		&::before {
+			content: '\007c';
+		}
+	}
 }
 
 /**

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -127,7 +127,13 @@ if ( ! function_exists( 'storefront_credit' ) ) {
 		<div class="site-info">
 			<?php echo esc_html( apply_filters( 'storefront_copyright_text', $content = '&copy; ' . get_bloginfo( 'name' ) . ' ' . date( 'Y' ) ) ); ?>
 			<?php if ( apply_filters( 'storefront_credit_link', true ) ) { ?>
-			<br /> <?php echo '<a href="https://woocommerce.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="author">' . esc_html__( 'Built with Storefront &amp; WooCommerce', 'storefront' ) . '</a>' ?>
+			<br />
+			<?php
+				if ( apply_filters( 'storefront_privacy_policy_link', true ) && function_exists( 'the_privacy_policy_link' ) ) {
+					the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
+				}
+			?>
+			<?php echo '<a href="https://woocommerce.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="author">' . esc_html__( 'Built with Storefront &amp; WooCommerce', 'storefront' ) . '</a>.' ?>
 			<?php } ?>
 		</div><!-- .site-info -->
 		<?php


### PR DESCRIPTION
Adds 'Privacy link' to footer:

![screen shot 2018-05-10 at 12 54 43](https://user-images.githubusercontent.com/1177726/39868501-cb5cb34e-5451-11e8-8c18-32bfaa606086.png)

Adds padding to labels after checkboxes:

![screen shot 2018-05-10 at 12 57 44](https://user-images.githubusercontent.com/1177726/39868505-ceebc4e6-5451-11e8-815f-2fc96da093f0.png)

This PR requires WordPress 4.9.6.

Fixes https://github.com/woocommerce/storefront/issues/835.