### PR TITLE
Add missing RTL support to customizer guided tour

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -426,6 +426,7 @@ module.exports = function( grunt ) {
 					'assets/css/woocommerce/woocommerce.css',
 					'assets/css/woocommerce/woocommerce-legacy.css',
 					'assets/css/admin/welcome-screen/welcome.css',
+					'assets/css/admin/customizer/customizer.css',
 					'assets/css/jetpack/jetpack.css',
 					'assets/css/base/icons.css'
 				]

--- a/assets/js/admin/customizer.js
+++ b/assets/js/admin/customizer.js
@@ -38,7 +38,7 @@
 			this._addListeners();
 
 			// Initial position
-			this.$container.css( 'left', ( $( '#customize-controls' ).width() + 10 ) + 'px' ).on( 'transitionend', function() {
+			this.$container.css( ! $( 'body' ).hasClass( 'rtl' ) ? 'left' : 'right', ( $( '#customize-controls' ).width() + 10 ) + 'px' ).on( 'transitionend', function() {
 				self.$container.addClass( 'sf-loaded' );
 			});
 

--- a/inc/nux/class-storefront-nux-guided-tour.php
+++ b/inc/nux/class-storefront-nux-guided-tour.php
@@ -37,11 +37,11 @@ if ( ! class_exists( 'Storefront_NUX_Guided_Tour' ) ) :
 				add_action( 'customize_controls_enqueue_scripts', array( $this, 'customize_scripts' ) );
 				add_action( 'customize_controls_print_footer_scripts', array( $this, 'print_templates' ) );
 
-				// if ( current_user_can( 'manage_options' ) ) {
+				if ( current_user_can( 'manage_options' ) ) {
 
-				// 	// Set Guided Tour flag so it doesn't show up again.
-				// 	update_option( 'storefront_nux_guided_tour', true );
-				// }
+					// Set Guided Tour flag so it doesn't show up again.
+					update_option( 'storefront_nux_guided_tour', true );
+				}
 			}
 		}
 

--- a/inc/nux/class-storefront-nux-guided-tour.php
+++ b/inc/nux/class-storefront-nux-guided-tour.php
@@ -37,11 +37,11 @@ if ( ! class_exists( 'Storefront_NUX_Guided_Tour' ) ) :
 				add_action( 'customize_controls_enqueue_scripts', array( $this, 'customize_scripts' ) );
 				add_action( 'customize_controls_print_footer_scripts', array( $this, 'print_templates' ) );
 
-				if ( current_user_can( 'manage_options' ) ) {
+				// if ( current_user_can( 'manage_options' ) ) {
 
-					// Set Guided Tour flag so it doesn't show up again.
-					update_option( 'storefront_nux_guided_tour', true );
-				}
+				// 	// Set Guided Tour flag so it doesn't show up again.
+				// 	update_option( 'storefront_nux_guided_tour', true );
+				// }
 			}
 		}
 
@@ -56,6 +56,7 @@ if ( ! class_exists( 'Storefront_NUX_Guided_Tour' ) ) :
 			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 			wp_enqueue_style( 'sp-guided-tour', get_template_directory_uri() . '/assets/css/admin/customizer/customizer.css', array(), $storefront_version, 'all' );
+			wp_style_add_data( 'sp-guided-tour', 'rtl', 'replace' );
 
 			wp_enqueue_script( 'sf-guided-tour', get_template_directory_uri() . '/assets/js/admin/customizer' . $suffix . '.js', array( 'jquery', 'wp-backbone' ), $storefront_version, true );
 


### PR DESCRIPTION
Before:

![screen shot 2018-09-19 at 18 43 37](https://user-images.githubusercontent.com/1177726/45771048-fb4cb200-bc3b-11e8-9273-2a9504f1f98d.png)

After:

![screen shot 2018-09-19 at 18 42 44](https://user-images.githubusercontent.com/1177726/45771053-fe47a280-bc3b-11e8-92a0-a0bb09f97d24.png)

To test:

1. Use a plugin like "RTL tester" to switch the site to RTL mode.
2. Run grunt to generate the new rtl file.
3. Visit the Customizer and confirm that the Guided tour "bubble" is positioned correctly.

You only get the "Guided Tour" the first time you visit the Customizer. If your test environment is a existing site, go to /wp-admin/options.php and set `storefront_nux_guided_tour` to `0` and then visit the Customizer.

Closes #964.