### PR TITLE
Fix handheld navigation accessibility

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -1256,7 +1256,7 @@ button.menu-toggle {
 .main-navigation.toggled {
 	.handheld-navigation,
 	.menu > ul:not( .nav-menu ),
-	ul[aria-expanded=true] {
+	.handheld-navigation > ul.nav-menu {
 		max-height: 9999px;
 	}
 }

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -11,6 +11,7 @@
 	// Wait for DOM to be ready.
 	document.addEventListener( 'DOMContentLoaded', function() {
 		var container = document.getElementById( 'site-navigation' );
+
 		if ( ! container ) {
 			return;
 		}
@@ -21,7 +22,55 @@
 			return;
 		}
 
-		var menu = container.querySelector( 'ul' );
+		// Add dropdown toggle that displays child menu items.
+		var handheld = document.getElementsByClassName( 'handheld-navigation' );
+
+		if ( ! handheld ) {
+			return;
+		}
+
+		[].forEach.call( handheld[0].querySelectorAll( '.menu-item-has-children > a, .page_item_has_children > a' ), function( anchor ) {
+
+			// Add dropdown toggle that displays child menu items
+			var btn = document.createElement( 'button' );
+			btn.setAttribute( 'aria-expanded', 'false' );
+			btn.setAttribute( 'aria-haspopup', 'true' );
+
+			btn.classList.add( 'dropdown-toggle' );
+
+			var btnSpan = document.createElement( 'span' );
+			btnSpan.classList.add( 'screen-reader-text' );
+			btnSpan.appendChild( document.createTextNode( storefrontScreenReaderText.expand ) );
+
+			btn.appendChild( btnSpan );
+
+			anchor.parentNode.insertBefore( btn, anchor.nextSibling );
+
+			// Set the active submenu dropdown toggle button initial state
+			if ( anchor.parentNode.classList.contains( 'current-menu-ancestor' ) ) {
+				btn.setAttribute( 'aria-expanded', 'true' );
+				btn.classList.add( 'toggled-on' );
+				btn.nextElementSibling.classList.add( 'toggled-on' );
+			}
+
+			// Add event listener
+			btn.addEventListener( 'click', function() {
+				btn.classList.toggle( 'toggled-on' );
+
+				// Remove text inside span
+				while ( btnSpan.firstChild ) {
+					btnSpan.removeChild( btnSpan.firstChild );
+				}
+
+				var expanded = btn.classList.contains( 'toggled-on' );
+
+				btn.setAttribute( 'aria-expanded', expanded );
+				btnSpan.appendChild( document.createTextNode( expanded ? storefrontScreenReaderText.collapse : storefrontScreenReaderText.expand ) );
+				btn.nextElementSibling.classList.toggle( 'toggled-on' );
+			} );
+		} );
+
+		var menu = handheld[0].querySelector( 'ul' );
 
 		// Hide menu toggle button if menu is empty and return early.
 		if ( ! menu ) {
@@ -30,59 +79,15 @@
 		}
 
 		button.setAttribute( 'aria-expanded', 'false' );
-		menu.setAttribute( 'aria-expanded', 'false' );
 		menu.classList.add( 'nav-menu' );
+		menu.style.visibility = 'hidden';
 
 		button.addEventListener( 'click', function() {
 			container.classList.toggle( 'toggled' );
 			var expanded = container.classList.contains( 'toggled' ) ? 'true' : 'false';
+			menu.style.visibility = 'true' === expanded ? 'visible' : 'hidden';
 			button.setAttribute( 'aria-expanded', expanded );
-			menu.setAttribute( 'aria-expanded', expanded );
 		} );
-
-		// Add dropdown toggle that displays child menu items.
-		var handheld = document.getElementsByClassName( 'handheld-navigation' );
-
-		if ( handheld.length > 0 ) {
-			[].forEach.call( handheld[0].querySelectorAll( '.menu-item-has-children > a, .page_item_has_children > a' ), function( anchor ) {
-
-				// Add dropdown toggle that displays child menu items
-				var btn = document.createElement( 'button' );
-				btn.setAttribute( 'aria-expanded', 'false' );
-				btn.classList.add( 'dropdown-toggle' );
-
-				var btnSpan = document.createElement( 'span' );
-				btnSpan.classList.add( 'screen-reader-text' );
-				btnSpan.appendChild( document.createTextNode( storefrontScreenReaderText.expand ) );
-
-				btn.appendChild( btnSpan );
-
-				anchor.parentNode.insertBefore( btn, anchor.nextSibling );
-
-				// Set the active submenu dropdown toggle button initial state
-				if ( anchor.parentNode.classList.contains( 'current-menu-ancestor' ) ) {
-					btn.setAttribute( 'aria-expanded', 'true' );
-					btn.classList.add( 'toggled-on' );
-					btn.nextElementSibling.classList.add( 'toggled-on' );
-				}
-
-				// Add event listener
-				btn.addEventListener( 'click', function() {
-					btn.classList.toggle( 'toggled-on' );
-
-					// Remove text inside span
-					while ( btnSpan.firstChild ) {
-						btnSpan.removeChild( btnSpan.firstChild );
-					}
-
-					var expanded = btn.classList.contains( 'toggled-on' );
-
-					btn.setAttribute( 'aria-expanded', expanded );
-					btnSpan.appendChild( document.createTextNode( expanded ? storefrontScreenReaderText.collapse : storefrontScreenReaderText.expand ) );
-					btn.nextElementSibling.classList.toggle( 'toggled-on' );
-				} );
-			} );
-		}
 
 		// Add focus class to parents of sub-menu anchors.
 		[].forEach.call( document.querySelectorAll( '.site-header .menu-item > a, .site-header .page_item > a, .site-header-cart a' ), function( anchor ) {

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -226,21 +226,22 @@ if ( ! function_exists( 'storefront_primary_navigation' ) ) {
 	function storefront_primary_navigation() {
 		?>
 		<nav id="site-navigation" class="main-navigation" role="navigation" aria-label="<?php esc_html_e( 'Primary Navigation', 'storefront' ); ?>">
-		<button class="menu-toggle" aria-controls="site-navigation" aria-expanded="false"><span><?php echo esc_attr( apply_filters( 'storefront_menu_toggle_text', __( 'Menu', 'storefront' ) ) ); ?></span></button>
 			<?php
-			wp_nav_menu(
-				array(
-					'theme_location'  => 'primary',
-					'container_class' => 'primary-navigation',
-				)
-			);
-
-			wp_nav_menu(
-				array(
-					'theme_location'  => 'handheld',
-					'container_class' => 'handheld-navigation',
-				)
-			);
+				wp_nav_menu(
+					array(
+						'theme_location'  => 'primary',
+						'container_class' => 'primary-navigation',
+					)
+				);
+			?>
+			<button class="menu-toggle" aria-haspopup="true" aria-expanded="false"><span><?php echo esc_attr( apply_filters( 'storefront_menu_toggle_text', __( 'Menu', 'storefront' ) ) ); ?></span></button>
+			<?php
+				wp_nav_menu(
+					array(
+						'theme_location'  => 'handheld',
+						'container_class' => 'handheld-navigation',
+					)
+				);
 			?>
 		</nav><!-- #site-navigation -->
 		<?php


### PR DESCRIPTION
When using VoiceOver, the handheld menu was still being read even though it wasn't visible on the page. This was because we set the `min-height` on the menu to `0` on load.

Without this PR, VoiceOver will still read the menu because technically it is there and not hidden.

* Hides handheld menu with CSS `visibility`
* Add `area-expanded` attribute to correct sections
* Add `aria-haspopup` attribute to indicated a sub menu is present

I moved the order of some of the JS inside `navigation.js`. The diff for this PR looks bigger than the actual changes.

How to test:

* Go to WordPress > Menus and add a few items to the "Handheld" location.
* Resize your browser until the mobile nav kicks in and turn on VoiceOver (⌘ + F5)
* Tab around the site to listen to the descriptions
* After you get to the "Menu" button, it should skip to the next section and not read the hidden collapsed menu.

Closes #1070.