### PR TITLE
Change store notice z-index value for compatibility with mobile search

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1542,7 +1542,7 @@ ul.order_details {
 	padding: 1em ms(2);
 	background-color: $info;
 	color: #fff;
-	z-index: 9999;
+	z-index: 9998;
 
 	a {
 		color: #fff;


### PR DESCRIPTION
This PR changes the `z-index` value for the store notice so that the mobile search bar is visible when the store notice is enabled.

<img width="339" alt="screen shot 2018-08-07 at 14 12 50" src="https://user-images.githubusercontent.com/1177726/43777902-0806efb8-9a4c-11e8-9659-056a4f6d3448.png">

Closes #942.