### PR TITLE
Fix #907 h3 scoping issue in woocommerce brands integration

### DIFF
--- a/assets/css/woocommerce/extensions/brands.scss
+++ b/assets/css/woocommerce/extensions/brands.scss
@@ -148,24 +148,24 @@ div#brands_a_z {
 			@include span(3 of 12);
 			transition: all 0.5s ease;
 		}
-	}
 
-	h3 {
-		@include span(last 9 of 12);
-		clear: right;
-		text-transform: uppercase;
+		h3 {
+			@include span(last 9 of 12);
+			clear: right;
+			text-transform: uppercase;
 
-		&:first-of-type {
-			margin-top: 0;
+			&:first-of-type {
+				margin-top: 0;
+			}
 		}
-	}
 
-	a.top {
-		clear: right;
-	}
+		a.top {
+			clear: right;
+		}
 
-	ul.brands {
-		@include span(last 9 of 12);
-		clear: right;
+		ul.brands {
+			@include span(last 9 of 12);
+			clear: right;
+		}
 	}
 }


### PR DESCRIPTION
see bug https://github.com/woocommerce/storefront/issues/907 

The brands.scss contains incorrectly scoped css in the brands integration, that applies to all h3 tags here: assets/css/woocommerce/extensions/brands.scss#153

This change was introduced in the Woocommerce Brands Integration #803 PR (#803).

The fix is easy, to move the the global h3 selector inside the div#brands_a_z selector in the brands.scss file.