### PR TITLE
Add styling for product columns on the header widget area

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -2033,7 +2033,8 @@ dl.variation {
 	.page-template-template-fullwidth-php,
 	.page-template-template-homepage-php,
 	.storefront-full-width-content {
-		.site-main {
+		.site-main,
+		.header-widget-region {
 			ul.products {
 				&.columns-1 {
 					li.product {


### PR DESCRIPTION
Right now styling for `ul.products` is limited to the main content. The "Below Header" widget area is a full width region, so it makes sense for styling to be supported there as well. This way, product shortcodes can be used there.

To test, add a text widget to the "Bellow Header" with `[products]` in the content.

Before:

<img width="1076" alt="screenshot 2019-02-25 at 17 02 50" src="https://user-images.githubusercontent.com/1177726/53354673-348dfa00-391f-11e9-9044-a18f720eaf4d.png">

After:

<img width="1089" alt="screenshot 2019-02-25 at 17 02 07" src="https://user-images.githubusercontent.com/1177726/53354684-3f488f00-391f-11e9-9063-41fab5b5121d.png">


Closes #1062.