### PR TITLE
Remove padding and transition styles from post navigation

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -1296,33 +1296,18 @@ button.menu-toggle {
 	.nav-next {
 		a {
 			display: inline-block;
-			transition: all, ease, 0.3s;
-			padding: ms(-2) 1em;
-			border-radius: 3px;
 		}
 	}
 
 	.nav-previous {
 		float: left;
 		width: 50%;
-
-		a {
-			&:hover {
-				transform: translate(-1em);
-			}
-		}
 	}
 
 	.nav-next {
 		float: right;
 		text-align: right;
 		width: 50%;
-
-		a {
-			&:hover {
-				transform: translate(1em);
-			}
-		}
 	}
 
 }


### PR DESCRIPTION
Removes padding and hover transition from the post navigation so it sits flush at the edge of the main content area.

To test, visit a regular post and look for the post navigation links at the end of the post.

Before:

<img width="806" alt="screenshot 2019-01-25 at 19 12 40" src="https://user-images.githubusercontent.com/1177726/51767456-5fddb900-20d5-11e9-8929-f605194f2f5e.png">

After:

<img width="822" alt="screenshot 2019-01-25 at 19 13 39" src="https://user-images.githubusercontent.com/1177726/51767460-62401300-20d5-11e9-9698-05464864a5ef.png">