### PR TITLE
Compatibility with Gutenberg editor

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -161,7 +161,9 @@ module.exports = function( grunt ) {
 					'assets/css/woocommerce/woocommerce.css': 'assets/css/woocommerce/woocommerce.scss',
 					'assets/css/woocommerce/woocommerce-legacy.css': 'assets/css/woocommerce/woocommerce-legacy.scss',
 					'assets/css/jetpack/jetpack.css': 'assets/css/jetpack/jetpack.scss',
-					'assets/css/base/icons.css': 'assets/css/base/icons.scss'
+					'assets/css/base/icons.css': 'assets/css/base/icons.scss',
+					'assets/css/base/gutenberg-blocks.css': 'assets/css/base/gutenberg-blocks.scss',
+					'assets/css/base/gutenberg-editor.css': 'assets/css/base/gutenberg-editor.scss'
 				}]
 			}
 		},
@@ -428,7 +430,9 @@ module.exports = function( grunt ) {
 					'assets/css/admin/welcome-screen/welcome.css',
 					'assets/css/admin/customizer/customizer.css',
 					'assets/css/jetpack/jetpack.css',
-					'assets/css/base/icons.css'
+					'assets/css/base/icons.css',
+					'assets/css/base/gutenberg-blocks.css',
+					'assets/css/base/gutenberg-editor.css'
 				]
 			}
 		},

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -755,6 +755,8 @@ table {
 		border-bottom: 1px solid $color_border;
 
 		.posted-on,
+		.post-author,
+		.post-comments,
 		.byline {
 			font-size: ms(-1);
 
@@ -764,8 +766,8 @@ table {
 		}
 	}
 
-	.entry-meta {
-		font-weight: 400;
+	.entry-taxonomy {
+		padding: ms(5) 0 0;
 	}
 
 	&.type-page {
@@ -793,17 +795,12 @@ table {
 }
 
 .cat-links,
-.tags-links,
-.comments-link,
-.vcard.author {
+.tags-links {
 	display: block;
-	margin-bottom: ms(3);
-}
+	margin-bottom: ms(1);
 
-.vcard.author {
-	.avatar {
-		width: 64px;
-		margin-bottom: 1em;
+	&:last-child {
+		margin-bottom: 0;
 	}
 }
 

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -767,7 +767,7 @@ table {
 	}
 
 	.entry-taxonomy {
-		padding: ms(5) 0 0;
+		margin: ms(2) 0 0;
 	}
 
 	&.type-page {

--- a/assets/css/base/_layout.scss
+++ b/assets/css/base/_layout.scss
@@ -350,19 +350,6 @@
 		}
 	}
 
-	.hentry.type-post {
-		@include clearfix;
-
-		.entry-meta {
-			@include span(2 of 9);
-			font-size: ms(-1);
-		}
-
-		.entry-content {
-			@include span(last 7 of 9);
-		}
-	}
-
 	/**
 	 * Menus
 	 *

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -10,563 +10,567 @@
 @import '../sass/utils/mixins';
 @import '../sass/vendors/modular-scale';
 
-// Typography
-.has-small-font-size {
-	font-size: ms(-1);
-}
-
-.has-medium-font-size {
-	font-size: ms(2);
-}
-
-.has-large-font-size {
-	font-size: ms(3);
-}
-
-.has-huge-font-size {
-	font-size: ms(4);
-}
-
-@media ( min-width: $container-width ) {
+.hentry .entry-content {
 	// Global
-	.page-template-template-fullwidth-php,
-	.storefront-full-width-content {
-		.alignfull,
-		.alignwide {
-			width: auto;
-			max-width: 1000%;
-			padding-left: ms(2);
-			padding-right: ms(2);
-		}
+	@media ( min-width: $container-width ) {
+		.page-template-template-fullwidth-php &,
+		.storefront-full-width-content & {
+			.alignfull,
+			.alignwide {
+				width: auto;
+				max-width: 1000%;
+				padding-left: ms(2);
+				padding-right: ms(2);
+			}
 
-		.alignfull {
-			margin-left: calc(50% - 50vw);
-			margin-right: calc(50% - 50vw);
-		}
+			.alignfull {
+				margin-left: calc(50% - 50vw);
+				margin-right: calc(50% - 50vw);
+			}
 
-		.alignwide {
-			margin-left: calc(25% - 25vw);
-			margin-right: calc(25% - 25vw);
+			.alignwide {
+				margin-left: calc(25% - 25vw);
+				margin-right: calc(25% - 25vw);
+			}
 		}
 	}
-}
 
-// Audio
-.wp-block-audio {
-	margin-bottom: ms(2);
-	width: 100%;
+	// Typography
+	.has-small-font-size {
+		font-size: ms(-1);
+	}
 
-	audio {
+	.has-medium-font-size {
+		font-size: ms(2);
+	}
+
+	.has-large-font-size {
+		font-size: ms(3);
+	}
+
+	.has-huge-font-size {
+		font-size: ms(4);
+	}
+
+	// Audio
+	.wp-block-audio {
+		margin-bottom: ms(2);
 		width: 100%;
-	}
 
-	&.alignleft audio,
-	&.alignright audio {
-		max-width: (0.5 * $handheld);
-	}
+		audio {
+			width: 100%;
+		}
 
-	&.aligncenter {
-		margin: 0 auto ms(2);
-		max-width: span(6);
-	}
-}
+		&.alignleft audio,
+		&.alignright audio {
+			max-width: (0.5 * $handheld);
+		}
 
-// Video
-.wp-block-video {
-	margin-bottom: ms(2);
-
-	video {
-		width: 100%;
-	}
-}
-
-// Button
-.wp-block-button {
-	margin-bottom: ms(2);
-
-	.wp-block-button__link {
-		font-size: ms(1);
-		line-height: 1.618;
-		border: 0;
-		background: none;
-		border-color: $color_body;
-		cursor: pointer;
-		padding: ms(-2) ms(2);
-		text-decoration: none;
-		font-weight: 600;
-		text-shadow: none;
-		display: inline-block;
-		outline: none;
-		-webkit-appearance: none;
-		border-radius: 0;
-	}
-
-	&:not( .is-style-squared ) {
-		.wp-block-button__link {
-			border-radius: 5px;
+		&.aligncenter {
+			margin: 0 auto ms(2);
+			max-width: span(6);
 		}
 	}
 
-	&:not( .has-text-color ) {
+	// Video
+	.wp-block-video {
+		margin-bottom: ms(2);
+
+		video {
+			width: 100%;
+		}
+	}
+
+	// Button
+	.wp-block-button {
+		margin-bottom: ms(2);
+
 		.wp-block-button__link {
+			font-size: ms(1);
+			line-height: 1.618;
+			border: 0;
+			background: none;
+			border-color: $color_body;
+			cursor: pointer;
+			padding: ms(-2) ms(2);
+			text-decoration: none;
+			font-weight: 600;
+			text-shadow: none;
+			display: inline-block;
+			outline: none;
+			-webkit-appearance: none;
+			border-radius: 0;
+		}
+
+		&:not( .is-style-squared ) {
+			.wp-block-button__link {
+				border-radius: 5px;
+			}
+		}
+
+		&:not( .has-text-color ) {
+			.wp-block-button__link {
+				color: #fff;
+
+				&:hover,
+				&:focus,
+				&:active {
+					color: #fff;
+				}
+			}
+		}
+
+		&:not( .has-background ) {
+			.wp-block-button__link {
+				background-color: $color_body;
+
+				&:hover,
+				&:focus,
+				&:active {
+					background-color: $color_body;
+				}
+			}
+		}
+
+		&.is-style-outline .wp-block-button__link,
+		&.is-style-outline .wp-block-button__link:focus,
+		&.is-style-outline .wp-block-button__link:active,
+		&.is-style-outline .wp-block-button__link:hover {
+			background: transparent;
+			border: 2px solid currentColor;
+		}
+	}
+
+	// Latest posts, categories, archives
+	.wp-block-archives,
+	.wp-block-categories,
+	.wp-block-latest-posts {
+		margin: 0 0 ms(2);
+		list-style: none;
+	}
+
+	.wp-block-latest-posts {
+		&__post-date {
+			font-size: ms(-1);
+		}
+
+		li {
+			margin: 0;
+		}
+
+		&.has-dates {
+			li {
+				margin: 0 0 1em;
+			}
+		}
+
+		&.is-grid {
+			li {
+				margin: 0 ms(1) 0 0;
+			}
+
+			&.has-dates {
+				li {
+					margin-bottom: 1em;
+				}
+			}
+		}
+
+		@media (min-width:600px) {
+			@for $i from 2 through 6 {
+				&.columns-#{$i} li {
+					margin-right: gutter(9);
+					width: span(9 / $i);
+
+					&:nth-of-type( #{$i}n ) {
+						margin-right: 0;
+					}
+				}
+			}
+
+			.page-template-template-fullwidth-php &,
+			.storefront-full-width-content & {
+				@for $i from 2 through 6 {
+					&.columns-#{$i} li {
+						margin-right: gutter(12);
+						width: span(12 / $i);
+
+						&:nth-of-type( #{$i}n ) {
+							margin-right: 0;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Paragraphs
+	p {
+		&.has-drop-cap {
+			&:not( :focus )::first-letter {
+				margin: 0.15em ms(-4) 0 0;
+				font-size: ms(7);
+				font-weight: 300;
+				line-height: 0.618;
+			}
+		}
+	}
+
+	// Pullquote
+	.wp-block-pullquote {
+		margin: 0 0 ms(2);
+
+		blockquote {
+			border: 0;
+			margin: 0;
+		}
+
+		p {
+			margin-bottom: ms(1);
+			font-size: ms(3);
+			line-height: 1.618;
+		}
+	}
+
+	// Blockquote
+	.wp-block-quote {
+		margin: 0 0 ms(2);
+		padding: 0;
+
+		&.is-large,
+		&.is-style-large {
+			margin: 0 0 ms(2);
+			padding: 0;
+			border: 0;
+
+			p {
+				font-size: ms(2);
+				line-height: 1.618;
+			}
+		}
+
+		footer,
+		cite {
+			color: $color_body;
+			font-size: ms(1);
+			font-weight: 700;
+		}
+	}
+
+	// Image
+	.wp-block-image {
+		margin-bottom: ms(2);
+
+		.alignleft {
+			margin-right: ms(1);
+		}
+
+		.alignright {
+			margin-left: ms(1);
+		}
+
+		figcaption {
+			margin: 0;
+			padding: ms(-1) 0;
+			font-size: ms(-1);
+			font-style: italic;
+			color: $color_body;
+		}
+
+		@media ( min-width: $container-width ) {
+			.page-template-template-fullwidth-php &,
+			.storefront-full-width-content & {
+				&.alignfull,
+				&.alignwide {
+					padding-left: 0;
+					padding-right: 0;
+				}
+			}
+		}
+	}
+
+	.wp-block-cover-image,
+	.wp-block-cover {
+		flex-flow: row wrap;
+
+		.wp-block-cover-image-text,
+		.wp-block-cover-text,
+		h2,
+		p {
+			font-size: ms(3);
+			font-weight: 300;
+			line-height: 1.618;
+			padding: ms(1);
+			width: calc(100vw - #{ms(1)});
+			max-width: calc(100vw - #{ms(1)});
 			color: #fff;
+			z-index: 1;
+			text-align: center;
+
+			@media ( min-width: $handheld ) {
+				padding: ms(1);
+				font-size: ms(4);
+				width: calc(8 * (100vw / 12 ));
+				max-width: calc(8 * (100vw / 12 ));
+			}
+
+			@media ( min-width: $desktop ) {
+				font-size: ms(4);
+				width: calc(6 * (100vw / 12 ));
+				max-width: calc(6 * (100vw / 12 ));
+			}
+		}
+
+		@media ( min-width: $container-width ) {
+			.page-template-template-fullwidth-php &,
+			.storefront-full-width-content & {
+				&.alignfull,
+				&.alignwide {
+					padding-left: 0;
+					padding-right: 0;
+				}
+			}
+		}
+	}
+
+	// Galleries
+	.wp-block-gallery {
+		margin: 0 0 ms(2);
+
+		.blocks-gallery-image,
+		.blocks-gallery-item {
+			width: span(6);
+			margin: 0 gutter(12) gutter(12) 0;
+			flex-grow: 0;
+
+			&:nth-of-type( even ) {
+				margin-right: 0;
+			}
+
+			figcaption {
+				font-size: ms(1);
+				padding: ms(4) ms(2) ms(-2);
+			}
+		}
+
+		@media (min-width:600px) {
+			.blocks-gallery-image,
+			.blocks-gallery-item {
+				margin: 0 gutter(9) gutter(9) 0;
+			}
+
+			@for $i from 2 through 8 {
+				&.columns-#{$i} .blocks-gallery-image,
+				&.columns-#{$i} .blocks-gallery-item {
+					margin-right: gutter(9);
+					width: calc(( 100% - #{gutter(9)} * #{$i - 1} ) / #{$i});
+
+					&:nth-of-type( #{$i}n ) {
+						margin-right: 0;
+					}
+				}
+			}
+
+			.page-template-template-fullwidth-php &,
+			.storefront-full-width-content & {
+				.blocks-gallery-image,
+				.blocks-gallery-item {
+					margin-bottom: gutter(12);
+					margin-right: gutter(12);
+				}
+
+				@for $i from 2 through 8 {
+					&.columns-#{$i} .blocks-gallery-image,
+					&.columns-#{$i} .blocks-gallery-item {
+						margin-right: gutter(12);
+						width: calc(( 100% - #{gutter(12)} * #{$i - 1} ) / #{$i});
+
+						&:nth-of-type( #{$i}n ) {
+							margin-right: 0;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Separator
+	.wp-block-separator {
+		border: 0;
+		margin: 0 auto ms(2);
+
+		&.is-style-dots {
+			&::before {
+				color: darken( $color_body, 20% );
+			}
+		}
+	}
+
+	// Twitter Embed
+	.wp-block-embed-twitter {
+		overflow: hidden;
+	}
+
+	// Table
+	.wp-block-table {
+		border-collapse: separate;
+
+		td,
+		th {
+			border: 0;
+			padding: 1em ms(2);
+			word-break: normal;
+		}
+
+		thead {
+			th {
+				padding: ms(2);
+			}
+		}
+	}
+
+	// File
+	.wp-block-file {
+		margin-bottom: ms(2);
+
+		.wp-block-file__button {
+			font-size: ms(-1);
+			line-height: 1.618;
+			border: 0;
+			background: none;
+			color: #fff;
+			background-color: $color_body;
+			border-color: $color_body;
+			cursor: pointer;
+			padding: ms(-2) ms(2);
+			text-decoration: none;
+			font-weight: 600;
+			text-shadow: none;
+			display: inline-block;
+			outline: none;
+			-webkit-appearance: none;
+			border-radius: 0;
 
 			&:hover,
 			&:focus,
 			&:active {
 				color: #fff;
-			}
-		}
-	}
-
-	&:not( .has-background ) {
-		.wp-block-button__link {
-			background-color: $color_body;
-
-			&:hover,
-			&:focus,
-			&:active {
 				background-color: $color_body;
+				border-color: $color_body;
 			}
 		}
 	}
 
-	&.is-style-outline .wp-block-button__link,
-	&.is-style-outline .wp-block-button__link:focus,
-	&.is-style-outline .wp-block-button__link:active,
-	&.is-style-outline .wp-block-button__link:hover {
-		background: transparent;
-		border: 2px solid currentColor;
-	}
-}
-
-// Latest posts, categories, archives
-.wp-block-archives,
-.wp-block-categories,
-.wp-block-latest-posts {
-	margin: 0 0 ms(2);
-	list-style: none;
-}
-
-.wp-block-latest-posts {
-	&__post-date {
-		font-size: ms(-1);
-	}
-
-	li {
-		margin: 0;
-	}
-
-	&.has-dates {
-		li {
-			margin: 0 0 1em;
-		}
-	}
-
-	&.is-grid {
-		li {
-			margin: 0 ms(1) 0 0;
-		}
-
-		&.has-dates {
-			li {
-				margin-bottom: 1em;
-			}
-		}
-	}
-}
-
-@media (min-width:600px) {
-	@for $i from 2 through 6 {
-		.wp-block-latest-posts {
-			&.columns-#{$i} li {
-				margin-right: gutter(9);
-				width: span(9 / $i);
-
-				&:nth-of-type( #{$i}n ) {
-					margin-right: 0;
-				}
-			}
-		}
-	}
-
-	.page-template-template-fullwidth-php,
-	.storefront-full-width-content {
-		@for $i from 2 through 6 {
-			.wp-block-latest-posts {
-				&.columns-#{$i} li {
-					margin-right: gutter(12);
-					width: span(12 / $i);
-
-					&:nth-of-type( #{$i}n ) {
-						margin-right: 0;
-					}
-				}
-			}
-		}
-	}
-}
-
-// Paragraphs
-p {
-	&.has-drop-cap {
-		&:not( :focus )::first-letter {
-			margin: 0.15em ms(-4) 0 0;
-			font-size: ms(7);
-			font-weight: 300;
-			line-height: 0.618;
-		}
-	}
-}
-
-// Pullquote
-.wp-block-pullquote {
-	margin: 0 0 ms(2);
-
-	blockquote {
-		border: 0;
-		margin: 0;
-	}
-
-	p {
-		margin-bottom: ms(1);
-		font-size: ms(3);
-		line-height: 1.618;
-	}
-}
-
-// Blockquote
-.wp-block-quote {
-	margin: 0 0 ms(2);
-	padding: 0;
-
-	&.is-large,
-	&.is-style-large {
-		margin: 0 0 ms(2);
-		padding: 0;
-		border: 0;
-
-		p {
-			font-size: ms(2);
-			line-height: 1.618;
-		}
-	}
-
-	footer,
-	cite {
+	// Code
+	.wp-block-code,
+	.wp-block-preformatted pre {
 		color: $color_body;
+		font-family: 'Courier 10 Pitch', Courier, monospace;
 		font-size: ms(1);
-		font-weight: 700;
-	}
-}
-
-// Image
-.wp-block-image {
-	margin-bottom: ms(2);
-
-	.alignleft {
-		margin-right: ms(1);
 	}
 
-	.alignright {
-		margin-left: ms(1);
-	}
-
-	figcaption {
-		margin: 0;
-		padding: ms(-1) 0;
-		font-size: ms(-1);
-		font-style: italic;
-		color: $color_body;
-	}
-}
-
-.wp-block-cover-image,
-.wp-block-cover {
-	flex-flow: row wrap;
-
-	.wp-block-cover-image-text,
-	.wp-block-cover-text,
-	h2,
-	p {
-		font-size: ms(3);
-		font-weight: 300;
-		line-height: 1.618;
-		padding: ms(1);
-		width: calc(100vw - #{ms(1)});
-		max-width: calc(100vw - #{ms(1)});
-		color: #fff;
-		z-index: 1;
-		text-align: center;
-
-		@include susy-media($handheld) {
-			padding: ms(1);
-			font-size: ms(4);
-			width: calc(8 * (100vw / 12 ));
-			max-width: calc(8 * (100vw / 12 ));
-		}
-
-		@include susy-media($desktop) {
-			font-size: ms(4);
-			width: calc(6 * (100vw / 12 ));
-			max-width: calc(6 * (100vw / 12 ));
-		}
-	}
-}
-
-@media ( min-width: $container-width ) {
-	// Global
-	.page-template-template-fullwidth-php,
-	.storefront-full-width-content {
-		.wp-block-cover-image,
-		.wp-block-cover,
-		.wp-block-image {
-			&.alignfull,
-			&.alignwide {
-				padding-left: 0;
-				padding-right: 0;
-			}
-		}
-	}
-}
-
-// Galleries
-.wp-block-gallery {
-	margin: 0 0 ms(2);
-
-	.blocks-gallery-image,
-	.blocks-gallery-item {
-		width: span(6);
-		margin: 0 gutter(12) gutter(12) 0;
-
-		figcaption {
-			font-size: ms(1);
-			padding: ms(4) ms(2) ms(-2);
-		}
-	}
-}
-
-@media (min-width:600px) {
-	.wp-block-gallery {
-		.blocks-gallery-image,
-		.blocks-gallery-item {
-			margin: 0 gutter(9) gutter(9) 0;
-		}
-	}
-
-	@for $i from 2 through 8 {
-		.wp-block-gallery.columns-#{$i} .blocks-gallery-image,
-		.wp-block-gallery.columns-#{$i} .blocks-gallery-item {
-			margin-right: gutter(9);
-			width: span(9 / $i);
-		}
-	}
-
-	.page-template-template-fullwidth-php,
-	.storefront-full-width-content {
-		.wp-block-gallery {
-			.blocks-gallery-image,
-			.blocks-gallery-item {
-				margin-bottom: gutter(12);
-				margin-right: gutter(12);
-			}
-		}
-
-		@for $i from 2 through 8 {
-			.wp-block-gallery.columns-#{$i} .blocks-gallery-image,
-			.wp-block-gallery.columns-#{$i} .blocks-gallery-item {
-				margin-right: gutter(12);
-				width: span(12 / $i);
-
-				&:nth-of-type( #{$i}n ) {
-					margin-right: 0;
-				}
-			}
-		}
-	}
-}
-
-// Separator
-.wp-block-separator {
-	border: 0;
-	margin: 0 auto ms(2);
-
-	&.is-style-dots {
-		&::before {
-			color: darken( $color_body, 20% );
-		}
-	}
-}
-
-// Twitter Embed
-.wp-block-embed-twitter {
-	overflow: hidden;
-}
-
-// Table
-.wp-block-table {
-	border-collapse: separate;
-
-	td,
-	th {
-		border: 0;
-		padding: 1em ms(2);
-		word-break: normal;
-	}
-
-	thead {
-		th {
-			padding: ms(2);
-		}
-	}
-}
-
-// File
-.wp-block-file {
-	margin-bottom: ms(2);
-
-	.wp-block-file__button {
-		font-size: ms(-1);
-		line-height: 1.618;
-		border: 0;
-		background: none;
-		color: #fff;
-		background-color: $color_body;
-		border-color: $color_body;
-		cursor: pointer;
-		padding: ms(-2) ms(2);
-		text-decoration: none;
-		font-weight: 600;
-		text-shadow: none;
-		display: inline-block;
-		outline: none;
-		-webkit-appearance: none;
+	.wp-block-code {
+		border: none;
 		border-radius: 0;
-
-		&:hover,
-		&:focus,
-		&:active {
-			color: #fff;
-			background-color: $color_body;
-			border-color: $color_body;
-		}
-	}
-}
-
-// Code
-.wp-block-code,
-.wp-block-preformatted pre {
-	color: $color_body;
-	font-family: 'Courier 10 Pitch', Courier, monospace;
-	font-size: ms(1);
-}
-
-.wp-block-code {
-	border: none;
-	border-radius: 0;
-	padding: ms(3);
-}
-
-// Columns
-.wp-block-column {
-	margin-bottom: ms(1);
-}
-
-@media (min-width:600px) {
-	.wp-block-column {
-		padding-left: 0;
-		padding-right: gutter(9);
+		padding: ms(3);
 	}
 
-	.page-template-template-fullwidth-php,
-	.storefront-full-width-content {
-		.wp-block-column {
-			padding-right: gutter(9);
-		}
-	}
-}
-
-@media (min-width:782px) {
+	// Columns
 	.wp-block-columns {
-		@for $i from 2 through 6 {
-			&.has-#{$i}-columns {
-				.wp-block-column {
-					&:nth-of-type( #{$i}n ) {
-						margin-right: 0;
+		.wp-block-column {
+			margin-bottom: ms(1);
+
+			@media (min-width:600px) {
+				padding-left: 0;
+				padding-right: gutter(9);
+				margin-left: 0;
+
+				.page-template-template-fullwidth-php &,
+				.storefront-full-width-content & {
+					padding-right: gutter(9);
+				}
+			}
+		}
+
+		@media (min-width:782px) {
+			@for $i from 2 through 6 {
+				&.has-#{$i}-columns {
+					.wp-block-column {
+						&:nth-of-type( #{$i}n ) {
+							margin-right: 0;
+						}
+					}
+				}
+			}
+
+			.wp-block-column {
+				padding-right: 0;
+
+				&:not( :first-child ) {
+					padding-left: 0;
+				}
+
+				&:not( :last-child ) {
+					padding-right: 0;
+					margin-right: gutter(9);
+				}
+
+				.page-template-template-fullwidth-php &,
+				.storefront-full-width-content & {
+					padding-right: 0;
+
+					&:not( :last-child ) {
+						margin-right: gutter(12);
 					}
 				}
 			}
 		}
 	}
 
-	.wp-block-column {
-		padding-right: 0;
+	// Latest Comments
+	.wp-block-latest-comments {
+		margin: 0 0 ms(2);
 
-		&:not( :first-child ) {
-			padding-left: 0;
+		&__comment-avatar {
+			margin-top: ms(-4);
 		}
 
-		&:not( :last-child ) {
-			padding-right: 0;
-			margin-right: gutter(9);
+		&__comment {
+			font-size: ms(1);
+			margin: 0 0 ms(1);
 		}
-	}
 
-	.page-template-template-fullwidth-php,
-	.storefront-full-width-content {
-		.wp-block-column {
-			padding-right: 0;
+		&__comment-date {
+			font-size: ms(-1);
+		}
 
-			&:not( :last-child ) {
-				margin-right: gutter(12);
+		&__comment-excerpt {
+			p {
+				margin: ms(-3) 0 ms(1);
+				font-size: 1em;
+				line-height: 1.618;
 			}
 		}
-	}
-}
 
-// Latest Comments
-.wp-block-latest-comments {
-	margin: 0 0 ms(2);
-
-	&__comment-avatar {
-		margin-top: ms(-4);
-	}
-
-	&__comment {
-		font-size: ms(1);
-		margin: 0 0 ms(1);
-	}
-
-	&__comment-date {
-		font-size: ms(-1);
-	}
-
-	&__comment-excerpt {
-		p {
-			margin: ms(-3) 0 ms(1);
-			font-size: 1em;
-			line-height: 1.618;
-		}
-	}
-
-	&.has-avatars {
-		.wp-block-latest-comments__comment {
-			.wp-block-latest-comments__comment-excerpt,
-			.wp-block-latest-comments__comment-meta {
-				margin-left: ms(6);
+		&.has-avatars {
+			.wp-block-latest-comments__comment {
+				.wp-block-latest-comments__comment-excerpt,
+				.wp-block-latest-comments__comment-meta {
+					margin-left: ms(6);
+				}
 			}
 		}
-	}
 
-	&:not( .has-avatars ):not( .has-dates ):not( .has-excerpts ) {
-		.wp-block-latest-comments__comment {
-			margin: 0;
-			line-height: 1.618;
+		&:not( .has-avatars ):not( .has-dates ):not( .has-excerpts ) {
+			.wp-block-latest-comments__comment {
+				margin: 0;
+				line-height: 1.618;
+			}
 		}
-	}
 
-	br {
-		display: inline;
-		content: '';
+		br {
+			display: inline;
+			content: '';
+		}
 	}
 }

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -535,6 +535,10 @@ p {
 .wp-block-latest-comments {
 	margin: 0 0 ms(2);
 
+	&__comment-avatar {
+		margin-top: ms(-4);
+	}
+
 	&__comment {
 		font-size: ms(1);
 		margin: 0 0 ms(1);
@@ -550,5 +554,26 @@ p {
 			font-size: 1em;
 			line-height: 1.618;
 		}
+	}
+
+	&.has-avatars {
+		.wp-block-latest-comments__comment {
+			.wp-block-latest-comments__comment-excerpt,
+			.wp-block-latest-comments__comment-meta {
+				margin-left: ms(6);
+			}
+		}
+	}
+
+	&:not( .has-avatars ):not( .has-dates ):not( .has-excerpts ) {
+		.wp-block-latest-comments__comment {
+			margin: 0;
+			line-height: 1.618;
+		}
+	}
+
+	br {
+		display: inline;
+		content: '';
 	}
 }

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -1,0 +1,554 @@
+@import 'bourbon';
+
+// Susy
+// Susy grid system. See: http://susydocs.oddbird.net/en/latest/
+@import '../../../node_modules/susy/sass/susy';
+
+// Utilities
+// Sass tools and helpers used across the project.
+@import '../sass/utils/variables';
+@import '../sass/utils/mixins';
+@import '../sass/vendors/modular-scale';
+
+// Typography
+.has-small-font-size {
+	font-size: ms(-1);
+}
+
+.has-medium-font-size {
+	font-size: ms(2);
+}
+
+.has-large-font-size {
+	font-size: ms(3);
+}
+
+.has-huge-font-size {
+	font-size: ms(4);
+}
+
+// Layout
+.alignfull {
+	margin-left: calc(50% - 50vw);
+	margin-right: calc(50% - 50vw);
+	width: auto;
+	max-width: 1000%;
+}
+
+.alignwide {
+	margin-left: calc(25% - 25vw);
+	margin-right: calc(25% - 25vw);
+	width: auto;
+	max-width: 1000%;
+}
+
+@include susy-media($desktop) {
+	.alignfull,
+	.alignwide {
+		margin-left: auto;
+		margin-right: auto;
+		max-width: none;
+	}
+
+	// Global
+	.page-template-template-fullwidth-php,
+	.storefront-full-width-content {
+		.alignfull {
+			margin-left: calc(50% - 50vw);
+			margin-right: calc(50% - 50vw);
+			width: auto;
+			max-width: 1000%;
+		}
+
+		.alignwide {
+			margin-left: calc(25% - 25vw);
+			margin-right: calc(25% - 25vw);
+			width: auto;
+			max-width: 1000%;
+		}
+	}
+}
+
+
+// Audio
+.wp-block-audio {
+	margin-bottom: ms(2);
+	width: 100%;
+
+	audio {
+		width: 100%;
+	}
+
+	&.alignleft audio,
+	&.alignright audio {
+		max-width: (0.5 * $handheld);
+	}
+
+	&.aligncenter {
+		margin: 0 auto ms(2);
+		max-width: span(6);
+	}
+}
+
+// Video
+.wp-block-video {
+	margin-bottom: ms(2);
+
+	video {
+		width: 100%;
+	}
+}
+
+// Button
+.wp-block-button {
+	margin-bottom: ms(2);
+
+	.wp-block-button__link {
+		font-size: ms(1);
+		line-height: 1.618;
+		border: 0;
+		background: none;
+		border-color: $color_body;
+		cursor: pointer;
+		padding: ms(-2) ms(2);
+		text-decoration: none;
+		font-weight: 600;
+		text-shadow: none;
+		display: inline-block;
+		outline: none;
+		-webkit-appearance: none;
+		border-radius: 0;
+	}
+
+	&:not( .is-style-squared ) {
+		.wp-block-button__link {
+			border-radius: 5px;
+		}
+	}
+
+	&:not( .has-text-color ) {
+		.wp-block-button__link {
+			color: #fff;
+
+			&:hover,
+			&:focus,
+			&:active {
+				color: #fff;
+			}
+		}
+	}
+
+	&:not( .has-background ) {
+		.wp-block-button__link {
+			background-color: $color_body;
+
+			&:hover,
+			&:focus,
+			&:active {
+				background-color: $color_body;
+			}
+		}
+	}
+
+	&.is-style-outline .wp-block-button__link,
+	&.is-style-outline .wp-block-button__link:focus,
+	&.is-style-outline .wp-block-button__link:active,
+	&.is-style-outline .wp-block-button__link:hover {
+		background: transparent;
+		border: 2px solid currentColor;
+	}
+}
+
+// Latest posts, categories, archives
+.wp-block-archives,
+.wp-block-categories,
+.wp-block-latest-posts {
+	margin: 0 0 ms(2);
+	list-style: none;
+}
+
+.wp-block-latest-posts {
+	&__post-date {
+		font-size: ms(-1);
+	}
+
+	li {
+		margin: 0 0 ms(1);
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	&.is-grid {
+		li {
+			margin: 0 ms(1) ms(1) 0;
+		}
+	}
+}
+
+@media (min-width:600px) {
+	@for $i from 2 through 6 {
+		.wp-block-latest-posts {
+			&.columns-#{$i} li {
+				margin-right: gutter(9);
+				width: span(9 / $i);
+
+				&:nth-of-type( #{$i}n ) {
+					margin-right: 0;
+				}
+			}
+		}
+	}
+
+	.page-template-template-fullwidth-php,
+	.storefront-full-width-content {
+		@for $i from 2 through 6 {
+			.wp-block-latest-posts {
+				&.columns-#{$i} li {
+					margin-right: gutter(12);
+					width: span(12 / $i);
+
+					&:nth-of-type( #{$i}n ) {
+						margin-right: 0;
+					}
+				}
+			}
+		}
+	}
+}
+
+// Paragraphs
+p {
+	&.has-drop-cap {
+		&:not( :focus )::first-letter {
+			margin: 0.15em ms(-4) 0 0;
+			font-size: ms(7);
+			font-weight: 300;
+			line-height: 0.618;
+		}
+	}
+}
+
+// Pullquote
+.wp-block-pullquote {
+	margin: 0 0 ms(2);
+
+	blockquote {
+		border: 0;
+		margin: 0;
+	}
+
+	p {
+		margin-bottom: ms(1);
+		font-size: ms(3);
+		line-height: 1.618;
+	}
+}
+
+// Blockquote
+.wp-block-quote {
+	margin: 0 0 ms(2);
+	padding: 0;
+
+	&.is-large,
+	&.is-style-large {
+		margin: 0 0 ms(2);
+		padding: 0;
+		border: 0;
+
+		p {
+			font-size: ms(2);
+			line-height: 1.618;
+		}
+	}
+
+	footer,
+	cite {
+		color: $color_body;
+		font-size: ms(1);
+		font-weight: 700;
+	}
+}
+
+// Image
+.wp-block-image {
+	margin-bottom: ms(2);
+
+	.alignleft {
+		margin-right: ms(1);
+	}
+
+	.alignright {
+		margin-left: ms(1);
+	}
+
+	figcaption {
+		margin: 0;
+		padding: ms(-1) 0;
+		font-size: ms(-1);
+		font-style: italic;
+		color: $color_body;
+	}
+}
+
+.wp-block-cover-image,
+.wp-block-cover {
+	.wp-block-cover-image-text,
+	.wp-block-cover-text,
+	h2 {
+		font-size: ms(3);
+		font-weight: 300;
+		line-height: 1.618;
+		padding: ms(1);
+		width: calc(100vw - #{ms(1)});
+		max-width: calc(100vw - #{ms(1)});
+
+		@include susy-media($handheld) {
+			padding: ms(1);
+			font-size: ms(4);
+			width: calc(8 * (100vw / 12 ));
+			max-width: calc(8 * (100vw / 12 ));
+		}
+
+		@include susy-media($desktop) {
+			font-size: ms(4);
+			width: calc(6 * (100vw / 12 ));
+			max-width: calc(6 * (100vw / 12 ));
+		}
+	}
+}
+
+// Galleries
+.wp-block-gallery {
+	margin: 0 0 ms(2);
+
+	.blocks-gallery-image,
+	.blocks-gallery-item {
+		margin: 0 ms(1) ms(1) 0;
+
+		figcaption {
+			font-size: ms(1);
+			padding: ms(4) ms(2) ms(-2);
+		}
+	}
+}
+
+@media (min-width:600px) {
+	.wp-block-gallery {
+		.blocks-gallery-image,
+		.blocks-gallery-item {
+			margin: 0 gutter(9) gutter(9) 0;
+		}
+	}
+
+	@for $i from 2 through 8 {
+		.wp-block-gallery.columns-#{$i} .blocks-gallery-image,
+		.wp-block-gallery.columns-#{$i} .blocks-gallery-item {
+			margin-right: gutter(9);
+			width: span(9 / $i);
+		}
+	}
+
+	.page-template-template-fullwidth-php,
+	.storefront-full-width-content {
+		.wp-block-gallery {
+			.blocks-gallery-image,
+			.blocks-gallery-item {
+				margin-bottom: gutter(12);
+				margin-right: gutter(12);
+			}
+		}
+
+		@for $i from 2 through 8 {
+			.wp-block-gallery.columns-#{$i} .blocks-gallery-image,
+			.wp-block-gallery.columns-#{$i} .blocks-gallery-item {
+				margin-right: gutter(12);
+				width: span(12 / $i);
+
+				&:nth-of-type( #{$i}n ) {
+					margin-right: 0;
+				}
+			}
+		}
+	}
+}
+
+// Separator
+.wp-block-separator {
+	border: 0;
+	margin: 0 auto ms(2);
+
+	&.is-style-dots {
+		&::before {
+			color: darken( $color_body, 20% );
+		}
+	}
+}
+
+// Twitter Embed
+.wp-block-embed-twitter {
+	overflow: hidden;
+}
+
+// Table
+.wp-block-table {
+	border-collapse: separate;
+
+	td,
+	th {
+		border: 0;
+		padding: 1em ms(2);
+		word-break: normal;
+	}
+
+	thead {
+		th {
+			padding: ms(2);
+		}
+	}
+}
+
+// File
+.wp-block-file {
+	margin-bottom: ms(2);
+
+	.wp-block-file__button {
+		font-size: ms(-1);
+		line-height: 1.618;
+		border: 0;
+		background: none;
+		color: #fff;
+		background-color: $color_body;
+		border-color: $color_body;
+		cursor: pointer;
+		padding: ms(-2) ms(2);
+		text-decoration: none;
+		font-weight: 600;
+		text-shadow: none;
+		display: inline-block;
+		outline: none;
+		-webkit-appearance: none;
+		border-radius: 0;
+
+		&:hover,
+		&:focus,
+		&:active {
+			color: #fff;
+			background-color: $color_body;
+			border-color: $color_body;
+		}
+	}
+}
+
+// Code
+.wp-block-code,
+.wp-block-preformatted pre {
+	color: $color_body;
+	font-family: 'Courier 10 Pitch', Courier, monospace;
+	font-size: ms(1);
+}
+
+.wp-block-code {
+	border: none;
+	border-radius: 0;
+	padding: ms(3);
+}
+
+// Columns
+.wp-block-column {
+	margin-bottom: ms(1);
+}
+
+@media (min-width:600px) {
+	.wp-block-column {
+		padding-left: 0;
+		padding-right: gutter(9);
+	}
+
+	.page-template-template-fullwidth-php,
+	.storefront-full-width-content {
+		.wp-block-column {
+			padding-right: gutter(9);
+		}
+	}
+}
+
+@media (min-width:600px) {
+	.wp-block-column {
+		padding-right: 0;
+
+		&:nth-child( odd ) {
+			padding-left: 0;
+		}
+
+		&:nth-child( 2n ) {
+			padding-right: 0;
+			margin-right: gutter(9);
+		}
+	}
+
+	.wp-block-columns {
+		@for $i from 2 through 6 {
+			&.has-#{$i}-columns {
+				.wp-block-column {
+					&:nth-of-type( #{$i}n ) {
+						margin-right: 0;
+					}
+				}
+			}
+		}
+	}
+
+	.page-template-template-fullwidth-php,
+	.storefront-full-width-content {
+		.wp-block-column {
+			padding-right: 0;
+
+			&:nth-child( 2n ) {
+				margin-right: gutter(12);
+			}
+		}
+	}
+}
+
+@media (min-width:782px) {
+	.wp-block-column:not( :first-child ) {
+		padding-left: 0;
+	}
+
+	.wp-block-column:not( :last-child ) {
+		padding-right: 0;
+		margin-right: gutter(9);
+	}
+
+	.page-template-template-fullwidth-php,
+	.storefront-full-width-content {
+		.wp-block-column:not( :last-child ) {
+			margin-right: gutter(12);
+		}
+	}
+}
+
+
+// Latest Comments
+.wp-block-latest-comments {
+	margin: 0 0 ms(2);
+
+	&__comment {
+		font-size: ms(1);
+		margin: 0 0 ms(1);
+	}
+
+	&__comment-date {
+		font-size: ms(-1);
+	}
+
+	&__comment-excerpt {
+		p {
+			margin: ms(-3) 0 ms(1);
+			font-size: 1em;
+			line-height: 1.618;
+		}
+	}
+}

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -552,3 +552,19 @@ p {
 		}
 	}
 }
+
+// Custom colors
+.has-primary-background-color {
+	background-color: $color_links;
+
+	p,
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	a {
+		color: #fff;
+	}
+}

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -552,19 +552,3 @@ p {
 		}
 	}
 }
-
-// Custom colors
-.has-primary-background-color {
-	background-color: $color_links;
-
-	p,
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6,
-	a {
-		color: #fff;
-	}
-}

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -27,48 +27,29 @@
 	font-size: ms(4);
 }
 
-// Layout
-.alignfull {
-	margin-left: calc(50% - 50vw);
-	margin-right: calc(50% - 50vw);
-	width: auto;
-	max-width: 1000%;
-}
-
-.alignwide {
-	margin-left: calc(25% - 25vw);
-	margin-right: calc(25% - 25vw);
-	width: auto;
-	max-width: 1000%;
-}
-
-@include susy-media($desktop) {
-	.alignfull,
-	.alignwide {
-		margin-left: auto;
-		margin-right: auto;
-		max-width: none;
-	}
-
+@media ( min-width: $container-width ) {
 	// Global
 	.page-template-template-fullwidth-php,
 	.storefront-full-width-content {
+		.alignfull,
+		.alignwide {
+			width: auto;
+			max-width: 1000%;
+			padding-left: ms(2);
+			padding-right: ms(2);
+		}
+
 		.alignfull {
 			margin-left: calc(50% - 50vw);
 			margin-right: calc(50% - 50vw);
-			width: auto;
-			max-width: 1000%;
 		}
 
 		.alignwide {
 			margin-left: calc(25% - 25vw);
 			margin-right: calc(25% - 25vw);
-			width: auto;
-			max-width: 1000%;
 		}
 	}
 }
-
 
 // Audio
 .wp-block-audio {
@@ -333,13 +314,30 @@ p {
 	}
 }
 
+@media ( min-width: $container-width ) {
+	// Global
+	.page-template-template-fullwidth-php,
+	.storefront-full-width-content {
+		.wp-block-cover-image,
+		.wp-block-cover,
+		.wp-block-image {
+			&.alignfull,
+			&.alignwide {
+				padding-left: 0;
+				padding-right: 0;
+			}
+		}
+	}
+}
+
 // Galleries
 .wp-block-gallery {
 	margin: 0 0 ms(2);
 
 	.blocks-gallery-image,
 	.blocks-gallery-item {
-		margin: 0 ms(1) ms(1) 0;
+		width: span(6);
+		margin: 0 gutter(12) gutter(12) 0;
 
 		figcaption {
 			font-size: ms(1);
@@ -488,20 +486,7 @@ p {
 	}
 }
 
-@media (min-width:600px) {
-	.wp-block-column {
-		padding-right: 0;
-
-		&:nth-child( odd ) {
-			padding-left: 0;
-		}
-
-		&:nth-child( 2n ) {
-			padding-right: 0;
-			margin-right: gutter(9);
-		}
-	}
-
+@media (min-width:782px) {
 	.wp-block-columns {
 		@for $i from 2 through 6 {
 			&.has-#{$i}-columns {
@@ -514,36 +499,30 @@ p {
 		}
 	}
 
+	.wp-block-column {
+		padding-right: 0;
+
+		&:not( :first-child ) {
+			padding-left: 0;
+		}
+
+		&:not( :last-child ) {
+			padding-right: 0;
+			margin-right: gutter(9);
+		}
+	}
+
 	.page-template-template-fullwidth-php,
 	.storefront-full-width-content {
 		.wp-block-column {
 			padding-right: 0;
 
-			&:nth-child( 2n ) {
+			&:not( :last-child ) {
 				margin-right: gutter(12);
 			}
 		}
 	}
 }
-
-@media (min-width:782px) {
-	.wp-block-column:not( :first-child ) {
-		padding-left: 0;
-	}
-
-	.wp-block-column:not( :last-child ) {
-		padding-right: 0;
-		margin-right: gutter(9);
-	}
-
-	.page-template-template-fullwidth-php,
-	.storefront-full-width-content {
-		.wp-block-column:not( :last-child ) {
-			margin-right: gutter(12);
-		}
-	}
-}
-
 
 // Latest Comments
 .wp-block-latest-comments {

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -485,9 +485,21 @@
 				padding-right: gutter(9);
 				margin-left: 0;
 
+				&:not( :last-child ) {
+					margin-right: 0;
+				}
+
+				&:nth-of-type( even ) {
+					padding-right: 0;
+				}
+
 				.page-template-template-fullwidth-php &,
 				.storefront-full-width-content & {
-					padding-right: gutter(9);
+					padding-right: gutter(12);
+
+					&:nth-of-type( even ) {
+						padding-right: 0;
+					}
 				}
 			}
 		}

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -302,15 +302,21 @@ p {
 
 .wp-block-cover-image,
 .wp-block-cover {
+	flex-flow: row wrap;
+
 	.wp-block-cover-image-text,
 	.wp-block-cover-text,
-	h2 {
+	h2,
+	p {
 		font-size: ms(3);
 		font-weight: 300;
 		line-height: 1.618;
 		padding: ms(1);
 		width: calc(100vw - #{ms(1)});
 		max-width: calc(100vw - #{ms(1)});
+		color: #fff;
+		z-index: 1;
+		text-align: center;
 
 		@include susy-media($handheld) {
 			padding: ms(1);

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -173,16 +173,24 @@
 	}
 
 	li {
-		margin: 0 0 ms(1);
+		margin: 0;
+	}
 
-		&:last-child {
-			margin-bottom: 0;
+	&.has-dates {
+		li {
+			margin: 0 0 1em;
 		}
 	}
 
 	&.is-grid {
 		li {
-			margin: 0 ms(1) ms(1) 0;
+			margin: 0 ms(1) 0 0;
+		}
+
+		&.has-dates {
+			li {
+				margin-bottom: 1em;
+			}
 		}
 	}
 }

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -1,0 +1,7 @@
+// Galleries
+.wp-block-gallery {
+	.blocks-gallery-image,
+	.blocks-gallery-item {
+		flex-grow: 0;
+	}
+}

--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -31,6 +31,24 @@
 	}
 }
 
+.entry-taxonomy {
+	.cat-links {
+		&::before {
+			@include sf-fa-icon;
+			content: fa-content( $fa-var-folder );
+			margin-right: ms(-3);
+		}
+	}
+
+	.tags-links {
+		&::before {
+			@include sf-fa-icon;
+			content: fa-content( $fa-var-tag );
+			margin-right: ms(-3);
+		}
+	}
+}
+
 #comments {
 	.commentlist {
 		.bypostauthor {

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -276,6 +276,9 @@ if ( ! class_exists( 'Storefront' ) ) :
 			wp_enqueue_style( 'storefront-style', get_template_directory_uri() . '/style.css', '', $storefront_version );
 			wp_style_add_data( 'storefront-style', 'rtl', 'replace' );
 
+			wp_enqueue_style( 'storefront-gutenberg-blocks', get_template_directory_uri() . '/assets/css/base/gutenberg-blocks.css', '', $storefront_version );
+			wp_style_add_data( 'storefront-gutenberg-blocks', 'rtl', 'replace' );
+
 			wp_enqueue_style( 'storefront-icons', get_template_directory_uri() . '/assets/css/base/icons.css', '', $storefront_version );
 			wp_style_add_data( 'storefront-icons', 'rtl', 'replace' );
 

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -183,7 +183,9 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 */
 			add_editor_style( 'assets/css/base/gutenberg-editor.css' );
 
-			// Editor color palette
+			/**
+			 * Editor color palette.
+			 */
 			add_theme_support(
 				'editor-color-palette',
 				array(
@@ -194,6 +196,11 @@ if ( ! class_exists( 'Storefront' ) ) :
 					),
 				)
 			);
+
+			/**
+			 * Add support for responsive embedded content.
+			 */
+			add_theme_support( 'responsive-embeds' );
 		}
 
 		/**

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -162,6 +162,26 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 * Declare support for selective refreshing of widgets.
 			 */
 			add_theme_support( 'customize-selective-refresh-widgets' );
+
+			/**
+			 * Add support for Block Styles.
+			 */
+			add_theme_support( 'wp-block-styles' );
+
+			/**
+			 * Add support for full and wide align images.
+			 */
+			add_theme_support( 'align-wide' );
+
+			/**
+			 * Add support for editor styles.
+			 */
+			add_theme_support( 'editor-styles' );
+
+			/**
+			 * Enqueue editor styles.
+			 */
+			add_editor_style( 'assets/css/base/gutenberg-editor.css' );
 		}
 
 		/**

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -182,6 +182,18 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 * Enqueue editor styles.
 			 */
 			add_editor_style( 'assets/css/base/gutenberg-editor.css' );
+
+			// Editor color palette
+			add_theme_support(
+				'editor-color-palette',
+				array(
+					array(
+						'name'  => esc_html__( 'Primary Color', 'storefront' ),
+						'slug'  => 'primary',
+						'color' => get_theme_mod( 'storefront_accent_color', apply_filters( 'storefront_default_accent_color', '#96588a' ) ),
+					),
+				)
+			);
 		}
 
 		/**

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -184,20 +184,6 @@ if ( ! class_exists( 'Storefront' ) ) :
 			add_editor_style( 'assets/css/base/gutenberg-editor.css' );
 
 			/**
-			 * Editor color palette.
-			 */
-			add_theme_support(
-				'editor-color-palette',
-				array(
-					array(
-						'name'  => esc_html__( 'Primary Color', 'storefront' ),
-						'slug'  => 'primary',
-						'color' => get_theme_mod( 'storefront_accent_color', apply_filters( 'storefront_default_accent_color', '#96588a' ) ),
-					),
-				)
-			);
-
-			/**
 			 * Add support for responsive embedded content.
 			 */
 			add_theme_support( 'responsive-embeds' );

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -820,6 +820,78 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 		}
 
 		/**
+		 * Get Gutenberg Customizer css.
+		 *
+		 * @see get_storefront_theme_mods()
+		 * @return array $styles the css
+		 */
+		public function gutenberg_get_css() {
+			$storefront_theme_mods = $this->get_storefront_theme_mods();
+			$brighten_factor       = apply_filters( 'storefront_brighten_factor', 25 );
+			$darken_factor         = apply_filters( 'storefront_darken_factor', -25 );
+
+			// Gutenberg
+			$styles = '
+				.wp-block-button .wp-block-button__link {
+					border-color: ' . $storefront_theme_mods['button_background_color'] . ';
+				}
+
+				.wp-block-button:not(.has-text-color) .wp-block-button__link {
+					color: ' . $storefront_theme_mods['button_text_color'] . ';
+				}
+
+				.wp-block-button:not(.has-text-color) .wp-block-button__link:hover,
+				.wp-block-button:not(.has-text-color) .wp-block-button__link:focus,
+				.wp-block-button:not(.has-text-color) .wp-block-button__link:active {
+					color: ' . $storefront_theme_mods['button_text_color'] . ';
+				}
+
+				.wp-block-button:not(.has-background) .wp-block-button__link {
+					background-color: ' . $storefront_theme_mods['button_background_color'] . ';
+				}
+
+				.wp-block-button:not(.has-background) .wp-block-button__link:hover,
+				.wp-block-button:not(.has-background) .wp-block-button__link:focus,
+				.wp-block-button:not(.has-background) .wp-block-button__link:active {
+					border-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_background_color'], $darken_factor ) . ';
+					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_background_color'], $darken_factor ) . ';
+				}
+
+				.wp-block-quote footer,
+				.wp-block-quote cite {
+					color: ' . $storefront_theme_mods['text_color'] . ';
+				}
+
+				.wp-block-image figcaption {
+					color: ' . $storefront_theme_mods['text_color'] . ';
+				}
+
+				.wp-block-separator.is-style-dots::before {
+					color: ' . $storefront_theme_mods['heading_color'] . ';
+				}
+
+				.wp-block-file .wp-block-file__button {
+					color: ' . $storefront_theme_mods['button_text_color'] . ';
+					background-color: ' . $storefront_theme_mods['button_background_color'] . ';
+					border-color: ' . $storefront_theme_mods['button_background_color'] . ';
+				}
+
+				.wp-block-file .wp-block-file__button:hover, .wp-block-file .wp-block-file__button:focus, .wp-block-file .wp-block-file__button:active {
+					color: ' . $storefront_theme_mods['button_text_color'] . ';
+					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_background_color'], $darken_factor ) . ';
+					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_background_color'], $darken_factor ) . ';
+				}
+
+				.wp-block-code,
+				.wp-block-preformatted pre {
+					color: ' . $storefront_theme_mods['text_color'] . ';
+				}
+			';
+
+			return apply_filters( 'storefront_gutenberg_customizer_css', $styles );
+		}
+
+		/**
 		 * Add CSS in <head> for styles handled by the theme customizer
 		 *
 		 * @since 1.0.0
@@ -827,6 +899,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 		 */
 		public function add_customizer_css() {
 			wp_add_inline_style( 'storefront-style', $this->get_css() );
+			wp_add_inline_style( 'storefront-gutenberg-blocks', $this->gutenberg_get_css() );
 		}
 
 		/**

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -830,7 +830,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			$brighten_factor       = apply_filters( 'storefront_brighten_factor', 25 );
 			$darken_factor         = apply_filters( 'storefront_darken_factor', -25 );
 
-			// Gutenberg
+			// Gutenberg.
 			$styles = '
 				.wp-block-button .wp-block-button__link {
 					border-color: ' . $storefront_theme_mods['button_background_color'] . ';

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -723,6 +723,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			.widget-area .widget a,
 			.hentry .entry-header .posted-on a,
+			.hentry .entry-header .post-author a,
+			.hentry .entry-header .post-comments a,
 			.hentry .entry-header .byline a {
 				color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['text_color'], 5 ) . ';
 			}

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -827,7 +827,6 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 		 */
 		public function gutenberg_get_css() {
 			$storefront_theme_mods = $this->get_storefront_theme_mods();
-			$brighten_factor       = apply_filters( 'storefront_brighten_factor', 25 );
 			$darken_factor         = apply_filters( 'storefront_darken_factor', -25 );
 
 			// Gutenberg.

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -886,6 +886,10 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				.wp-block-preformatted pre {
 					color: ' . $storefront_theme_mods['text_color'] . ';
 				}
+
+				.wp-block-table:not( .is-style-stripes ) tbody tr:nth-child(2n) td {
+					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -2 ) . ';
+				}
 			';
 
 			return apply_filters( 'storefront_gutenberg_customizer_css', $styles );

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -424,7 +424,7 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 	 * @since 1.0.0
 	 */
 	function storefront_post_meta() {
-		// Posted on
+		// Posted on.
 		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 
 		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
@@ -445,7 +445,7 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 			'<span class="posted-on"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a></span>'
 		);
 
