### PR TITLE
Update order of sass imports in Gutenberg Sass files

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -1,14 +1,19 @@
+// Bourbon
+// See: https://www.bourbon.io/docs/latest/
 @import 'bourbon';
 
 // Susy
-// Susy grid system. See: http://susydocs.oddbird.net/en/latest/
-@import '../../../node_modules/susy/sass/susy';
+// Susy grid system. See: http://oddbird.net/susy/docs/
+@import 'node_modules/susy/sass/susy';
+
+// Vendors
+// External libraries and frameworks.
+@import '../sass/vendors/modular-scale';
 
 // Utilities
 // Sass tools and helpers used across the project.
 @import '../sass/utils/variables';
 @import '../sass/utils/mixins';
-@import '../sass/vendors/modular-scale';
 
 /**
  * Front-end only styles

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -1,14 +1,19 @@
+// Bourbon
+// See: https://www.bourbon.io/docs/latest/
 @import 'bourbon';
 
 // Susy
-// Susy grid system. See: http://susydocs.oddbird.net/en/latest/
-@import '../../../node_modules/susy/sass/susy';
+// Susy grid system. See: http://oddbird.net/susy/docs/
+@import 'node_modules/susy/sass/susy';
+
+// Vendors
+// External libraries and frameworks.
+@import '../sass/vendors/modular-scale';
 
 // Utilities
 // Sass tools and helpers used across the project.
 @import '../sass/utils/variables';
 @import '../sass/utils/mixins';
-@import '../sass/vendors/modular-scale';
 
 /**
  * Base styles
@@ -308,7 +313,7 @@ table {
 
 // Main content width
 .wp-block {
-	max-width: ms(18);
+	max-width: $container-width;
 }
 
 .wp-block[data-align='wide'] {


### PR DESCRIPTION
Updates the order of the Sass imports. Without this PR Sass files are not compiled correctly and some of the variables do not translate into values.

For example, in `gutenberg-blocks.css`

`@media (min-width: 66.4989378333em)`

and not

`@media (min-width: ms(18)) {`

This isn't a problem in the current live version of the theme in WordPress.org since I spotted the issue before deploying it.