### PR TITLE
Only add title to columns with data title attribute

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -254,10 +254,12 @@ table.shop_table_responsive {
 			text-align: right;
 			clear: both;
 
-			&::before {
-				content: attr(data-title) ': ';
-				font-weight: 600;
-				float: left;
+			&[data-title] {
+				&::before {
+					content: attr(data-title) ': ';
+					font-weight: 600;
+					float: left;
+				}
 			}
 
 			&.product-remove {


### PR DESCRIPTION
We use the title in the `data-title` attribute to display the title in responsive tables. This change makes sure we only add the title if the data attribute exists in the column.

Otherwise you get an empty `:` (colon) when no title exists in the column.

To test, go to My Account > Orders > View order. Resize your window. Remove the `data-title` from one of the columns. Without this PR you'll see a a colon with no title.

Closes #910.