### PR TITLE
Remove rule that sets logo image 100% width if WC active

### DIFF
--- a/assets/css/base/_layout.scss
+++ b/assets/css/base/_layout.scss
@@ -35,10 +35,6 @@
 		.site-header {
 			.site-branding {
 				@include span(9 of 12);
-
-				img {
-					max-width: 100%;
-				}
 			}
 
 			.site-search {


### PR DESCRIPTION
Sometime when we slightly refactored the header, this change was introduced, but it overrides other CSS rules that set the logo to a specific size.

This could cause some unwanted behaviour when changing  the size of the `.site-branding` container.

With this change, the logo image will inherit the size from a different selector and will always be set at `230px`.