### PR TITLE
Move 'posted on' inside span

### DIFF
--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -435,9 +435,9 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 		);
 
 		$posted_on = sprintf(
+			'<span class="posted-on">%s <a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a></span>',
 			/* translators: %s: post date */
-			_x( 'Posted on %s', 'post date', 'storefront' ),
-			'<span class="posted-on"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a></span>'
+			_x( 'Posted on', 'post date', 'storefront' )
 		);
 
 		// Author.
@@ -464,7 +464,7 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 		echo wp_kses(
 			sprintf( '%1$s %2$s %3$s', $posted_on, $author, $comments ), array(
 				'span' => array(
-					'class'  => array(),
+					'class' => array(),
 				),
 				'a'    => array(
 					'href'  => array(),


### PR DESCRIPTION
Fixes and issue where the text 'Posted on' is slightly bigger in size than the rest of the post meta content.

Before:

<img width="479" alt="screenshot 2018-11-23 at 16 27 00" src="https://user-images.githubusercontent.com/1177726/48953110-a465a080-ef3c-11e8-96e6-313320728d92.png">

After:

<img width="482" alt="screenshot 2018-11-23 at 16 26 45" src="https://user-images.githubusercontent.com/1177726/48953114-a891be00-ef3c-11e8-9a2c-76f8b445ee9d.png">