-		// Author
+		// Author.
 		$author = sprintf(
 			'<span class="post-author">%1$s <a href="%2$s" class="url fn" rel="author">%3$s</a></span>',
 			__( 'by', 'storefront' ),
@@ -453,7 +453,7 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 			esc_html( get_the_author() )
 		);
 
-		// Comments
+		// Comments.
 		$comments = '';
 
 		if ( ! post_password_required() && ( comments_open() || '0' !== get_comments_number() ) ) {
@@ -486,6 +486,11 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 }
 
 if ( ! function_exists( 'storefront_post_taxonomy' ) ) {
+	/**
+	 * Display the post taxonomies
+	 *
+	 * @since 2.4.0
+	 */
 	function storefront_post_taxonomy() {
 		/* translators: used between list items, there is a space after the comma */
 		$categories_list = get_the_category_list( __( ', ', 'storefront' ) );

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -362,11 +362,11 @@ if ( ! function_exists( 'storefront_post_header' ) ) {
 		<header class="entry-header">
 		<?php
 		if ( is_single() ) {
-			storefront_posted_on();
+			storefront_post_meta();
 			the_title( '<h1 class="entry-title">', '</h1>' );
 		} else {
 			if ( 'post' == get_post_type() ) {
-				storefront_posted_on();
+				storefront_post_meta();
 			}
 
 			the_title( sprintf( '<h2 class="alpha entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
@@ -424,56 +424,92 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 	 * @since 1.0.0
 	 */
 	function storefront_post_meta() {
+		// Posted on
+		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+
+		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time> <time class="updated" datetime="%3$s">%4$s</time>';
+		}
+
+		$time_string = sprintf(
+			$time_string,
+			esc_attr( get_the_date( 'c' ) ),
+			esc_html( get_the_date() ),
+			esc_attr( get_the_modified_date( 'c' ) ),
+			esc_html( get_the_modified_date() )
+		);
+
+		$posted_on = sprintf(
+			/* translators: %s: post date */
+			_x( 'Posted on %s', 'post date', 'storefront' ),
+			'<span class="posted-on"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a></span>'
+		);
+
+		// Author
+		$author = sprintf(
+			'<span class="post-author">%1$s <a href="%2$s" class="url fn" rel="author">%3$s</a></span>',
+			__( 'by', 'storefront' ),
+			esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
+			esc_html( get_the_author() )
+		);
+
+		// Comments
+		$comments = '';
+
+		if ( ! post_password_required() && ( comments_open() || '0' !== get_comments_number() ) ) {
+			$comments_number = get_comments_number_text( __( 'Leave a comment', 'storefront' ), __( '1 Comment', 'storefront' ), __( '% Comments', 'storefront' ) );
+
+			$comments = sprintf(
+				'<span class="post-comments">&mdash; <a href="%1$s">%2$s</a></span>',
+				esc_url( get_comments_link() ),
+				$comments_number
+			);
+		}
+
+		echo wp_kses(
+			sprintf( '%1$s %2$s %3$s', $posted_on, $author, $comments ), array(
+				'span' => array(
+					'class'  => array(),
+				),
+				'a'    => array(
+					'href'  => array(),
+					'title' => array(),
+					'rel'   => array(),
+				),
+				'time' => array(
+					'datetime' => array(),
+					'class'    => array(),
+				),
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'storefront_post_taxonomy' ) ) {
+	function storefront_post_taxonomy() {
+		/* translators: used between list items, there is a space after the comma */
+		$categories_list = get_the_category_list( __( ', ', 'storefront' ) );
+
+		/* translators: used between list items, there is a space after the comma */
+		$tags_list = get_the_tag_list( '', __( ', ', 'storefront' ) );
 		?>
-		<aside class="entry-meta">
-			<?php
-			if ( 'post' == get_post_type() ) : // Hide category and tag text for pages on Search.
 
-				?>
-			<div class="vcard author">
-				<?php
-					echo get_avatar( get_the_author_meta( 'ID' ), 128 );
-					echo '<div class="label">' . esc_attr( __( 'Written by', 'storefront' ) ) . '</div>';
-					echo sprintf( '<a href="%1$s" class="url fn" rel="author">%2$s</a>', esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ), get_the_author() );
-				?>
+		<aside class="entry-taxonomy">
+			<?php if ( $categories_list ) : ?>
+			<div class="cat-links">
+				<span class="screen-reader-text"><?php echo esc_attr( __( 'Posted in', 'storefront' ) ); ?></span>
+				<?php echo wp_kses_post( $categories_list ); ?>
 			</div>
-				<?php
-				/* translators: used between list items, there is a space after the comma */
-				$categories_list = get_the_category_list( __( ', ', 'storefront' ) );
+			<?php endif; // End if categories. ?>
 
-				if ( $categories_list ) :
-					?>
-				<div class="cat-links">
-						<?php
-						echo '<div class="label">' . esc_attr( __( 'Posted in', 'storefront' ) ) . '</div>';
-						echo wp_kses_post( $categories_list );
-						?>
-				</div>
-				<?php endif; // End if categories. ?>
-
-				<?php
-				/* translators: used between list items, there is a space after the comma */
-				$tags_list = get_the_tag_list( '', __( ', ', 'storefront' ) );
-
-				if ( $tags_list ) :
-					?>
-				<div class="tags-links">
-						<?php
-						echo '<div class="label">' . esc_attr( __( 'Tagged', 'storefront' ) ) . '</div>';
-						echo wp_kses_post( $tags_list );
-						?>
-				</div>
-				<?php endif; // End if $tags_list. ?>
-
-		<?php endif; // End if 'post' == get_post_type(). ?>
-
-			<?php if ( ! post_password_required() && ( comments_open() || '0' != get_comments_number() ) ) : ?>
-				<div class="comments-link">
-					<?php echo '<div class="label">' . esc_attr( __( 'Comments', 'storefront' ) ) . '</div>'; ?>
-					<span class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'storefront' ), __( '1 Comment', 'storefront' ), __( '% Comments', 'storefront' ) ); ?></span>
-				</div>
-			<?php endif; ?>
+			<?php if ( $tags_list ) : ?>
+			<div class="tags-links">
+				<span class="screen-reader-text"><?php echo esc_attr( __( 'Tagged', 'storefront' ) ); ?></span>
+				<?php echo wp_kses_post( $tags_list ); ?>
+			</div>
+			<?php endif; // End if $tags_list. ?>
 		</aside>
+
 		<?php
 	}
 }
@@ -511,43 +547,11 @@ if ( ! function_exists( 'storefront_post_nav' ) ) {
 if ( ! function_exists( 'storefront_posted_on' ) ) {
 	/**
 	 * Prints HTML with meta information for the current post-date/time and author.
+	 *
+	 * @deprecated 2.4.0
 	 */
 	function storefront_posted_on() {
-		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time> <time class="updated" datetime="%3$s">%4$s</time>';
-		}
-
-		$time_string = sprintf(
-			$time_string,
-			esc_attr( get_the_date( 'c' ) ),
-			esc_html( get_the_date() ),
-			esc_attr( get_the_modified_date( 'c' ) ),
-			esc_html( get_the_modified_date() )
-		);
-
-		$posted_on = sprintf(
-			/* translators: %s: post date */
-			_x( 'Posted on %s', 'post date', 'storefront' ),
-			'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
-		);
-
-		echo wp_kses(
-			apply_filters( 'storefront_single_post_posted_on_html', '<span class="posted-on">' . $posted_on . '</span>', $posted_on ), array(
-				'span' => array(
-					'class'  => array(),
-				),
-				'a'    => array(
-					'href'  => array(),
-					'title' => array(),
-					'rel'   => array(),
-				),
-				'time' => array(
-					'datetime' => array(),
-					'class'    => array(),
-				),
-			)
-		);
+		_deprecated_function( 'storefront_posted_on', '2.4.0' );
 	}
 }
 

--- a/inc/storefront-template-hooks.php
+++ b/inc/storefront-template-hooks.php
@@ -59,12 +59,12 @@ add_action( 'homepage', 'storefront_homepage_content', 10 );
  * @see  storefront_display_comments()
  */
 add_action( 'storefront_loop_post', 'storefront_post_header', 10 );
-add_action( 'storefront_loop_post', 'storefront_post_meta', 20 );
 add_action( 'storefront_loop_post', 'storefront_post_content', 30 );
+add_action( 'storefront_loop_post', 'storefront_post_taxonomy', 40 );
 add_action( 'storefront_loop_after', 'storefront_paging_nav', 10 );
 add_action( 'storefront_single_post', 'storefront_post_header', 10 );
-add_action( 'storefront_single_post', 'storefront_post_meta', 20 );
 add_action( 'storefront_single_post', 'storefront_post_content', 30 );
+add_action( 'storefront_single_post_bottom', 'storefront_post_taxonomy', 5 );
 add_action( 'storefront_single_post_bottom', 'storefront_post_nav', 10 );
 add_action( 'storefront_single_post_bottom', 'storefront_display_comments', 20 );
 add_action( 'storefront_post_content_before', 'storefront_post_thumbnail', 10 );

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -500,12 +500,11 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 		 *
 		 * @since  2.3.4
 		 *
-		 * @param  array  $group_mode_data
+		 * @param  array $group_mode_data Group mode data.
 		 * @return array
 		 */
 		public function bundles_group_mode_options_data( $group_mode_data ) {
-
-			$group_mode_data[ 'parent' ][ 'features' ][] = 'parent_cart_item_meta';
+			$group_mode_data['parent']['features'][] = 'parent_cart_item_meta';
 
 			return $group_mode_data;
 		}


### PR DESCRIPTION
This PR adds enhanced compatibility with the upcoming WordPress editor. Changes introduced in this PR:

* Declare support for Gutenberg features
* Styling for blocks included with the editor
* Change the single post layout from having the post meta to the left of the content to allow for blocks to go full width
* Add CSS file for future editor styles

**Post meta before:**

<img width="1091" alt="before" src="https://user-images.githubusercontent.com/1177726/48911920-1d48f780-ee6c-11e8-91fb-e24028c288e8.png">

**Post meta after:**

<img width="1087" alt="after" src="https://user-images.githubusercontent.com/1177726/48911960-3d78b680-ee6c-11e8-9762-765a06335086.png">
