### PR TITLE
Remove 'comments closed' message from pages

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -65,7 +65,7 @@ if ( post_password_required() ) {
 
 	endif;
 
-	if ( ! comments_open() && '0' !== get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) :
+	if ( ! comments_open() && 0 !== intval( get_comments_number() ) && post_type_supports( get_post_type(), 'comments' ) ) :
 		?>
 		<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'storefront' ); ?></p>
 		<?php

--- a/comments.php
+++ b/comments.php
@@ -65,7 +65,7 @@ if ( post_password_required() ) {
 
 	endif;
 
-	if ( ! comments_open() && 0 !== get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) :
+	if ( ! comments_open() && '0' !== get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) :
 		?>
 		<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'storefront' ); ?></p>
 		<?php

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -13,7 +13,7 @@ if ( ! function_exists( 'storefront_display_comments' ) ) {
 	 */
 	function storefront_display_comments() {
 		// If comments are open or we have at least one comment, load up the comment template.
-		if ( comments_open() || 0 !== get_comments_number() ) :
+		if ( comments_open() || '0' !== get_comments_number() ) :
 			comments_template();
 		endif;
 	}

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -13,7 +13,7 @@ if ( ! function_exists( 'storefront_display_comments' ) ) {
 	 */
 	function storefront_display_comments() {
 		// If comments are open or we have at least one comment, load up the comment template.
-		if ( comments_open() || '0' !== get_comments_number() ) :
+		if ( comments_open() || 0 !== intval( get_comments_number() ) ) :
 			comments_template();
 		endif;
 	}
@@ -451,7 +451,7 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 		// Comments.
 		$comments = '';
 
-		if ( ! post_password_required() && ( comments_open() || '0' !== get_comments_number() ) ) {
+		if ( ! post_password_required() && ( comments_open() || 0 !== intval( get_comments_number() ) ) ) {
 			$comments_number = get_comments_number_text( __( 'Leave a comment', 'storefront' ), __( '1 Comment', 'storefront' ), __( '% Comments', 'storefront' ) );
 
 			$comments = sprintf(


### PR DESCRIPTION
Fixes the conditional logic for checking the number of comments. The issue was introduced in https://github.com/woocommerce/storefront/commit/a5f9c57962be2628b4f1d3c2ed5318612897fb58.

`get_comments_number()` returns a string, not an integer. @claudiosanches was right :)

Without this PR, you'll find the "comments closed" message at the bottom of pages. For example, check the Cart page and you'll find this:

<img width="1124" alt="screenshot 2018-11-23 at 11 44 11" src="https://user-images.githubusercontent.com/1177726/48941866-280b9700-ef15-11e8-97ca-b9e6dea7edd2.png">
