### PR TITLE
Improvements to Product Pagination

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -40,6 +40,8 @@ if ( storefront_is_woocommerce_activated() ) {
 	$storefront->woocommerce            = require 'inc/woocommerce/class-storefront-woocommerce.php';
 	$storefront->woocommerce_customizer = require 'inc/woocommerce/class-storefront-woocommerce-customizer.php';
 
+	require 'inc/woocommerce/class-storefront-woocommerce-adjacent-products.php';
+
 	require 'inc/woocommerce/storefront-woocommerce-template-hooks.php';
 	require 'inc/woocommerce/storefront-woocommerce-template-functions.php';
 	require 'inc/woocommerce/storefront-woocommerce-functions.php';

--- a/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
+++ b/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Storefront WooCommerce Adjacent Products Class
+ *
+ * @package  storefront
+ * @since    2.4.3
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
+
+	/**
+	 * The Storefront WooCommerce Adjacent Products Class
+	 */
+	class Storefront_WooCommerce_Adjacent_Products {
+
+		/**
+		 * The current product ID.
+		 *
+		 * @var int|null
+		 */
+		private $current_product = null;
+
+		/**
+		 * Whether post should be in a same taxonomy term.
+		 *
+		 * @var bool
+		 */
+		private $in_same_term = false;
+
+		/**
+		 * List of excluded term IDs.
+		 *
+		 * @var string
+		 */
+		private $excluded_terms = '';
+
+		/**
+		 * Taxonomy slug.
+		 *
+		 * @var string
+		 */
+		private $taxonomy = 'product_cat';
+
+		/**
+		 * Whether to retrieve previous product.
+		 *
+		 * @var bool
+		 */
+		private $previous = false;
+
+		/**
+		 * Constructor.
+		 *
+		 * @since 2.4.3
+		 *
+		 * @param bool         $in_same_term   Optional. Whether post should be in a same taxonomy term. Default false.
+		 * @param array|string $excluded_terms Optional. Comma-separated list of excluded term IDs. Default empty.
+		 * @param string       $taxonomy       Optional. Taxonomy, if $in_same_term is true. Default 'product_cat'.
+		 * @param bool         $previous       Optional. Whether to retrieve previous product. Default false.
+		 */
+		public function __construct( $in_same_term = false, $excluded_terms = '', $taxonomy = 'product_cat', $previous = false ) {
+			$this->in_same_term   = $in_same_term;
+			$this->excluded_terms = $excluded_terms;
+			$this->taxonomy       = $taxonomy;
+			$this->previous       = $previous;
+		}
+
+		/**
+		 * Get adjacent product or circle back to the first/last valid product.
+		 *
+		 * @since 2.4.3
+		 *
+		 * @return WC_Product|false Product object if successful. False if no valid product is found.
+		 */
+		public function get_product() {
+			global $post;
+
+			$product = false;
+
+			$this->current_product = $post->ID;
+
+			// Try to get a valid product via `get_adjacent_post()`.
+			while ( $adjacent = $this->get_adjacent() ) {
+				$product = wc_get_product( $adjacent->ID );
+
+				if ( $product && $product->is_visible() ) {
+					break;
+				}
+
+				$product               = false;
+				$this->current_product = $adjacent->ID;
+			}
+
+			if ( $product ) {
+				return $product;
+			}
+
+			// No valid product found; Query WC for first/last product.
+			$product = $this->query_wc();
+
+			if ( $product ) {
+				return $product;
+			}
+
+			return false;
+		}
+
+		/**
+		 * Get adjacent post.
+		 *
+		 * @since 2.4.3
+		 *
+		 * @return WP_POST|false Post object if successful. False if no valid post is found.
+		 */
+		private function get_adjacent() {
+			global $post;
+
+			$direction = $this->previous ? 'previous' : 'next';
+
+			add_filter( 'get_' . $direction . '_post_where', array( $this, 'filter_post_where' ) );
+
+			$adjacent = get_adjacent_post( $this->in_same_term, $this->excluded_terms, $this->previous, $this->taxonomy );
+
+			remove_filter( 'get_' . $direction . '_post_where', array( $this, 'filter_post_where' ) );
+
+			return $adjacent;
+		}
+
+		/**
+		 * Filters the WHERE clause in the SQL for an adjacent post query, replacing the
+		 * date with date of the next post to consider.
+		 *
+		 * @since 2.4.3
+		 *
+		 * @param string $where The `WHERE` clause in the SQL.
+		 * @return WP_POST|false Post object if successful. False if no valid post is found.
+		 */
+		public function filter_post_where( $where ) {
+			global $post;
+
+			$new = get_post( $this->current_product );
+
+			$where = str_replace( $post->post_date, $new->post_date, $where );
+
+			return $where;
+		}
+
+		/**
+		 * Query WooCommerce for either the first or last products.
+		 *
+		 * @since 2.4.3
+		 *
+		 * @return WC_Product|false Post object if successful. False if no valid post is found.
+		 */
+		private function query_wc() {
+			global $post;
+
+			$args = array(
+				'limit'      => 2,
+				'visibility' => 'catalog',
+				'exclude'    => array( $post->ID ),
+				'orderby'    => 'date',
+			);
+
+			if ( ! $this->previous ) {
+				$args['order'] = 'ASC';
+			}
+
+			if ( $this->in_same_term ) {
+				$terms = get_the_terms( $post->ID, $this->taxonomy );
+
+				if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+					$args['category'] = wp_list_pluck( $terms, 'slug' );
+				}
+			}
+
+			$products = wc_get_products( apply_filters( 'storefront_woocommerce_adjacent_query_args', $args ) );
+
+			// At least 2 results are required, otherwise previous/next will be the same.
+			if ( ! empty( $products ) && count( $products ) >= 2 ) {
+				return $products[0];
+			}
+
+			return false;
+		}
+	}
+
+endif;

