### PR TITLE
Handheld navigation dropdown toggle color

### DIFF
--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -653,7 +653,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			.site-branding h1 a,
 			.site-footer .storefront-handheld-footer-bar a:not(.button),
 			button.menu-toggle,
-			button.menu-toggle:hover {
+			button.menu-toggle:hover,
+			.handheld-navigation .dropdown-toggle {
 				color: ' . $storefront_theme_mods['header_link_color'] . ';
 			}
 


### PR DESCRIPTION
Like all other links in the header, the color for the handheld dropdown handle should be the same as of the other header.

To test:

* Go to Customizer > Header and change the color of the links. 
* Resize the browser window
* The dropdown handle should have the color selected in the Customizer

<img width="360" alt="screen shot 2018-07-11 at 17 00 03" src="https://user-images.githubusercontent.com/1177726/42584902-2dbf9488-852c-11e8-9509-80d5e0817f24.png">


Closes #934.