### PR TITLE
Support CP 3.14 and PB 5.8

### DIFF
--- a/assets/css/woocommerce/extensions/bundles.scss
+++ b/assets/css/woocommerce/extensions/bundles.scss
@@ -1,76 +1,187 @@
 /**
- * WooCommerce AJAX Layered Nav
+ * WooCommerce Product Bundles
  */
 
 /**
  * Imports
  */
+
 @import 'bourbon';
 @import '../../sass/utils/variables';
 @import '../../sass/utils/mixins';
 @import '../../../../node_modules/susy/sass/susy';
 @import '../../sass/vendors/modular-scale';
 
+/**
+ * Base
+ */
+
 .bundle_form {
+
 	div.bundled_product_summary {
+
 		padding-bottom: ms(3) !important;
 		margin-bottom: ms(3);
 		border-bottom: 1px solid $color_border;
+
+		padding-left: 0;
+
+		.bundled_product_images {
+
+			margin-left: 0;
+
+			a {
+				margin: 0 !important;
+			}
+
+			img {
+				width: 100% !important;
+				margin-bottom: 0;
+			}
+		}
+	}
+
+	div.bundled_product_summary, tr.bundled_product_summary {
+		.details {
+			font-size: ms(-1);
+		}
 	}
 }
 
+.woocommerce, .woocommerce-page {
+	#content div.product, div.product {
+		.bundle_form div.bundled_product_summary .bundled_product_images {
+			@include span( 2 of 10 );
+		}
+	}
+}
+
+.bundle_form {
+	div.bundled_product_summary:not( .thumbnail_hidden ) {
+		.details {
+			@include span( last 8 of 10 );
+		}
+	}
+}
+
+
+.bundle_form {
+	div.bundled_product_summary:not( .thumbnail_hidden ) {
+		.details {
+			padding: 0 !important;
+		}
+	}
+}
+
+.bundled_table_item {
+	.product-name {
+		padding-left: 4rem;
+	}
+}
+
+/**
+ * Desktop
+ */
+
 @include susy-media($desktop) {
-	.bundle_form {
-		div.bundled_product_summary {
-			padding-left: 0;
-			.bundled_product_images {
-				margin-left: 0;
-				@include span( 2 of 10 );
 
-				a {
-					margin: 0 !important;
+	.bundle_table_item dl.bundle_configuration {
+		display: none;
+	}
+
+	.sp-product-gallery-stacked, .storefront-full-width-content, .page-template-template-fullwidth-php {
+		.bundle_form {
+			.bundled_product_summary {
+				.details {
+					font-size: 1em;
 				}
-
-				img {
-					width: 100% !important;
-				}
-			}
-
-			.details {
-				@include span( last 8 of 10 );
-				font-size: ms(-1);
 			}
 		}
-		div.bundled_product_summary.thumbnail_hidden {
-			padding-left: 0;
+	}
+
+	.sp-product-gallery-stacked, .storefront-full-width-content, .page-template-template-fullwidth-php {
+
+		#content div.product, div.product {
+			.bundle_form div.bundled_product_summary .bundled_product_images {
+				@include span( 2 of 8 );
+			}
+		}
+
+		.bundle_form {
+			div.bundled_product_summary:not( .thumbnail_hidden ) {
+				.details {
+					@include span( last 6 of 8 );
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Handheld
+ */
+
+@include susy-media(max-width $handheld) {
+
+	.woocommerce, .woocommerce-page {
+		#content div.product, div.product {
+			.bundle_form div.bundled_product_summary .bundled_product_images {
+				@include span( 10 of 10 );
+			}
+		}
+	}
+
+	.bundle_form {
+		div.bundled_product_summary:not( .thumbnail_hidden ) {
 			.details {
 				@include span( 10 of 10 );
 			}
 		}
 	}
 
-	.page-template-template-fullwidth-php,
-	.storefront-full-width-content {
-		.bundle_form {
-			div.bundled_product_summary {
-				padding-left: 0;
-				.bundled_product_images {
-					margin-left: 0;
-					@include span( 2 of 8 );
-				}
+	table.shop_table_responsive tr.bundled_table_item {
+		display: none;
+	}
 
-				.details {
-					@include span( last 6 of 8 );
-					font-size: 1em;
-				}
+	.bundle_form {
+
+		div.bundled_product_summary .bundled_product_images {
+			max-width: 50%;
+		}
+
+		div.bundled_product_summary .bundled_product_images {
+			img {
+				margin-bottom: 1em;
 			}
-			div.bundled_product_summary.thumbnail_hidden {
-				padding-left: 0;
-				.details {
-					@include span( 8 of 8 );
-				}
+		}
+
+		table.bundled_products td {
+			display: block;
+		}
+
+		table.bundled_products thead {
+			display: none;
+		}
+
+		table.bundled_products tr td.bundled_item_images_col {
+			width: 100%;
+			padding-bottom: 0;
+		}
+
+		table.bundled_products tr {
+
+			td.bundled_item_images_col, td.bundled_item_details_col {
+				padding-bottom: 0;
 			}
+
+			td.bundled_item_images_col {
+				width: 100%;
+			}
+		}
+
+		table.bundled_products tr td.bundled_item_qty_col {
+			max-width: 100%;
+			text-align: left;
 		}
 	}
 }
-

--- a/assets/css/woocommerce/extensions/composite-products.scss
+++ b/assets/css/woocommerce/extensions/composite-products.scss
@@ -5,11 +5,16 @@
 /**
  * Imports
  */
+
 @import 'bourbon';
 @import '../../sass/utils/variables';
 @import '../../sass/utils/mixins';
 @import '../../../../node_modules/susy/sass/susy';
 @import '../../sass/vendors/modular-scale';
+
+/**
+ * Base
+ */
 
 .composite_summary .summary_element {
 
@@ -31,6 +36,179 @@
 		}
 	}
 }
+
+.composite_form {
+	.component {
+		.component_summary {
+
+			.content {
+				margin-bottom: ms(3);
+			}
+
+			.composited_product_details_wrapper {
+
+				padding-left: 0;
+
+				.composited_product_images {
+
+					margin-left: 0;
+
+					a {
+						margin: 0 !important;
+					}
+
+					img {
+						width: 100%;
+						height: auto;
+						margin-bottom: 0;
+					}
+				}
+			}
+		}
+
+		&:not( .selection_thumbnail_hidden ) .component_summary {
+			.composited_product_details_wrapper {
+				.details {
+					padding: 0;
+				}
+			}
+		}
+
+		.component_option_thumbnails {
+
+			.component_option_thumbnail {
+
+				box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0 );
+
+				&.selected,
+				&.selected:hover {
+					box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0.06 );
+				}
+
+				&:hover {
+					box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0.03 );
+				}
+
+				&.disabled,
+				&.disabled:hover {
+					box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0 );
+				}
+			}
+		}
+
+		.select_label {
+			display: block;
+			margin-bottom: 1em;
+		}
+	}
+}
+
+.woocommerce, .woocommerce-page {
+	#content div.product, div.product {
+		.component .composited_product_images {
+			@include span( 2 of 10 );
+		}
+	}
+}
+
+.composite_form {
+	.component {
+		&:not( .selection_thumbnail_hidden ) .component_summary {
+			.composited_product_details_wrapper {
+				.details {
+					@include span( last 8 of 10 );
+				}
+			}
+		}
+	}
+}
+
+.component_table_item {
+	.product-name {
+		padding-left: 4rem;
+	}
+}
+
+/**
+ * Desktop
+ */
+
+@include susy-media($desktop) {
+
+	.component_container_table_item dl.composite_configuration {
+		display: none;
+	}
+
+	.sp-product-gallery-stacked, .storefront-full-width-content, .page-template-template-fullwidth-php {
+
+		#content div.product, div.product {
+			.component .composited_product_images {
+				@include span( 2 of 8 );
+			}
+		}
+
+		.composite_form {
+			.component {
+				&:not( .selection_thumbnail_hidden ) .component_summary {
+					.composited_product_details_wrapper {
+						.details {
+							@include span( last 6 of 8 );
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Handheld
+ */
+
+@include susy-media(max-width $handheld) {
+
+	table.shop_table_responsive tr.component_table_item {
+		display: none;
+	}
+
+	.woocommerce, .woocommerce-page {
+		#content div.product, div.product {
+			.component .composited_product_images {
+				@include span( 10 of 10 );
+			}
+		}
+	}
+
+	.composite_form {
+		.component {
+
+			&:not( .selection_thumbnail_hidden ) .component_summary {
+				.composited_product_details_wrapper {
+					.details {
+						@include span( 10 of 10 );
+					}
+				}
+			}
+
+			.component_summary {
+				.composited_product_details_wrapper {
+
+					.composited_product_images {
+						max-width: 50%;
+
+						img {
+							margin-bottom: 1em;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Widget
+ */
 
 .widget.widget_composite_summary.widget_position_fixed {
 	font-size: ms(1);
@@ -100,168 +278,5 @@
 
 	.composite_button {
 		float: left;
-	}
-}
-
-.single-product div.product {
-
-	.selection_thumbnail_hidden .component_selections .component_summary {
-		.component_data {
-			@include span(12 of 12);
-		}
-	}
-
-	.component_selections {
-		.component_summary {
-
-			border-bottom: 1px solid $color_border;
-
-			.content {
-				margin-bottom: ms(3);
-			}
-
-			.composited_product_details_wrapper {
-				padding-left: 0;
-			}
-
-			.composited_product_images {
-
-				margin-left: 0;
-
-				@include span(3 of 12);
-
-				a {
-					padding-right: 0;
-				}
-
-				img {
-					width: 100%;
-					height: auto;
-				}
-			}
-
-			.component_data {
-				@include span(last 9 of 12);
-				margin-left: 0;
-			}
-		}
-
-		> div {
-			padding-left: 0;
-		}
-
-		.select_label {
-			display: block;
-			margin-bottom: 1em;
-		}
-
-		.component_option_thumbnails {
-
-			.component_option_thumbnail {
-				margin-left: 5px; /* v2.5.5 compat */
-				box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0 );
-
-				&.selected,
-				&.selected:hover {
-					box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0.06 );
-				}
-
-				&:hover {
-					box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0.03 );
-				}
-
-				&.disabled,
-				&.disabled:hover {
-					box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0 );
-				}
-			}
-		}
-	}
-
-	.component.progressive .component_summary {
-		border-bottom: none;
-	}
-}
-
-.storefront-full-width-content {
-	&.single-product div.product {
-
-		.selection_thumbnail_hidden .component_selections .component_summary {
-			.component_data {
-				@include span(12 of 12);
-			}
-		}
-
-		.component_selections {
-			.component_summary {
-				.composited_product_images {
-					@include span(3 of 12);
-
-					a {
-						padding-right: 0;
-					}
-				}
-
-				.component_data {
-					@include span(last 9 of 12);
-					margin-left: 0;
-				}
-			}
-		}
-	}
-}
-
-.swc-product-gallery-stacked,
-.swc-product-gallery-hidden {
-	&.single-product div.product {
-
-		.selection_thumbnail_hidden .component_selections .component_summary {
-			.component_data {
-				@include span(12 of 12);
-			}
-		}
-
-		.component_selections {
-			.component_summary {
-				.composited_product_images {
-					@include span(3 of 12);
-
-					a {
-						padding-right: 0;
-					}
-				}
-
-				.component_data {
-					@include span(last 9 of 12);
-				}
-			}
-		}
-	}
-
-	&.storefront-full-width-content {
-		&.single-product div.product {
-
-			.selection_thumbnail_hidden .component_selections .component_summary {
-				.component_data {
-					@include span(12 of 12);
-				}
-			}
-
-			.component_selections {
-				.component_summary {
-					.composited_product_images {
-						@include span(3 of 12);
-
-						a {
-							padding-right: 0;
-						}
-					}
-
-					.component_data {
-						@include span(last 9 of 12);
-					}
-				}
-			}
-		}
 	}
 }

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -40,6 +40,7 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			}
 
 			// Integrations.
+			add_action( 'after_setup_theme',                        array( $this, 'setup_integrations' ), 11 );
 			add_action( 'wp_enqueue_scripts',                       array( $this, 'woocommerce_integrations_scripts' ), 99 );
 			add_action( 'wp_enqueue_scripts',                       array( $this, 'add_customizer_css' ), 140 );
 		}
@@ -417,6 +418,48 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			}
 
 			return apply_filters( 'storefront_customizer_woocommerce_extension_css', $woocommerce_extension_style );
+		}
+
+		/*
+		|--------------------------------------------------------------------------
+		| Integrations.
+		|--------------------------------------------------------------------------
+		*/
+
+		/**
+		 * Sets up integrations.
+		 *
+		 * @since  2.3.4
+		 *
+		 * @return void
+		 */
+		public function setup_integrations() {
+
+			if ( $this->is_woocommerce_extension_activated( 'WC_Bundles' ) ) {
+				add_filter( 'woocommerce_bundled_table_item_js_enqueued', '__return_true' );
+				add_filter( 'woocommerce_bundles_group_mode_options_data', array( $this, 'bundles_group_mode_options_data' ) );
+			}
+
+			if ( $this->is_woocommerce_extension_activated( 'WC_Composite_Products' ) ) {
+				add_filter( 'woocommerce_composited_table_item_js_enqueued', '__return_true' );
+				add_filter( 'woocommerce_display_composite_container_cart_item_data', '__return_true' );
+			}
+		}
+
+		/**
+		 * Add "Includes" meta to parent cart items.
+		 * Displayed only on handheld/mobile screens.
+		 *
+		 * @since  2.3.4
+		 *
+		 * @param  array  $group_mode_data
+		 * @return array
+		 */
+		public function bundles_group_mode_options_data( $group_mode_data ) {
+
+			$group_mode_data[ 'parent' ][ 'features' ][] = 'parent_cart_item_meta';
+
+			return $group_mode_data;
 		}
 	}
 


### PR DESCRIPTION
This PR:

* Introduces new styles for Bundle /Composite-type single-product pages. Both Composite Products v3.14 and Product Bundles v5.8 include updates to the single-product page styles that need to be supported by Storefront. The change set here is backwards compatible with previous PB/CP versions.
* Adds support for some advanced theme features in CP/PB which improve the way Bundle/Composite child items are displayed on handheld screens in the cart (older PB/CP versions aren't affected):

<img width="499" alt="image 2018-09-27 at 9 42 30 a m" src="https://user-images.githubusercontent.com/1783726/46127562-b7f4d380-c239-11e8-8c64-397ec7ffb08b.png">

See #969 