### PR TITLE
Update post taxonomy design to match design from Products

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -768,6 +768,8 @@ table {
 
 	.entry-taxonomy {
 		margin: ms(2) 0 0;
+		padding-top: 1em;
+		border-top: 1px solid rgba( 0, 0, 0, 0.05 );
 	}
 
 	&.type-page {
@@ -775,6 +777,17 @@ table {
 			border-bottom: 0;
 			margin-bottom: 0;
 		}
+	}
+}
+
+.cat-links,
+.tags-links {
+	font-size: 0.875em;
+
+	a {
+		color: #727272;
+		font-weight: 600;
+		text-decoration: underline;
 	}
 }
 
@@ -792,16 +805,6 @@ table {
 .page-links {
 	clear: both;
 	margin: 0 0 ms(1);
-}
-
-.cat-links,
-.tags-links {
-	display: block;
-	margin-bottom: ms(1);
-
-	&:last-child {
-		margin-bottom: 0;
-	}
 }
 
 /**

--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -31,24 +31,6 @@
 	}
 }
 
-.entry-taxonomy {
-	.cat-links {
-		&::before {
-			@include sf-fa-icon;
-			content: fa-content( $fa-var-folder );
-			margin-right: ms(-3);
-		}
-	}
-
-	.tags-links {
-		&::before {
-			@include sf-fa-icon;
-			content: fa-content( $fa-var-tag );
-			margin-right: ms(-3);
-		}
-	}
-}
-
 #comments {
 	.commentlist {
 		.bypostauthor {

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -497,17 +497,15 @@ if ( ! function_exists( 'storefront_post_taxonomy' ) ) {
 		<aside class="entry-taxonomy">
 			<?php if ( $categories_list ) : ?>
 			<div class="cat-links">
-				<span class="screen-reader-text"><?php echo esc_attr( __( 'Posted in', 'storefront' ) ); ?></span>
-				<?php echo wp_kses_post( $categories_list ); ?>
+				<?php echo esc_html( _n( 'Category:', 'Categories:', count( get_the_category() ), 'storefront' ) ); ?> <?php echo wp_kses_post( $categories_list ); ?>
 			</div>
-			<?php endif; // End if categories. ?>
+			<?php endif; ?>
 
 			<?php if ( $tags_list ) : ?>
 			<div class="tags-links">
-				<span class="screen-reader-text"><?php echo esc_attr( __( 'Tagged', 'storefront' ) ); ?></span>
-				<?php echo wp_kses_post( $tags_list ); ?>
+				<?php echo esc_html( _n( 'Tag:', 'Tags:', count( get_the_tags() ), 'storefront' ) ); ?> <?php echo wp_kses_post( $tags_list ); ?>
 			</div>
-			<?php endif; // End if $tags_list. ?>
+			<?php endif; ?>
 		</aside>
 
 		<?php


### PR DESCRIPTION
Updates the post taxonomy design to be more inline with the similar design present on Product pages. Since the design on Product pages has been there for a very long time, I think it makes sense for both to be the same.

As a reminder, the icons you see in the screenshots below were introduced in 2.4.

Before:

<img width="203" alt="screenshot 2019-01-07 at 16 27 57" src="https://user-images.githubusercontent.com/1177726/50779830-447f4b00-1299-11e9-97b4-c2631e1b33a8.png">

After:

<img width="818" alt="screenshot 2019-01-07 at 16 27 32" src="https://user-images.githubusercontent.com/1177726/50779841-4a752c00-1299-11e9-9260-f9a609a80003.png">