### PR TITLE
Revert filter name: storefront_customizer_woocommerce_css

### DIFF
--- a/inc/woocommerce/class-storefront-woocommerce-customizer.php
+++ b/inc/woocommerce/class-storefront-woocommerce-customizer.php
@@ -304,7 +304,7 @@ if ( ! class_exists( 'Storefront_WooCommerce_Customizer' ) ) :
 				}';
 			}
 
-			return apply_filters( 'storefront_woocommerce_customizer_css', $styles );
+			return apply_filters( 'storefront_customizer_woocommerce_css', $styles );
 		}
 
 		/**


### PR DESCRIPTION
In 2.4 we moved all WooCommerce related code to separate files. In the process we incorrectly changed the name of CSS filter from `storefront_customizer_woocommerce_css` to `storefront_woocommerce_customizer_css`.

This PR reverts this change. 

Closes #1030.