### PR TITLE
Clear floats on alignwide and alignfull blocks

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -29,6 +29,7 @@
 				max-width: 1000%;
 				padding-left: ms(2);
 				padding-right: ms(2);
+				clear: both;
 			}
 
 			.alignfull {


### PR DESCRIPTION
This clears floats on wide/full blocks. This is necessary for when there's a block with another one floated to the left/right such a paragraph + image.

Before:

<img width="1519" alt="screenshot 2018-12-12 at 23 26 46" src="https://user-images.githubusercontent.com/1177726/49905430-8f0dd300-fe65-11e8-8e6a-0534325239ca.png">

After:

<img width="1120" alt="screenshot 2018-12-12 at 23 27 31" src="https://user-images.githubusercontent.com/1177726/49905434-9208c380-fe65-11e8-84d7-0e6b5767e062.png">