### PR TITLE
Update Grunt copy task file excludes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -319,7 +319,10 @@ module.exports = function( grunt ) {
 					'!Gruntfile.js',
 					'!package.json',
 					'!package-lock.json',
+					'!composer.lock',
+					'!phpcs.xml',
 					'!node_modules/**',
+					'!vendor/**',
 					'!.DS_Store',
 					'!npm-debug.log',
 					'!composer.json',
@@ -485,6 +488,7 @@ module.exports = function( grunt ) {
 	]);
 
 	grunt.registerTask( 'deploy', [
+		'dev',
 		'copy',
 		'compress'
 	]);


### PR DESCRIPTION
Add `composer.lock`, `phpcs.xml`, and the `vendor` folder to the list of excludes in the Copy task.

Also adds `dev` to the deploy `task` to ensure everything is built and up to date when generating a new build.