### PR TITLE
Gutenberg editor styles

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -10,6 +10,9 @@
 @import '../sass/utils/mixins';
 @import '../sass/vendors/modular-scale';
 
+/**
+ * Front-end only styles
+ */
 .hentry .entry-content {
 	// Global
 	@media ( min-width: $container-width ) {
@@ -35,6 +38,40 @@
 		}
 	}
 
+	// Image
+	.wp-block-image {
+		@media ( min-width: $container-width ) {
+			.storefront-align-wide.page-template-template-fullwidth-php &,
+			.storefront-align-wide.storefront-full-width-content & {
+				&.alignfull,
+				&.alignwide {
+					padding-left: 0;
+					padding-right: 0;
+				}
+			}
+		}
+	}
+
+	.wp-block-cover-image,
+	.wp-block-cover {
+		@media ( min-width: $container-width ) {
+			.storefront-align-wide.page-template-template-fullwidth-php &,
+			.storefront-align-wide.storefront-full-width-content & {
+				&.alignfull,
+				&.alignwide {
+					padding-left: 0;
+					padding-right: 0;
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Front-end + editor styles
+ */
+.hentry .entry-content,
+.editor-styles-wrapper {
 	// Typography
 	.has-small-font-size {
 		font-size: ms(-1);
@@ -179,8 +216,8 @@
 		@media (min-width:600px) {
 			@for $i from 2 through 6 {
 				&.columns-#{$i} li {
-					margin-right: gutter(9);
-					width: span(9 / $i);
+					margin-right: gutter(12);
+					width: span(12 / $i);
 
 					&:nth-of-type( #{$i}n ) {
 						margin-right: 0;
@@ -188,12 +225,11 @@
 				}
 			}
 
-			.page-template-template-fullwidth-php &,
-			.storefront-full-width-content & {
+			body:not( .page-template-template-fullwidth-php ):not( .storefront-full-width-content ) & {
 				@for $i from 2 through 6 {
 					&.columns-#{$i} li {
-						margin-right: gutter(12);
-						width: span(12 / $i);
+						margin-right: gutter(9);
+						width: span(9 / $i);
 
 						&:nth-of-type( #{$i}n ) {
 							margin-right: 0;
@@ -235,7 +271,7 @@
 	// Blockquote
 	.wp-block-quote {
 		margin: 0 0 ms(2);
-		padding: 0;
+		padding: 0 0 0 1em;
 
 		&.is-large,
 		&.is-style-large {
@@ -250,7 +286,8 @@
 		}
 
 		footer,
-		cite {
+		cite,
+		&__citation {
 			color: $color_body;
 			font-size: ms(1);
 			font-weight: 700;
@@ -275,17 +312,6 @@
 			font-size: ms(-1);
 			font-style: italic;
 			color: $color_body;
-		}
-
-		@media ( min-width: $container-width ) {
-			.storefront-align-wide.page-template-template-fullwidth-php &,
-			.storefront-align-wide.storefront-full-width-content & {
-				&.alignfull,
-				&.alignwide {
-					padding-left: 0;
-					padding-right: 0;
-				}
-			}
 		}
 	}
 
@@ -356,14 +382,14 @@
 		@media (min-width:600px) {
 			.blocks-gallery-image,
 			.blocks-gallery-item {
-				margin: 0 gutter(9) gutter(9) 0;
+				margin: 0 gutter(12) gutter(12) 0;
 			}
 
 			@for $i from 2 through 8 {
 				&.columns-#{$i} .blocks-gallery-image,
 				&.columns-#{$i} .blocks-gallery-item {
-					margin-right: gutter(9);
-					width: calc(( 100% - #{gutter(9)} * #{$i - 1} ) / #{$i});
+					margin-right: gutter(12);
+					width: calc(( 100% - #{gutter(12)} * #{$i - 1} ) / #{$i});
 
 					&:nth-of-type( #{$i}n ) {
 						margin-right: 0;
@@ -371,19 +397,18 @@
 				}
 			}
 
-			.page-template-template-fullwidth-php &,
-			.storefront-full-width-content & {
+			body:not( .page-template-template-fullwidth-php ):not( .storefront-full-width-content ) & {
 				.blocks-gallery-image,
 				.blocks-gallery-item {
-					margin-bottom: gutter(12);
-					margin-right: gutter(12);
+					margin-bottom: gutter(9);
+					margin-right: gutter(9);
 				}
 
 				@for $i from 2 through 8 {
 					&.columns-#{$i} .blocks-gallery-image,
 					&.columns-#{$i} .blocks-gallery-item {
-						margin-right: gutter(12);
-						width: calc(( 100% - #{gutter(12)} * #{$i - 1} ) / #{$i});
+						margin-right: gutter(9);
+						width: calc(( 100% - #{gutter(9)} * #{$i - 1} ) / #{$i});
 
 						&:nth-of-type( #{$i}n ) {
 							margin-right: 0;
@@ -482,7 +507,7 @@
 
 			@media (min-width:600px) {
 				padding-left: 0;
-				padding-right: gutter(9);
+				padding-right: gutter(12);
 				margin-left: 0;
 
 				&:not( :last-child ) {
@@ -493,9 +518,8 @@
 					padding-right: 0;
 				}
 
-				.page-template-template-fullwidth-php &,
-				.storefront-full-width-content & {
-					padding-right: gutter(12);
+				body:not( .page-template-template-fullwidth-php ):not( .storefront-full-width-content ) & {
+					padding-right: gutter(9);
 
 					&:nth-of-type( even ) {
 						padding-right: 0;
@@ -524,15 +548,14 @@
 
 				&:not( :last-child ) {
 					padding-right: 0;
-					margin-right: gutter(9);
+					margin-right: gutter(12);
 				}
 
-				.page-template-template-fullwidth-php &,
-				.storefront-full-width-content & {
+				body:not( .page-template-template-fullwidth-php ):not( .storefront-full-width-content ) & {
 					padding-right: 0;
 
 					&:not( :last-child ) {
-						margin-right: gutter(12);
+						margin-right: gutter(9);
 					}
 				}
 			}

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -1,7 +1,338 @@
-// Galleries
-.wp-block-gallery {
-	.blocks-gallery-image,
-	.blocks-gallery-item {
-		flex-grow: 0;
+@import 'bourbon';
+
+// Susy
+// Susy grid system. See: http://susydocs.oddbird.net/en/latest/
+@import '../../../node_modules/susy/sass/susy';
+
+// Utilities
+// Sass tools and helpers used across the project.
+@import '../sass/utils/variables';
+@import '../sass/utils/mixins';
+@import '../sass/vendors/modular-scale';
+
+/**
+ * Base styles
+ */
+
+.editor-block-list__block,
+.editor-default-block-appender textarea.editor-default-block-appender__content,
+.editor-post-title__block .editor-post-title__input {
+	font-family: $base-font;
+}
+
+.editor-block-list__block,
+.editor-block-list__block p,
+.editor-default-block-appender textarea.editor-default-block-appender__content {
+	font-size: 16px;
+	line-height: 1.618;
+}
+
+// Post title
+.editor-post-title__block {
+	position: relative;
+	margin-bottom: ms(1);
+
+	&::after {
+		content: none;
+		position: absolute;
+		top: auto;
+		bottom: 0;
+		right: 14px;
+		left: 14px;
+		border-bottom: 1px solid rgba( 0, 0, 0, 0.05);
 	}
+
+	@media ( min-width: $desktop ) {
+		margin-bottom: ms(5);
+	}
+}
+
+.editor-post-title__block .editor-post-title__input {
+	clear: both;
+	font-weight: 300;
+	color: darken( $color_body, 20% );
+	font-size: ms(5);
+	line-height: 1.214;
+	letter-spacing: -1px;
+}
+
+// Headings - applies to both Classic and Header blocks
+h1,
+.wp-block-freeform.block-library-rich-text__tinymce h1,
+h2,
+.wp-block-freeform.block-library-rich-text__tinymce h2,
+h3,
+.wp-block-freeform.block-library-rich-text__tinymce h3,
+h4,
+.wp-block-freeform.block-library-rich-text__tinymce h4,
+h5,
+.wp-block-freeform.block-library-rich-text__tinymce h5,
+h6,
+.wp-block-freeform.block-library-rich-text__tinymce h6 {
+	clear: both;
+	font-weight: 300;
+	margin: 0 0 ms(-3);
+	color: darken( $color_body, 20% );
+}
+
+h1,
+.wp-block-freeform.block-library-rich-text__tinymce h1 {
+	font-size: ms(5);
+	line-height: 1.214;
+	letter-spacing: -1px;
+}
+
+h2,
+.wp-block-freeform.block-library-rich-text__tinymce h2 {
+	font-size: 2em;
+	line-height: 1.214;
+
+	& + h3 {
+		border-top: 1px solid $color_border;
+		padding-top: ms(-3);
+	}
+}
+
+h3,
+.wp-block-freeform.block-library-rich-text__tinymce h3 {
+	font-size: ms(3);
+}
+
+h4,
+.wp-block-freeform.block-library-rich-text__tinymce h4 {
+	font-size: ms(2);
+}
+
+p,
+ul,
+ol,
+table,
+blockquote,
+form {
+	& + h2,
+	& + header h2,
+	& + h3,
+	& + h4 {
+		margin-top: ms(4);
+	}
+}
+
+hr {
+	background-color: #ccc;
+	border: 0;
+	height: 1px;
+	margin: 0 0 ms(2);
+}
+
+p {
+	margin: 0 0 ms(2);
+}
+
+ul,
+ol {
+	margin: 0 0 ms(2) 3em;
+	padding: 0;
+}
+
+ul {
+	list-style: disc;
+}
+
+ol {
+	list-style: decimal;
+}
+
+li > ul,
+li > ol {
+	margin-bottom: 0;
+	margin-left: ms(1);
+}
+
+dt {
+	font-weight: 600;
+}
+
+dd {
+	margin: 0 0 ms(3);
+}
+
+b,
+strong {
+	font-weight: 600;
+}
+
+dfn,
+cite,
+em,
+i {
+	font-style: italic;
+}
+
+blockquote,
+.wp-block-freeform.block-library-rich-text__tinymce blockquote {
+	margin: 1em 40px;
+	padding: 0 ms(1);
+	border-left: 3px solid rgba( 0, 0, 0, 0.05 );
+	font-style: italic;
+	box-shadow: none;
+}
+
+address {
+	margin: 0 0 ms(2);
+}
+
+pre {
+	background: rgba( #000, 0.1 );
+	font-family: 'Courier 10 Pitch', Courier, monospace;
+	margin-bottom: ms(3);
+	padding: ms(3);
+	overflow: auto;
+	max-width: 100%;
+}
+
+code,
+kbd,
+tt,
+var {
+	font-family: Monaco, Consolas, 'Andale Mono', 'DejaVu Sans Mono', monospace;
+	background-color: rgba( 0, 0, 0, 0.05 );
+	padding: 0.202em ms(-3);
+}
+
+abbr,
+acronym {
+	border-bottom: 1px dotted #666;
+	cursor: help;
+}
+
+mark,
+ins {
+	text-decoration: none;
+	font-weight: 600;
+	background: transparent;
+}
+
+sup,
+sub {
+	font-size: 75%;
+	height: 0;
+	line-height: 0;
+	position: relative;
+	vertical-align: baseline;
+}
+
+sup {
+	bottom: 1ex;
+}
+
+sub {
+	top: 0.5ex;
+}
+
+small {
+	font-size: 75%;
+}
+
+big {
+	font-size: 125%;
+}
+
+figure {
+	margin: 0;
+}
+
+img {
+	height: auto; // Make sure images are scaled correctly.
+	max-width: 100%; // Adhere to container width.
+	display: block;
+}
+
+a {
+	text-decoration: none;
+
+	&:focus {
+		outline: 1px dotted $color_woocommerce;
+	}
+}
+
+table {
+	border-spacing: 0;
+	width: 100%;
+	border-collapse: separate;
+	margin: 0 0 ms(2);
+
+	caption {
+		padding: 1em 0;
+		font-weight: 600;
+	}
+
+	td,
+	th {
+		padding: 1em ms(2);
+		text-align: left;
+		vertical-align: top;
+		border: 0;
+
+		p:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	th {
+		font-weight: 600;
+	}
+
+	thead {
+		th {
+			padding: ms(2);
+			vertical-align: middle;
+		}
+	}
+
+	tbody {
+		h2 {
+			font-size: 1em;
+			letter-spacing: normal;
+			font-weight: normal;
+
+			a {
+				font-weight: normal;
+			}
+		}
+	}
+}
+
+/**
+ * Block styles
+ */
+
+// Main content width
+.wp-block {
+	max-width: ms(18);
+}
+
+.wp-block[data-align='wide'] {
+	max-width: ms(19);
+}
+
+.wp-block[data-align='full'] {
+	max-width: none;
+}
+
+// Tables
+.wp-block-table {
+	&__cell-content {
+		padding: 0;
+	}
+}
+
+// Latest posts, categories, archives
+ul.wp-block-archives,
+.wp-block-categories ul,
+ul.wp-block-latest-posts {
+	padding-left: 0;
+	padding-right: 0;
+	margin-left: 0;
+	margin-right: 0;
+	list-style: none;
 }

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -27,6 +27,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 			add_action( 'widgets_init', array( $this, 'widgets_init' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'scripts' ), 10 );
 			add_action( 'wp_enqueue_scripts', array( $this, 'child_scripts' ), 30 ); // After WooCommerce.
+			add_action( 'enqueue_block_editor_assets', array( $this, 'block_editor_assets' ) );
 			add_filter( 'body_class', array( $this, 'body_classes' ) );
 			add_filter( 'wp_page_menu_args', array( $this, 'page_menu_args' ) );
 			add_filter( 'navigation_markup_template', array( $this, 'navigation_markup_template' ) );
@@ -181,7 +182,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 			/**
 			 * Enqueue editor styles.
 			 */
-			add_editor_style( 'assets/css/base/gutenberg-editor.css' );
+			add_editor_style( array( 'assets/css/base/gutenberg-editor.css', $this->google_fonts() ) );
 
 			/**
 			 * Add support for responsive embedded content.
@@ -290,20 +291,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 			/**
 			 * Fonts
 			 */
-			$google_fonts = apply_filters(
-				'storefront_google_font_families', array(
-					'source-sans-pro' => 'Source+Sans+Pro:400,300,300italic,400italic,600,700,900',
-				)
-			);
-
-			$query_args = array(
-				'family' => implode( '|', $google_fonts ),
-				'subset' => rawurlencode( 'latin,latin-ext' ),
-			);
-
-			$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );
-
-			wp_enqueue_style( 'storefront-fonts', $fonts_url, array(), null );
+			wp_enqueue_style( 'storefront-fonts', $this->google_fonts(), array(), null );
 
 			/**
 			 * Scripts
@@ -331,6 +319,41 @@ if ( ! class_exists( 'Storefront' ) ) :
 			}
 
 			wp_enqueue_script( 'jquery-pep', get_template_directory_uri() . '/assets/js/vendor/pep.min.js', array(), '0.4.3', true );
+		}
+
+		/**
+		 * Register Google fonts.
+		 *
+		 * @since 2.4.0
+		 * @return string Google fonts URL for the theme.
+		 */
+		public function google_fonts() {
+			$google_fonts = apply_filters(
+				'storefront_google_font_families', array(
+					'source-sans-pro' => 'Source+Sans+Pro:400,300,300italic,400italic,600,700,900',
+				)
+			);
+
+			$query_args = array(
+				'family' => implode( '|', $google_fonts ),
+				'subset' => rawurlencode( 'latin,latin-ext' ),
+			);
+
+			$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );
+
+			return $fonts_url;
+		}
+
+		/**
+		 * Enqueue supplemental block editor styles.
+		 *
+		 * @since 2.4.0
+		 */
+		public function block_editor_assets() {
+			global $storefront_version;
+
+			wp_enqueue_style( 'storefront-editor-block-styles', get_theme_file_uri( '/assets/css/base/gutenberg-blocks.css' ), false, $storefront_version, 'all' );
+			wp_style_add_data( 'storefront-editor-block-styles', 'rtl', 'replace' );
 		}
 
 		/**

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -897,6 +897,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 		/**
 		 * Enqueue dynamic colors to use editor blocks.
+		 *
+		 * @since 2.4.0
 		 */
 		public static function block_editor_customizer_css() {
 			global $storefront_version;

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -28,6 +28,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			add_action( 'wp_enqueue_scripts', array( $this, 'add_customizer_css' ), 130 );
 			add_action( 'customize_controls_print_styles', array( $this, 'customizer_custom_control_css' ) );
 			add_action( 'customize_register', array( $this, 'edit_default_customizer_settings' ), 99 );
+			add_action( 'enqueue_block_editor_assets', array( $this, 'block_editor_customizer_css' ) );
 			add_action( 'init', array( $this, 'default_theme_mod_values' ), 10 );
 		}
 
@@ -892,6 +893,63 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			';
 
 			return apply_filters( 'storefront_gutenberg_customizer_css', $styles );
+		}
+
+		/**
+		 * Enqueue dynamic colors to use editor blocks.
+		 */
+		public static function block_editor_customizer_css() {
+			global $storefront_version;
+
+			$storefront_theme_mods = $this->get_storefront_theme_mods();
+			$brighten_factor       = apply_filters( 'storefront_brighten_factor', 25 );
+			$darken_factor         = apply_filters( 'storefront_darken_factor', -25 );
+
+			$styles = '
+			.editor-styles-wrapper table th {
+				background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -7 ) . ';
+			}
+
+			.editor-styles-wrapper table tbody td {
+				background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -2 ) . ';
+			}
+
+			.editor-styles-wrapper table tbody tr:nth-child(2n) td,
+			.editor-styles-wrapper fieldset,
+			.editor-styles-wrapper fieldset legend {
+				background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -4 ) . ';
+			}
+
+			.editor-styles-wrapper h1,
+			.editor-styles-wrapper h2,
+			.editor-styles-wrapper h3,
+			.editor-styles-wrapper h4,
+			.editor-styles-wrapper h5,
+			.editor-styles-wrapper h6 {
+				color: ' . $storefront_theme_mods['heading_color'] . ';
+			}
+
+			.editor-styles-wrapper .editor-block-list__block {
+				color: ' . $storefront_theme_mods['text_color'] . ';
+			}
+
+			.editor-styles-wrapper a,
+			.wp-block-freeform.block-library-rich-text__tinymce a {
+				color: ' . $storefront_theme_mods['accent_color'] . ';
+			}
+
+			.editor-styles-wrapper a:focus,
+			.wp-block-freeform.block-library-rich-text__tinymce a:focus {
+				outline-color: ' . $storefront_theme_mods['accent_color'] . ';
+			}
+
+			body.post-type-post .editor-post-title__block::after {
+				content: "";
+			}';
+
+			$styles .= $this->gutenberg_get_css();
+
+			wp_add_inline_style( 'storefront-editor-block-styles', apply_filters( 'storefront_gutenberg_block_editor_customizer_css', $styles ) );
 		}
 
 		/**


### PR DESCRIPTION
This PR adds support for editor styles in the new editor. The output in the frontend should match almost 100% (minus the odd padding here and there) to what you see in the editor. This includes colors, typography (Google Fonts), general styling, and dynamic colors set in the Customizer.

Here's an example of a frontend vs backend:

**Frontend**

<img width="1097" alt="screenshot 2018-12-05 at 15 36 49" src="https://user-images.githubusercontent.com/1177726/49524426-a36d3100-f8a3-11e8-91cd-60bc2918d973.png">

**Backend**

<img width="1745" alt="screenshot 2018-12-05 at 15 36 38" src="https://user-images.githubusercontent.com/1177726/49524441-a9fba880-f8a3-11e8-94f7-d9b3d26db015.png">

Closes #653.