### PR TITLE
simplifying ABSPATH check

### DIFF
--- a/inc/admin/class-storefront-admin.php
+++ b/inc/admin/class-storefront-admin.php
@@ -6,9 +6,7 @@
  * @since    2.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'Storefront_Admin' ) ) :
 	/**

--- a/inc/admin/class-storefront-plugin-install.php
+++ b/inc/admin/class-storefront-plugin-install.php
@@ -6,9 +6,7 @@
  * @since    2.2.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'Storefront_Plugin_Install' ) ) :
 	/**

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -6,9 +6,7 @@
  * @package  storefront
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'Storefront' ) ) :
 

--- a/inc/customizer/class-storefront-customizer-control-arbitrary.php
+++ b/inc/customizer/class-storefront-customizer-control-arbitrary.php
@@ -5,9 +5,7 @@
  * @package  storefront
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * The arbitrary control class

--- a/inc/customizer/class-storefront-customizer-control-more.php
+++ b/inc/customizer/class-storefront-customizer-control-more.php
@@ -5,9 +5,7 @@
  * @package  storefront
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * The 'more' Storefront control class

--- a/inc/customizer/class-storefront-customizer-control-radio-image.php
+++ b/inc/customizer/class-storefront-customizer-control-radio-image.php
@@ -13,9 +13,7 @@
  * @package  storefront
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * The radio image class.

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -6,9 +6,7 @@
  * @since    2.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'Storefront_Customizer' ) ) :
 

--- a/inc/jetpack/class-storefront-jetpack.php
+++ b/inc/jetpack/class-storefront-jetpack.php
@@ -6,9 +6,7 @@
  * @since    2.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'Storefront_Jetpack' ) ) :
 

--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -6,9 +6,7 @@
  * @since    2.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 

--- a/inc/nux/class-storefront-nux-guided-tour.php
+++ b/inc/nux/class-storefront-nux-guided-tour.php
@@ -6,9 +6,7 @@
  * @since    2.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'Storefront_NUX_Guided_Tour' ) ) :
 

--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -6,9 +6,7 @@
  * @since    2.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 

--- a/inc/woocommerce/class-storefront-woocommerce-customizer.php
+++ b/inc/woocommerce/class-storefront-woocommerce-customizer.php
@@ -6,9 +6,7 @@
  * @since    2.4.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'Storefront_WooCommerce_Customizer' ) ) :
 

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -6,9 +6,7 @@
  * @since    2.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 


### PR DESCRIPTION
Currently we are using following code to check for ABSPATH:

`if ( ! defined( 'ABSPATH' ) ) {
	exit;
}`

However, we can simplify the above code by using:

`defined( 'ABSPATH' ) || exit;`

