### PR TITLE
Revert global col-full and remove relative positioning from header col-full

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -279,10 +279,6 @@ body {
 	-webkit-tap-highlight-color: rgba( 0, 0, 0, 0 );
 }
 
-.col-full {
-	@include clearfix;
-}
-
 /**
  * Header
  */

--- a/assets/css/base/_layout.scss
+++ b/assets/css/base/_layout.scss
@@ -121,6 +121,7 @@
 	}
 
 	.col-full {
+		@include clearfix;
 		@include container($container-width);
 		padding: 0 ms(5);
 		box-sizing: content-box;

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -56,12 +56,6 @@
  * Header Elements
  */
 .woocommerce-active {
-	.site-header {
-		.col-full {
-			position: relative;
-		}
-	}
-
 	.site-branding {
 		float: left;
 	}


### PR DESCRIPTION
To test, check if the site title and menu button show side by side on mobile devices, and that the title is clickable on mobile:

<img width="319" alt="screen shot 2018-05-16 at 11 50 43" src="https://user-images.githubusercontent.com/1177726/40112934-9bd933d8-58ff-11e8-868c-13d4fa32fb6b.png">

Closes #872.