### PR TITLE
Add missing WC functions file include

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -42,6 +42,7 @@ if ( storefront_is_woocommerce_activated() ) {
 
 	require 'inc/woocommerce/storefront-woocommerce-template-hooks.php';
 	require 'inc/woocommerce/storefront-woocommerce-template-functions.php';
+	require 'inc/woocommerce/storefront-woocommerce-functions.php';
 }
 
 if ( is_admin() ) {

--- a/inc/jetpack/class-storefront-jetpack.php
+++ b/inc/jetpack/class-storefront-jetpack.php
@@ -61,21 +61,21 @@ if ( ! class_exists( 'Storefront_Jetpack' ) ) :
 		public function jetpack_infinite_scroll_loop() {
 			do_action( 'storefront_jetpack_infinite_scroll_before' );
 
-			if ( storefront_is_product_archive() ) {
+			if ( function_exists( 'storefront_is_product_archive' ) && storefront_is_product_archive() ) {
 				do_action( 'storefront_jetpack_product_infinite_scroll_before' );
 				woocommerce_product_loop_start();
 			}
 
 			while ( have_posts() ) :
 				the_post();
-				if ( storefront_is_product_archive() ) {
+				if ( function_exists( 'storefront_is_product_archive' ) && storefront_is_product_archive() ) {
 					wc_get_template_part( 'content', 'product' );
 				} else {
 					get_template_part( 'content', get_post_format() );
 				}
 			endwhile; // end of the loop.
 
-			if ( storefront_is_product_archive() ) {
+			if ( function_exists( 'storefront_is_product_archive' ) && storefront_is_product_archive() ) {
 				woocommerce_product_loop_end();
 				do_action( 'storefront_jetpack_product_infinite_scroll_after' );
 			}

--- a/inc/woocommerce/storefront-woocommerce-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-functions.php
@@ -11,12 +11,8 @@
  * @return boolean
  */
 function storefront_is_product_archive() {
-	if ( storefront_is_woocommerce_activated() ) {
-		if ( is_shop() || is_product_taxonomy() || is_product_category() || is_product_tag() ) {
-			return true;
-		} else {
-			return false;
-		}
+	if ( is_shop() || is_product_taxonomy() || is_product_category() || is_product_tag() ) {
+		return true;
 	} else {
 		return false;
 	}


### PR DESCRIPTION
In Storefront 2.4 we reorganized the file structure for the theme and ended up forgetting to include one of the files - `storefront-woocommerce-functions.php`

This file contains the `storefront_is_product_archive()` function that is used in our Jetpack Infinite Scroll integration. Without this file, users using this option will get a fatal error when trying to dynamically load new products.

I've also refactored the code a little bit:

* Removed the now unnecessary `storefront_is_woocommerce_activated()` check since this file will only load when WooCommerce is active.
* In the Jetpack integration file, check if the `storefront_is_product_archive()` function exists.

To test:

* Install Jetpack. I recommend using debug mode so that you don't have to deal with authentication with WP.com and that's not required for this particular issue: https://jetpack.com/support/development-mode/
* Go to Jetpack settings and enabled "Infinite Scroll":
* You should now see a "More products" button instead of regular pagination in the Shop page.
* Clicking that button should reveal more products. You might need to update the number of products per page in the Customizer if you don't have a lot of products in your test install.

Jetpack options:


<img width="759" alt="screenshot 2018-12-10 at 12 20 09" src="https://user-images.githubusercontent.com/1177726/49732274-fbc27b00-fc75-11e8-92b9-78b8600d7469.png">

Shop page:

<img width="350" alt="screenshot 2018-12-10 at 12 22 18" src="https://user-images.githubusercontent.com/1177726/49732369-54921380-fc76-11e8-9868-a11562eba81d.png">



Closes #1016.