### PR TITLE
Remove legacy font weight

### DIFF
--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -194,7 +194,6 @@ input[type='submit'],
 					bottom: 0;
 					text-align: center;
 					line-height: 2.618046972; // 4.236/1.618
-					font-weight: 400;
 					font-size: ms(3);
 					text-indent: 0;
 					display: block;


### PR DESCRIPTION
Remove `font-weight` that is currently preventing the new Font Awesome icons from displaying on the handheld footer bar.

Closes #878.