### PR TITLE
Check if object is in the expected format and has right properties

### DIFF
--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -402,6 +402,13 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 		public function get_woocommerce_extension_css() {
 			global $storefront;
 
+			if ( ! is_object( $storefront ) ||
+				 ! property_exists( $storefront, 'customizer' ) ||
+				 ! is_a( $storefront->customizer, 'Storefront_Customizer' ) ||
+				 ! method_exists( $storefront->customizer, 'get_storefront_theme_mods' ) ) {
+				return apply_filters( 'storefront_customizer_woocommerce_extension_css', '' );
+			}
+
 			$storefront_theme_mods = $storefront->customizer->get_storefront_theme_mods();
 
 			$woocommerce_extension_style = '';


### PR DESCRIPTION
Since `$storefront` is a global variable, there have been instances where users have replaced or removed some of the methods assigned to this variable (see `functions.php` for the assignments).

This PR adds a series of conditional statements to try to mitigate this case where a class may not longer be being loaded.