### PR TITLE
Prevent select from overflowing container

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -44,6 +44,7 @@ textarea {
 select {
 	color: initial;
 	font-family: $base-font;
+	max-width: 100%;
 }
 
 h1,

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -573,6 +573,7 @@ ul.products {
 		}
 
 		table.variations {
+			table-layout: fixed;
 			margin: 0;
 
 			th,
@@ -585,6 +586,10 @@ ul.products {
 
 			.value {
 				margin-bottom: 1em;
+			}
+
+			select {
+				max-width: 70%;
 			}
 		}
 

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -590,6 +590,7 @@ ul.products {
 
 			select {
 				max-width: 70%;
+				vertical-align: middle;
 			}
 		}
 


### PR DESCRIPTION
Fixes overflow issue noticed in https://github.com/woocommerce/woocommerce/issues/20756#issue-340209496

* Sets global select `max-width` to `100%`
* Sets variations select `max-width` to `75%` so that the "clear" button is able to line up side by side with the dropdown.

Before:

![img_5740](https://user-images.githubusercontent.com/1177726/42648995-5096a22e-8600-11e8-9690-ef535a778014.jpg)

After:

![img_5739](https://user-images.githubusercontent.com/1177726/42649000-592ef1d4-8600-11e8-98da-1a187f78167b.jpg)

