### PR TITLE
Add custom body class if align-wide is supported

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -13,8 +13,8 @@
 .hentry .entry-content {
 	// Global
 	@media ( min-width: $container-width ) {
-		.page-template-template-fullwidth-php &,
-		.storefront-full-width-content & {
+		.storefront-align-wide.page-template-template-fullwidth-php &,
+		.storefront-align-wide.storefront-full-width-content & {
 			.alignfull,
 			.alignwide {
 				width: auto;
@@ -278,8 +278,8 @@
 		}
 
 		@media ( min-width: $container-width ) {
-			.page-template-template-fullwidth-php &,
-			.storefront-full-width-content & {
+			.storefront-align-wide.page-template-template-fullwidth-php &,
+			.storefront-align-wide.storefront-full-width-content & {
 				&.alignfull,
 				&.alignwide {
 					padding-left: 0;
@@ -322,8 +322,8 @@
 		}
 
 		@media ( min-width: $container-width ) {
-			.page-template-template-fullwidth-php &,
-			.storefront-full-width-content & {
+			.storefront-align-wide.page-template-template-fullwidth-php &,
+			.storefront-align-wide.storefront-full-width-content & {
 				&.alignfull,
 				&.alignwide {
 					padding-left: 0;

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -403,6 +403,11 @@ if ( ! class_exists( 'Storefront' ) ) :
 				$classes[] = 'storefront-secondary-navigation';
 			}
 
+			// Add class if align-wide is supported.
+			if ( current_theme_supports( 'align-wide' ) ) {
+				$classes[] = 'storefront-align-wide';
+			}
+
 			return $classes;
 		}
 


### PR DESCRIPTION
Adds a custom body if the current theme supports Gutenberg's align-wide option.

This is useful for child themes that don't support this option so that we don't have to manually reset styles on each child theme individually.

To test, see if the `storefront-align-wide` shows up in the list of `body` classes.