### PR TITLE
Remove extra space from entry date link

### DIFF
--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -423,7 +423,7 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 
 		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time> <time class="updated" datetime="%3$s">%4$s</time>';
+			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
 		}
 
 		$time_string = sprintf(


### PR DESCRIPTION
Notice the extra space on the post date link, between the date and "by admin".

Before:

<img width="359" alt="screenshot 2019-01-25 at 19 02 12" src="https://user-images.githubusercontent.com/1177726/51766947-d4175d00-20d3-11e9-8993-6aa4fe27eb06.png">

After:

<img width="357" alt="screenshot 2019-01-25 at 19 02 40" src="https://user-images.githubusercontent.com/1177726/51766951-d679b700-20d3-11e9-8c7e-cfb7dbde0b34.png">