### PR TITLE
Accessibility: Allow zooming

### DIFF
--- a/header.php
+++ b/header.php
@@ -11,7 +11,7 @@
 <html <?php language_attributes(); ?>>
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2.0">
 <link rel="profile" href="http://gmpg.org/xfn/11">
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 


### PR DESCRIPTION
This PR fixes WCAG 2.0 (AA) violation by enabling zooming and scale. Being able to zoom is essential for users with low vision.

Test in before/after in Chrome mobile. With this PR you should be able to pinch to Zoom.

Closes #919.