--- a/inc/woocommerce/storefront-woocommerce-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-functions.php
@@ -17,3 +17,33 @@ function storefront_is_product_archive() {
 		return false;
 	}
 }
+
+/**
+ * Retrieves the previous product.
+ *
+ * @since 2.4.3
+ *
+ * @param bool         $in_same_term   Optional. Whether post should be in a same taxonomy term. Default false.
+ * @param array|string $excluded_terms Optional. Comma-separated list of excluded term IDs. Default empty.
+ * @param string       $taxonomy       Optional. Taxonomy, if $in_same_term is true. Default 'product_cat'.
+ * @return WC_Product|false Product object if successful. False if no valid product is found.
+ */
+function storefront_get_previous_product( $in_same_term = false, $excluded_terms = '', $taxonomy = 'product_cat' ) {
+	$product = new Storefront_WooCommerce_Adjacent_Products( $in_same_term, $excluded_terms, $taxonomy, true );
+	return $product->get_product();
+}
+
+/**
+ * Retrieves the next product.
+ *
+ * @since 2.4.3
+ *
+ * @param bool         $in_same_term   Optional. Whether post should be in a same taxonomy term. Default false.
+ * @param array|string $excluded_terms Optional. Comma-separated list of excluded term IDs. Default empty.
+ * @param string       $taxonomy       Optional. Taxonomy, if $in_same_term is true. Default 'product_cat'.
+ * @return WC_Product|false Product object if successful. False if no valid product is found.
+ */
+function storefront_get_next_product( $in_same_term = false, $excluded_terms = '', $taxonomy = 'product_cat' ) {
+	$product = new Storefront_WooCommerce_Adjacent_Products( $in_same_term, $excluded_terms, $taxonomy );
+	return $product->get_product();
+}

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -709,34 +709,31 @@ if ( ! function_exists( 'storefront_single_product_pagination' ) ) {
 		}
 
 		// Show only products in the same category?
