### PR TITLE
Add `storefront_after_site` action

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -34,6 +34,8 @@
 
 </div><!-- #page -->
 
+<?php do_action( 'storefront_after_site' ); ?>
+
 <?php wp_footer(); ?>
 
 </body>


### PR DESCRIPTION
There is a `storefront_before_site` action but no `storefront_after_site`. This PR adds this action to footer.php.

I've placed it before `wp_footer()` since that hook is usually for scripts etc.