### PR TITLE
Decrease breadcrumb bottom margin

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1881,7 +1881,7 @@ dl.variation {
 	 */
 	.storefront-breadcrumb {
 		padding: ms(2) 0;
-		margin: 0 0 ms(7);
+		margin: 0 0 ms(6);
 	}
 
 	/**


### PR DESCRIPTION
The recent changes to the breadcrumb wrappers seem to have increased the size of the breadcrumbs bottom margin, this PR reduces the size of the margin.

Compare 2.2 vs 2.3 to see the difference in size.