-		$in_same_term   = apply_filters( 'storefront_single_product_pagination_same_category', false );
+		$in_same_term   = apply_filters( 'storefront_single_product_pagination_same_category', true );
 		$excluded_terms = apply_filters( 'storefront_single_product_pagination_excluded_terms', '' );
 		$taxonomy       = apply_filters( 'storefront_single_product_pagination_taxonomy', 'product_cat' );
 
-		// Get previous and next products.
-		$previous_product = get_previous_post( $in_same_term, $excluded_terms, $taxonomy );
-		$next_product     = get_next_post( $in_same_term, $excluded_terms, $taxonomy );
+		$previous_product = storefront_get_previous_product( $in_same_term, $excluded_terms, $taxonomy );
+		$next_product     = storefront_get_next_product( $in_same_term, $excluded_terms, $taxonomy );
 
 		if ( ! $previous_product && ! $next_product ) {
 			return;
 		}
 
-		if ( $previous_product ) {
-			$previous_product = wc_get_product( $previous_product->ID );
-		}
-
-		if ( $next_product ) {
-			$next_product = wc_get_product( $next_product->ID );
-		}
-
 		?>
 		<nav class="storefront-product-pagination" aria-label="<?php esc_attr_e( 'More products', 'storefront' ); ?>">
-			<?php if ( $previous_product && $previous_product->is_visible() ) : ?>
-				<?php previous_post_link( '%link', wp_kses_post( $previous_product->get_image() ) . '<span class="storefront-product-pagination__title">%title</span>', $in_same_term, $excluded_terms, $taxonomy ); ?>
+			<?php if ( $previous_product ) : ?>
+				<a href="<?php echo esc_url( $previous_product->get_permalink() ); ?>" rel="prev">
+					<?php echo wp_kses_post( $previous_product->get_image() ); ?>
+					<span class="storefront-product-pagination__title"><?php echo wp_kses_post( $previous_product->get_name() ); ?></span>
+				</a>
 			<?php endif; ?>
 
-			<?php if ( $next_product && $next_product->is_visible() ) : ?>
-				<?php next_post_link( '%link', wp_kses_post( $next_product->get_image() ) . '<span class="storefront-product-pagination__title">%title</span>', $in_same_term, $excluded_terms, $taxonomy ); ?>
+			<?php if ( $next_product ) : ?>
+				<a href="<?php echo esc_url( $next_product->get_permalink() ); ?>" rel="next">
+					<?php echo wp_kses_post( $next_product->get_image() ); ?>
+					<span class="storefront-product-pagination__title"><?php echo wp_kses_post( $next_product->get_name() ); ?></span>
+				</a>
 			<?php endif; ?>
 		</nav><!-- .storefront-product-pagination -->
 		<?php


### PR DESCRIPTION
Ever since we incorporated Product Pagination into Storefront, there have been a few complains about the way it works:

* Invisible products break pagination
* It doesn't circle back to the begging

We have been relying on the `get_adjacent_post()` function, but its functionality is quite limited. Although it provides a good number of filters, it depends on the current global `$post` so modifications have to be very tactical.

This PR introduces a new class that addresses the complains listed above. It uses `get_adjacent_post()` where possible and a regular WC query to get the first/last item.

First we try to get a valid product via `get_adjacent_post()` adding a filter so each iteration of the loop uses the date of the next product to test. The results of this function are cached by default.

If no product is found, it we might have reached the "end". So we use `wc_get_products()` to get the first product (or the other way around).

**How to test:**

1. Add a few products to the same category. Make sure a couple items are set to hidden in the visibility options.
2. Go to one of the Product pages and you should see the [previous / next links](https://cldup.com/htYPyPdomk.png) in the edges of the screen.
3. Invisible products should not appear in the pagination.
4. It should continuously display previous / next products. When it reaches the end of the list of products, it should circle back and display the first/last product.

Related issues: #961, #922.