### PR TITLE
Add hooks to post title and move post meta to new hook

### DIFF
--- a/content-single.php
+++ b/content-single.php
@@ -16,7 +16,6 @@
 	 * Functions hooked into storefront_single_post add_action
 	 *
 	 * @hooked storefront_post_header          - 10
-	 * @hooked storefront_post_meta            - 20
 	 * @hooked storefront_post_content         - 30
 	 */
 	do_action( 'storefront_single_post' );

--- a/content.php
+++ b/content.php
@@ -14,7 +14,6 @@
 	 * Functions hooked in to storefront_loop_post action.
 	 *
 	 * @hooked storefront_post_header          - 10
-	 * @hooked storefront_post_meta            - 20
 	 * @hooked storefront_post_content         - 30
 	 */
 	do_action( 'storefront_loop_post' );

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -356,16 +356,21 @@ if ( ! function_exists( 'storefront_post_header' ) ) {
 		?>
 		<header class="entry-header">
 		<?php
+
+		/**
+		 * Functions hooked in to storefront_post_header_before action.
+		 *
+		 * @hooked storefront_post_meta - 10
+		 */
+		do_action( 'storefront_post_header_before' );
+
 		if ( is_single() ) {
-			storefront_post_meta();
 			the_title( '<h1 class="entry-title">', '</h1>' );
 		} else {
-			if ( 'post' === get_post_type() ) {
-				storefront_post_meta();
-			}
-
 			the_title( sprintf( '<h2 class="alpha entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
 		}
+
+		do_action( 'storefront_post_header_after' );
 		?>
 		</header><!-- .entry-header -->
 		<?php
@@ -419,6 +424,10 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 	 * @since 1.0.0
 	 */
 	function storefront_post_meta() {
+		if ( 'post' !== get_post_type() ) {
+			return;
+		}
+
 		// Posted on.
 		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 

--- a/inc/storefront-template-hooks.php
+++ b/inc/storefront-template-hooks.php
@@ -67,6 +67,7 @@ add_action( 'storefront_single_post', 'storefront_post_content', 30 );
 add_action( 'storefront_single_post_bottom', 'storefront_post_taxonomy', 5 );
 add_action( 'storefront_single_post_bottom', 'storefront_post_nav', 10 );
 add_action( 'storefront_single_post_bottom', 'storefront_display_comments', 20 );
+add_action( 'storefront_post_header_before', 'storefront_post_meta', 10 );
 add_action( 'storefront_post_content_before', 'storefront_post_thumbnail', 10 );
 
 /**


### PR DESCRIPTION
In certain situations you might want to move the post meta from one hook to another. So this PR removes the direct call to `storefront_post_meta()` and then add it back via the `storefront_post_header_before` hook.

Two new hooks introduced:

* `storefront_post_header_before `
* `storefront_post_header_after`