### PR TITLE
Remove starter content if not entering the customizer through the NUX

### DIFF
--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -31,6 +31,10 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			add_action( 'after_setup_theme', array( $this, 'remove_default_widgets' ) );
 			add_action( 'transition_post_status', array( $this, 'transition_post_status' ), 10, 3 );
 			add_filter( 'the_title', array( $this, 'filter_auto_draft_title' ), 10, 2 );
+
+			if ( ! isset( $_GET['sf_starter_content'] ) || 1 !== absint( $_GET['sf_starter_content'] ) ) {
+				add_filter( 'storefront_starter_content', '__return_empty_array' );
+			}
 		}
 
 		/**
@@ -243,8 +247,6 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 */
 		public function filter_start_content( $content, $config ) {
 			if ( ! isset( $_GET['sf_starter_content'] ) || 1 !== absint( $_GET['sf_starter_content'] ) ) {
-
-				// We only allow starter content if the users comes from the NUX wizard.
 				return $content;
 			}
 
@@ -642,7 +644,6 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 							),
 						),
 					),
-
 				),
 				'belt' => array(
 					'post_title'     => esc_attr__( 'Belt', 'storefront' ),


### PR DESCRIPTION
Remove starter content if not entering the customizer through the NUX. 

To test, create a new WooCommerce/Storefront site without any products, and enter the customizer through the Storefront NUX prompt:

![screen shot 2018-08-22 at 17 36 52](https://user-images.githubusercontent.com/1177726/44477251-fe9b5080-a631-11e8-96d9-56ae705278b3.png)

You should see dummy content in the Customizer:

![screen shot 2018-08-22 at 17 37 31](https://user-images.githubusercontent.com/1177726/44477284-1a065b80-a632-11e8-92d4-e80191626932.png)

Now, go back to the dashboard, **without saving anything** on the Customizer. Enter the Customizer again through the Appearance > Customizer link in the admin menu. 

You should see a regular archives page:

![screen shot 2018-08-22 at 17 35 55](https://user-images.githubusercontent.com/1177726/44477196-e0cdeb80-a631-11e8-913b-8e3db3e2b780.png)

Closes #948.