### PR TITLE
Accessibility: Underline links, outlines

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -247,9 +247,14 @@ img {
 a {
 	color: $color_links;
 	text-decoration: none;
+}
 
+a,
+input,
+textarea,
+button {
 	&:focus {
-		outline-color: $color_woocommerce;
+		outline: 2px solid $color_woocommerce;
 	}
 }
 
@@ -933,7 +938,6 @@ textarea,
 	padding: ms(-2);
 	background-color: darken( $body-background, 5% );
 	color: $color_body;
-	outline-color: $color_woocommerce;
 	border: 0;
 	-webkit-appearance: none;
 	box-sizing: border-box;

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -249,7 +249,7 @@ a {
 	text-decoration: none;
 
 	&:focus {
-		outline: 1px dotted $color_woocommerce;
+		outline-color: $color_woocommerce;
 	}
 }
 
@@ -858,7 +858,6 @@ input[type='submit'],
 	font-weight: 600;
 	text-shadow: none;
 	display: inline-block;
-	outline: none;
 	-webkit-appearance: none;
 	border-radius: 0;
 
@@ -874,10 +873,6 @@ input[type='submit'],
 
 	&:hover {
 		color: #fff;
-	}
-
-	&:focus {
-		outline: 1px dotted $color_woocommerce;
 	}
 
 	&.loading {
@@ -938,7 +933,7 @@ textarea,
 	padding: ms(-2);
 	background-color: darken( $body-background, 5% );
 	color: $color_body;
-	outline: none;
+	outline-color: $color_woocommerce;
 	border: 0;
 	-webkit-appearance: none;
 	box-sizing: border-box;
@@ -947,8 +942,7 @@ textarea,
 		inset 0 1px 1px rgba( 0, 0, 0, 0.125 );
 
 	&:focus {
-		background-color: darken( $body-background, 10% );
-		color: darken( $color_body, 10% );
+		background-color: darken( $body-background, 7% );
 	}
 }
 

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -450,6 +450,11 @@ body {
 
 	a:not( .button ) {
 		color: $color_links;
+		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
+		}
 	}
 }
 
@@ -762,6 +767,16 @@ table {
 
 			a {
 				@include underlinedLink();
+			}
+		}
+	}
+
+	.entry-content {
+		a:not( .button ) {
+			text-decoration: underline;
+
+			&:hover {
+				text-decoration: none;
 			}
 		}
 	}

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -138,7 +138,6 @@
 			font-weight: 600;
 			text-shadow: none;
 			display: inline-block;
-			outline: none;
 			-webkit-appearance: none;
 			border-radius: 0;
 		}
@@ -440,7 +439,6 @@
 			font-weight: 600;
 			text-shadow: none;
 			display: inline-block;
-			outline: none;
 			-webkit-appearance: none;
 			border-radius: 0;
 			opacity: 1;

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1374,21 +1374,23 @@ label.inline {
 	margin-left: ms(1);
 }
 
-.woocommerce-MyAccount-navigation {
-	ul {
-		margin-left: 0;
-		border-top: 1px solid $color_border;
+.hentry .entry-content {
+	.woocommerce-MyAccount-navigation {
+		ul {
+			margin-left: 0;
+			border-top: 1px solid $color_border;
 
-		li {
-			list-style: none;
-			border-bottom: 1px solid $color_border;
-			position: relative;
+			li {
+				list-style: none;
+				border-bottom: 1px solid $color_border;
+				position: relative;
 
-			&.woocommerce-MyAccount-navigation-link {
-				a {
-					text-decoration: none;
-					padding: ms(-1) 0;
-					display: block;
+				&.woocommerce-MyAccount-navigation-link {
+					a {
+						text-decoration: none;
+						padding: ms(-1) 0;
+						display: block;
+					}
 				}
 			}
 		}

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -781,6 +781,14 @@ a.reset_variations {
 .woocommerce-breadcrumb {
 	font-size: ms(-1);
 
+	a {
+		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
 	.breadcrumb-separator {
 		display: inline-block;
 		padding: 0 ms(-3);
@@ -1388,9 +1396,12 @@ label.inline {
 			border-bottom: 1px solid $color_border;
 			position: relative;
 
-			a {
-				padding: ms(-1) 0;
-				display: block;
+			&.woocommerce-MyAccount-navigation-link {
+				a {
+					text-decoration: none;
+					padding: ms(-1) 0;
+					display: block;
+				}
 			}
 		}
 	}

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -144,11 +144,6 @@
 				text-indent: -9999px;
 				z-index: 999;
 				border-right: 1px solid rgba( #fff, 0.2 );
-
-				&:active,
-				&:focus {
-					outline: none;
-				}
 			}
 
 			&.search {
@@ -939,7 +934,6 @@ a.reset_variations {
 		@include border-top-radius(1em);
 		@include border-bottom-radius(1em);
 		cursor: ew-resize;
-		outline: none;
 		background: $color_links;
 		box-sizing: border-box;
 		margin-top: -0.25em;
@@ -1086,12 +1080,6 @@ table.cart {
 			display: block;
 			width: 100%;
 			margin: ms(-3) 0;
-
-			&[name='update_cart'] {
-				&:focus {
-					outline: none;
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
This PR:

* Underlines links in post content, footer, and breadcrumbs
* Outline styles

Links:

<img width="340" alt="links_breadcrumb" src="https://user-images.githubusercontent.com/1177726/54138366-383d7880-4417-11e9-837b-8c411b119bc9.png">

<img width="1125" alt="links_content" src="https://user-images.githubusercontent.com/1177726/54138378-3bd0ff80-4417-11e9-8185-3d4440d20821.png">

<img width="1202" alt="links_footer" src="https://user-images.githubusercontent.com/1177726/54138382-3d9ac300-4417-11e9-8ad9-0942c3698873.png">

Outlines:

<img width="471" alt="Screenshot 2019-03-11 at 16 04 06" src="https://user-images.githubusercontent.com/1177726/54138414-52775680-4417-11e9-86a4-ac54b48ee3ef.png">

Closes #918.