### PR TITLE
Refactor posted on sprintf

### DIFF
--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -434,12 +434,13 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 			esc_html( get_the_modified_date() )
 		);
 
-		$posted_on = sprintf( '<span class="posted-on">%1$s <a href="%2$s" rel="bookmark">%3$s</a></span>',
+		$output_time_string = sprintf( '<a href="%1$s" rel="bookmark">%2$s</a>', esc_url( get_permalink() ), $time_string );
+
+		$posted_on = '
+			<span class="posted-on">' .
 			/* translators: %s: post date */
-			_x( 'Posted on', 'post date', 'storefront' ),
-			esc_url( get_permalink() ),
-			$time_string
-		);
+			sprintf( __( 'Posted on %s', 'storefront' ), $output_time_string ) .
+			'</span>';
 
 		// Author.
 		$author = sprintf(

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -434,10 +434,11 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 			esc_html( get_the_modified_date() )
 		);
 
-		$posted_on = sprintf(
-			'<span class="posted-on">%s <a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a></span>',
+		$posted_on = sprintf( '<span class="posted-on">%1$s <a href="%2$s" rel="bookmark">%3$s</a></span>',
 			/* translators: %s: post date */
-			_x( 'Posted on', 'post date', 'storefront' )
+			_x( 'Posted on', 'post date', 'storefront' ),
+			esc_url( get_permalink() ),
+			$time_string
 		);
 
 		// Author.


### PR DESCRIPTION
Refactor posted meta `sprintf` output and separate the different elements for a better readability.

The output should stay the same in posts:

<img width="820" alt="screenshot 2018-12-20 at 16 37 51" src="https://user-images.githubusercontent.com/1177726/50297835-9fc9d480-0475-11e9-9767-778995f822fe.png">
