### PR TITLE
Memberships mobile table layout

### DIFF
--- a/assets/css/woocommerce/extensions/memberships.scss
+++ b/assets/css/woocommerce/extensions/memberships.scss
@@ -46,3 +46,13 @@
 		}
 	}
 }
+
+@include susy-media (max-width $desktop) {
+	.woocommerce-account {
+		table {
+			&.my_account_memberships {
+				table-layout: auto;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Before:

<img width="364" alt="screen shot 2018-05-23 at 16 11 53" src="https://user-images.githubusercontent.com/1177726/40426576-1c4a2e10-5ea4-11e8-9110-eaca3c4770a2.png">

After:

<img width="353" alt="screen shot 2018-05-23 at 16 11 24" src="https://user-images.githubusercontent.com/1177726/40426595-21dcff24-5ea4-11e8-8999-803a5bff3313.png">

Closes #754.