### PR TITLE
LTR price filter label when in RTL

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -981,6 +981,22 @@ a.reset_variations {
 }
 
 /**
+ * Right to left styles
+ */
+
+/*!rtl:begin:ignore*/
+.rtl {
+	.widget_price_filter {
+		.price_label,
+		.price_label span {
+			direction: ltr;
+			unicode-bidi: embed;
+		}
+	}
+}
+/*!rtl:end:ignore*/
+
+/**
  * Cart
  */
 table.cart {


### PR DESCRIPTION
For both RTL&LTR sites, the price slider widget label should display from left to right $1 - $100.

See the following PRs or #921 for more information:

https://github.com/woocommerce/woocommerce/pull/20417
https://github.com/woocommerce/woocommerce/pull/20221

Kudos @mikeyarce. :)

Closes #921.