### PR TITLE
Action hook right before closing <body> tag

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -36,5 +36,7 @@
 
 <?php wp_footer(); ?>
 
+<?php do_action( 'storefront_after_site' ); ?>
+
 </body>
 </html>


### PR DESCRIPTION
Hi, I would like to submit my request to add an action hook right before the closing <body> tag.

That is, essentially, the counterpart to 'storefront_before_site' and would be useful to add custom code or small JS snippets at the very end.
