### PR TITLE
Minify base css

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -212,6 +212,13 @@ module.exports = function( grunt ) {
 				src: ['*.css'],
 				dest: 'assets/css/woocommerce/',
 				ext: '.css'
+			},
+			base: {
+				expand: true,
+				cwd: 'assets/css/base/',
+				src: ['*.css'],
+				dest: 'assets/css/base/',
+				ext: '.css'
 			}
 		},
 


### PR DESCRIPTION
I'm currently doing some performance optimizations on my shop and noticed the unminified icon-styles.

Is there a specific reason why the CSS in the `base` folder is not minified?