### PR TITLE
 Fix undefined error when no menu assigned to handheld location

### DIFF
--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -70,12 +70,6 @@
 
 		var menu = handheld[0].querySelector( 'ul' );
 
-		// Hide menu toggle button if menu is empty and return early.
-		if ( ! menu ) {
-			button.style.display = 'none';
-			return;
-		}
-
 		button.setAttribute( 'aria-expanded', 'false' );
 		menu.classList.add( 'nav-menu' );
 		menu.style.visibility = 'hidden';

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -7,9 +7,7 @@
  * Also adds a focus class to parent li's for accessibility.
  */
 ( function() {
-
-	// Wait for DOM to be ready.
-	document.addEventListener( 'DOMContentLoaded', function() {
+	var handheldMenu = function() {
 		var container = document.getElementById( 'site-navigation' );
 
 		if ( ! container ) {
@@ -88,7 +86,9 @@
 			menu.style.visibility = 'true' === expanded ? 'visible' : 'hidden';
 			button.setAttribute( 'aria-expanded', expanded );
 		} );
+	};
 
+	var focusClass = function() {
 		// Add focus class to parents of sub-menu anchors.
 		[].forEach.call( document.querySelectorAll( '.site-header .menu-item > a, .site-header .page_item > a, .site-header-cart a' ), function( anchor ) {
 			anchor.addEventListener( 'focus', function() {
@@ -114,6 +114,9 @@
 			} );
 		} );
 
+	};
+
+	var touchEvents = function() {
 		// Add an identifying class to dropdowns when on a touch device
 		// This is required to switch the dropdown hiding method from a negative `left` value to `display: none`.
 		if ( ( 'ontouchstart' in window || navigator.maxTouchPoints ) && window.innerWidth > 767 ) {
@@ -154,5 +157,12 @@
 				} );
 			} );
 		}
+	};
+
+	// Wait for DOM to be ready.
+	document.addEventListener( 'DOMContentLoaded', function() {
+		handheldMenu();
+		focusClass();
+		touchEvents();
 	} );
 } )();

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -25,7 +25,7 @@
 		// Add dropdown toggle that displays child menu items.
 		var handheld = document.getElementsByClassName( 'handheld-navigation' );
 
-		if ( ! handheld ) {
+		if ( 0 === handheld.length ) {
 			return;
 		}
 

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -235,16 +235,20 @@ if ( ! function_exists( 'storefront_primary_navigation' ) ) {
 				);
 			?>
 
-			<?php if ( has_nav_menu( 'handheld' ) ) : ?>
+			<?php
+				$handheld = wp_nav_menu(
+					array(
+						'theme_location'  => 'handheld',
+						'container_class' => 'handheld-navigation',
+						'echo'            => false,
+						'fallback_cb'     => '__return_false',
+					)
+				);
+			?>
+
+			<?php if ( ! empty( $handheld ) ) : ?>
 				<button class="menu-toggle" aria-haspopup="true" aria-expanded="false"><span><?php echo esc_attr( apply_filters( 'storefront_menu_toggle_text', __( 'Menu', 'storefront' ) ) ); ?></span></button>
-				<?php
-					wp_nav_menu(
-						array(
-							'theme_location'  => 'handheld',
-							'container_class' => 'handheld-navigation',
-						)
-					);
-				?>
+				<?php echo $handheld; // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 			<?php endif; ?>
 		</nav><!-- #site-navigation -->
 		<?php

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -234,15 +234,18 @@ if ( ! function_exists( 'storefront_primary_navigation' ) ) {
 					)
 				);
 			?>
-			<button class="menu-toggle" aria-haspopup="true" aria-expanded="false"><span><?php echo esc_attr( apply_filters( 'storefront_menu_toggle_text', __( 'Menu', 'storefront' ) ) ); ?></span></button>
-			<?php
-				wp_nav_menu(
-					array(
-						'theme_location'  => 'handheld',
-						'container_class' => 'handheld-navigation',
-					)
-				);
-			?>
+
+			<?php if ( has_nav_menu( 'handheld' ) ) : ?>
+				<button class="menu-toggle" aria-haspopup="true" aria-expanded="false"><span><?php echo esc_attr( apply_filters( 'storefront_menu_toggle_text', __( 'Menu', 'storefront' ) ) ); ?></span></button>
+				<?php
+					wp_nav_menu(
+						array(
+							'theme_location'  => 'handheld',
+							'container_class' => 'handheld-navigation',
+						)
+					);
+				?>
+			<?php endif; ?>
 		</nav><!-- #site-navigation -->
 		<?php
 	}


### PR DESCRIPTION
This PR fixes an undefined error when no menu is assigned to the handheld location. The issue was introduced in https://github.com/woocommerce/storefront/pull/1074.

I also moved the different bits of functionality into separate functions which should make it easier to maintain things going forward.

In addition to the above, to stop the menu button from being outputted to the page when there's no menu assign or no menu items in the handheld location, I changed the way the menu outputted by first assigning it to a variable and checking its contents.

To test:

1) Create a menu with items and assign it to the "Handheld" location.
2) Resize the browser until mobile mode kicks in, and confirm that the "Menu" toggle shows up and the menu appears once clicked.

Then:

1) Remove items from the menu
2) Check if the "Menu" toggle is displayed. It shouldn't
3) Also test by unassigned all menus from the "Handheld" location and again, check if the "Menu" toggle shows up.

Also check the console for JS errors.

Closes #1079.
