### PR TITLE
Remove static related/upsells columns size

### DIFF
--- a/assets/css/woocommerce/woocommerce-legacy.scss
+++ b/assets/css/woocommerce/woocommerce-legacy.scss
@@ -141,4 +141,18 @@
 			}
 		}
 	}
+
+	/**
+	 * Full width single product
+	 */
+	.storefront-full-width-content.single-product {
+		.related,
+		.upsells {
+			ul.products {
+				li.product {
+					@include span(4 of 12);
+				}
+			}
+		}
+	}
 }

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -2269,15 +2269,6 @@ dl.variation {
 				}
 			}
 		}
-
-		.related,
-		.upsells {
-			ul.products {
-				li.product {
-					@include span(4 of 12);
-				}
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
In https://github.com/woocommerce/storefront/pull/779 we added support for the columns wrappers in WC 2.3.

This PR remove the static CSS for the 3 columns in related products and inherits the CSS from the columns wrapper.

Also keeps backwards compatibility by adding the removed CSS to the legacy file.

