### PR TITLE
Move handheld footer bar JS to separate file

### DIFF
--- a/assets/js/footer.js
+++ b/assets/js/footer.js
@@ -1,0 +1,47 @@
+/**
+ * footer.js
+ *
+ * Adds a class required to reveal the search in the handheld footer bar.
+ * Also hides the handheld footer bar when an input is focused.
+ */
+( function() {
+	// Wait for DOM to be ready.
+	document.addEventListener( 'DOMContentLoaded', function() {
+		if ( 0 === document.getElementsByClassName( 'storefront-handheld-footer-bar' ).length ) {
+			return;
+		}
+
+		// Add class to footer search when clicked.
+		[].forEach.call( document.querySelectorAll( '.storefront-handheld-footer-bar .search > a' ), function( anchor ) {
+			anchor.addEventListener( 'click', function( event ) {
+				anchor.parentElement.classList.toggle( 'active' );
+				event.preventDefault();
+			} );
+		} );
+
+		// Add focus class to body when an input field is focused.
+		// This is used to hide the Handheld Footer Bar when an input is focused.
+		var footer_bar = document.getElementsByClassName( 'storefront-handheld-footer-bar' );
+		var forms      = document.forms;
+		var isFocused  = function( focused ) {
+			return function() {
+				if ( !! focused ) {
+					document.body.classList.add( 'sf-input-focused' );
+				} else {
+					document.body.classList.remove( 'sf-input-focused' );
+				}
+			};
+		};
+
+		if ( footer_bar.length && forms.length ) {
+			for ( var i = 0; i < forms.length; i++ ) {
+				if ( footer_bar[0].contains( forms[ i ] ) ) {
+					continue;
+				}
+
+				forms[ i ].addEventListener( 'focus', isFocused( true ), true );
+				forms[ i ].addEventListener( 'blur', isFocused( false ), true );
+			}
+		}
+	} );
+} )();

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -5,7 +5,6 @@
  *
  * Handles toggling the navigation menu for small screens.
  * Also adds a focus class to parent li's for accessibility.
- * Finally adds a class required to reveal the search in the handheld footer bar.
  */
 ( function() {
 
@@ -83,39 +82,6 @@
 					btn.nextElementSibling.classList.toggle( 'toggled-on' );
 				} );
 			} );
-		}
-
-		// Add class to footer search when clicked.
-		[].forEach.call( document.querySelectorAll( '.storefront-handheld-footer-bar .search > a' ), function( anchor ) {
-			anchor.addEventListener( 'click', function( event ) {
-				anchor.parentElement.classList.toggle( 'active' );
-				event.preventDefault();
-			} );
-		} );
-
-		// Add focus class to body when an input field is focused.
-		// This is used to hide the Handheld Footer Bar when an input is focused.
-		var footer_bar = document.getElementsByClassName( 'storefront-handheld-footer-bar' );
-		var forms      = document.forms;
-		var isFocused  = function( focused ) {
-			return function() {
-				if ( !! focused ) {
-					document.body.classList.add( 'sf-input-focused' );
-				} else {
-					document.body.classList.remove( 'sf-input-focused' );
-				}
-			};
-		};
-
-		if ( footer_bar.length && forms.length ) {
-			for ( var i = 0; i < forms.length; i++ ) {
-				if ( footer_bar[0].contains( forms[ i ] ) ) {
-					continue;
-				}
-
-				forms[ i ].addEventListener( 'focus', isFocused( true ), true );
-				forms[ i ].addEventListener( 'blur', isFocused( false ), true );
-			}
 		}
 
 		// Add focus class to parents of sub-menu anchors.

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -300,6 +300,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 			wp_enqueue_script( 'storefront-navigation', get_template_directory_uri() . '/assets/js/navigation' . $suffix . '.js', array(), $storefront_version, true );
+			wp_enqueue_script( 'storefront-handheld-footer-bar', get_template_directory_uri() . '/assets/js/footer' . $suffix . '.js', array(), $storefront_version, true );
 			wp_enqueue_script( 'storefront-skip-link-focus-fix', get_template_directory_uri() . '/assets/js/skip-link-focus-fix' . $suffix . '.js', array(), '20130115', true );
 
 			if ( has_nav_menu( 'handheld' ) ) {

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -300,7 +300,6 @@ if ( ! class_exists( 'Storefront' ) ) :
 			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 			wp_enqueue_script( 'storefront-navigation', get_template_directory_uri() . '/assets/js/navigation' . $suffix . '.js', array(), $storefront_version, true );
-			wp_enqueue_script( 'storefront-handheld-footer-bar', get_template_directory_uri() . '/assets/js/footer' . $suffix . '.js', array(), $storefront_version, true );
 			wp_enqueue_script( 'storefront-skip-link-focus-fix', get_template_directory_uri() . '/assets/js/skip-link-focus-fix' . $suffix . '.js', array(), '20130115', true );
 
 			if ( has_nav_menu( 'handheld' ) ) {

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -145,6 +145,8 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			wp_register_script( 'storefront-header-cart', get_template_directory_uri() . '/assets/js/woocommerce/header-cart' . $suffix . '.js', array(), $storefront_version, true );
 			wp_enqueue_script( 'storefront-header-cart' );
 
+			wp_enqueue_script( 'storefront-handheld-footer-bar', get_template_directory_uri() . '/assets/js/footer' . $suffix . '.js', array(), $storefront_version, true );
+
 			if ( ! class_exists( 'Storefront_Sticky_Add_to_Cart' ) && is_product() ) {
 				wp_register_script( 'storefront-sticky-add-to-cart', get_template_directory_uri() . '/assets/js/sticky-add-to-cart' . $suffix . '.js', array(), $storefront_version, true );
 			}


### PR DESCRIPTION
This PR moves all the JS related to the Handheld Footer Bar out of `navigation.js`. This makes things a tad bit more modular and also fixes an issue that could happen in situations where the primary navigation is unhooked and not used in the site.

To test, resize the browser to a mobile size, and click the "Search" icon. A search form should appear.

<img width="271" alt="screenshot 2019-02-25 at 23 07 40" src="https://user-images.githubusercontent.com/1177726/53375089-2c02e700-3952-11e9-8b5b-256a4288340e.png">
