### PR TITLE
Remove font weight from from a/link elements 

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -246,7 +246,6 @@ img {
 a {
 	color: $color_links;
 	text-decoration: none;
-	font-weight: 400;
 
 	&:focus {
 		outline: 1px dotted $color_woocommerce;


### PR DESCRIPTION
Removes the default from `a` links, it's by default 400 in every browser.

This change enhances compatibility with web site builder plugins. 

Closes #920.