### PR TITLE
Remove unnecessary trailing slash

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -48,7 +48,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 */
 
 			// Loads wp-content/languages/themes/storefront-it_IT.mo.
-			load_theme_textdomain( 'storefront', trailingslashit( WP_LANG_DIR ) . 'themes/' );
+			load_theme_textdomain( 'storefront', trailingslashit( WP_LANG_DIR ) . 'themes' );
 
 			// Loads wp-content/themes/child-theme-name/languages/it_IT.mo.
 			load_theme_textdomain( 'storefront', get_stylesheet_directory() . '/languages' );


### PR DESCRIPTION
The trailing slash is not required in the first load_theme_textdomain() call.
It results in a search for: /wp-content/languages/themes//en_US.mo 
It's not harmful but simply inconsistent and unnecessary.