### PR TITLE
Allow for a flexible height on the site logo

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -75,6 +75,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 				'height'      => 110,
 				'width'       => 470,
 				'flex-width'  => true,
+				'flex-height' => true,
 			) ) );
 
 			/**


### PR DESCRIPTION
Allowing this also 'enables' the "Skip Cropping" button in the Media Library UI.

<img width="292" alt="screen shot 2018-06-20 at 12 41 23" src="https://user-images.githubusercontent.com/1177726/41656259-4d4d9fbc-7487-11e8-89a6-66281f35bfca.png">
