### PR TITLE
Method incorrectly defined as static

### DIFF
--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -900,9 +900,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 		 *
 		 * @since 2.4.0
 		 */
-		public static function block_editor_customizer_css() {
-			global $storefront_version;
-
+		public function block_editor_customizer_css() {
 			$storefront_theme_mods = $this->get_storefront_theme_mods();
 			$brighten_factor       = apply_filters( 'storefront_brighten_factor', 25 );
 			$darken_factor         = apply_filters( 'storefront_darken_factor', -25 );


### PR DESCRIPTION
The `block_editor_customizer_css()` method is currently incorrectly defined as `static`. This is causing fatal errors in some hosting platforms such as WPEngine.

Since there's no need for this method to be defined as `static`, this PR removes the keyword.

It also needs `global $storefront_version` which is not being used anywhere on the method.

Closes #1011.