### PR TITLE
Fix deprecated Sass notices when running a build

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -436,7 +436,7 @@ body {
  */
 .site-footer {
 	background-color: #f3f3f3;
-	color: $color_body + #333;
+	color: mix( $color_body, #333 );
 	padding: ms(3) 0 ms(6);
 
 	h1,
@@ -445,7 +445,7 @@ body {
 	h4,
 	h5,
 	h6 {
-		color: $color_body + #222;
+		color: mix( $color_body, #222 );
 	}
 
 	a:not( .button ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6800,9 +6800,9 @@
       }
     },
     "susy": {
-      "version": "2.2.12",
-      "resolved": "https://registry.npmjs.org/susy/-/susy-2.2.12.tgz",
-      "integrity": "sha1-ZEwkQe0A0pMofo1JoBbb+RkhWVM=",
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/susy/-/susy-2.2.14.tgz",
+      "integrity": "sha512-4I7Cb4Cjw2TF6ZEMxT8W9/Ap35Kn/r6y3LIO+NzaMRBxfbmT+w2KvbrANG/JCqJjlPgqvwLfLF9vmndSMGZuLg==",
       "dev": true
     },
     "svg-tags": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-wp-i18n": "^1.0.3",
     "node-sass": "^4.11.0",
     "stylelint": "~9.10.1",
-    "susy": "2.2.12"
+    "susy": "2.2.14"
   },
   "engines": {
     "node": ">=0.8.0",


### PR DESCRIPTION
* Updates Susy to 2.2.4
* Updates deprecated Sass color operations

To test, run `npm install` and then `npm run build`, you should not see any deprecated notices such as:

```
DEPRECATION WARNING: Passing a string to call() is deprecated and will be illegal
in Sass 4.0. Use call(get-function("variable-exists")) instead.
```