### PR TITLE
Remove menu transition when no menu assigned to primary location

### DIFF
--- a/assets/css/base/_layout.scss
+++ b/assets/css/base/_layout.scss
@@ -476,6 +476,7 @@
 			max-height: none;
 			overflow: visible;
 			margin-left: -1em;
+			transition: none;
 
 			> li {
 				// The first level menu item


### PR DESCRIPTION
There's a transition being inherit from the mobile styles for menus:

![1084](https://user-images.githubusercontent.com/1177726/54649375-d5488300-4aa1-11e9-9e7b-bcb114386629.gif)

This happens when no menu is assigned to the "Primary" menu location, and it uses the fallback.

**To test:**

1. Run `npm run build`
2. Ensure no custom menus are assigned to the "Primary Menu" location
3. Refresh Storefront, you shouldn't see the menu transition

Closes #1084.