### PR TITLE
WP 5.2 cover block + Blocks Homepage

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -292,14 +292,11 @@
 		}
 	}
 
-	.wp-block-cover-image,
 	.wp-block-cover {
 		flex-flow: row wrap;
 
-		.wp-block-cover-image-text,
-		.wp-block-cover-text,
-		h2,
-		p {
+		// < 5.2 styling
+		> .wp-block-cover-text {
 			font-size: ms(3);
 			font-weight: 300;
 			line-height: 1.618;
@@ -319,6 +316,23 @@
 
 			@media ( min-width: $desktop ) {
 				font-size: ms(4);
+				width: calc(6 * (100vw / 12 ));
+				max-width: calc(6 * (100vw / 12 ));
+			}
+		}
+
+		// > 5.2 styling
+		.wp-block-cover__inner-container {
+			padding: ms(1);
+			width: calc(100vw - #{ms(1)});
+			max-width: calc(100vw - #{ms(1)});
+
+			@media ( min-width: $handheld ) {
+				width: calc(8 * (100vw / 12 ));
+				max-width: calc(8 * (100vw / 12 ));
+			}
+
+			@media ( min-width: $desktop ) {
 				width: calc(6 * (100vw / 12 ));
 				max-width: calc(6 * (100vw / 12 ));
 			}

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -73,6 +73,30 @@
 	}
 }
 
+// Homepage
+.home.page-template-template-fullwidth {
+	.hentry {
+		margin-bottom: 0;
+
+		.entry-content {
+			> .wp-block-cover.alignfull,
+			> .wp-block-image.alignfull {
+				width: auto;
+				max-width: 1000%;
+				margin-left: calc(50% - 50vw);
+				margin-right: calc(50% - 50vw);
+				margin-top: - ms(7);
+				margin-bottom: ms(7);
+			}
+
+			h2 + .woocommerce,
+			h2 + [class*='wp-block-woocommerce-'] {
+				margin-top: ms(4);
+			}
+		}
+	}
+}
+
 /**
  * Front-end + editor styles
  */

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -351,7 +351,6 @@
 			padding: ms(5) ms(1);
 			width: calc(100vw - #{ms(1)});
 			max-width: calc(100vw - #{ms(1)});
-			color: $color-body;
 
 			*:nth-last-child( -n+1 ) {
 				margin-bottom: 0;

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -297,7 +297,7 @@
 		min-height: 350px;
 
 		// < 5.2 styling
-		> .wp-block-cover-text {
+		p.wp-block-cover-text {
 			font-size: ms(3);
 			font-weight: 300;
 			line-height: 1.618;

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -294,6 +294,7 @@
 
 	.wp-block-cover {
 		flex-flow: row wrap;
+		min-height: 350px;
 
 		// < 5.2 styling
 		> .wp-block-cover-text {
@@ -323,9 +324,65 @@
 
 		// > 5.2 styling
 		.wp-block-cover__inner-container {
-			padding: ms(1);
+			padding: ms(5) ms(1);
 			width: calc(100vw - #{ms(1)});
 			max-width: calc(100vw - #{ms(1)});
+			color: $color-body;
+
+			*:nth-last-child( -n+1 ) {
+				margin-bottom: 0;
+			}
+
+			h1,
+			h2,
+			h3,
+			h4,
+			h5,
+			h6 {
+				padding: 0;
+				margin-left: auto;
+				margin-right: auto;
+				color: #000000;
+			}
+
+			h1 {
+				font-size: ms(6);
+				margin-bottom: ms(-6);
+			}
+
+			h2 {
+				font-size: ms(5);
+				margin-bottom: ms(-5);
+			}
+
+			h3 {
+				font-size: ms(4);
+				margin-bottom: ms(-4);
+			}
+
+			h4 {
+				font-size: ms(3);
+				margin-bottom: ms(-3);
+			}
+
+			h5 {
+				font-size: ms(2);
+				margin-bottom: ms(-2);
+			}
+
+			h6 {
+				font-size: ms(2);
+				margin-bottom: ms(-2);
+			}
+
+			p {
+				&:not( .has-small-font-size ),
+				&:not( .has-medium-font-size ),
+				&:not( .has-large-font-size ),
+				&:not( .has-huge-font-size ) {
+					font-size: 1.1em;
+				}
+			}
 
 			@media ( min-width: $handheld ) {
 				width: calc(8 * (100vw / 12 ));
@@ -335,6 +392,8 @@
 			@media ( min-width: $desktop ) {
 				width: calc(6 * (100vw / 12 ));
 				max-width: calc(6 * (100vw / 12 ));
+				padding-top: ms(9);
+				padding-bottom: ms(9);
 			}
 		}
 

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -342,7 +342,6 @@
 				padding: 0;
 				margin-left: auto;
 				margin-right: auto;
-				color: #000000;
 			}
 
 			h1 {

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -364,6 +364,16 @@ ul.products {
 	}
 }
 
+.hentry .entry-content {
+	ul.products {
+		li.product {
+			> a {
+				text-decoration: none;
+			}
+		}
+	}
+}
+
 .price {
 	del {
 		opacity: 0.5;

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -894,6 +894,15 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				.wp-block-table:not( .is-style-stripes ) tbody tr:nth-child(2n) td {
 					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -2 ) . ';
 				}
+
+				.wp-block-cover .wp-block-cover__inner-container h1,
+				.wp-block-cover .wp-block-cover__inner-container h2,
+				.wp-block-cover .wp-block-cover__inner-container h3,
+				.wp-block-cover .wp-block-cover__inner-container h4,
+				.wp-block-cover .wp-block-cover__inner-container h5,
+				.wp-block-cover .wp-block-cover__inner-container h6 {
+					color: ' . $storefront_theme_mods['hero_text_color'] . ';
+				}
 			';
 
 			return apply_filters( 'storefront_gutenberg_customizer_css', $styles );

--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -26,6 +26,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			add_filter( 'get_theme_starter_content', array( $this, 'filter_start_content' ), 10, 2 );
 			add_action( 'woocommerce_product_query', array( $this, 'wc_query' ) );
 			add_filter( 'woocommerce_shortcode_products_query', array( $this, 'shortcode_loop_products' ), 10, 3 );
+			add_filter( 'woocommerce_product_categories', array( $this, 'filter_product_categories_shortcode' ) );
 			add_action( 'customize_preview_init', array( $this, 'add_product_tax' ), 10 );
 			add_action( 'customize_preview_init', array( $this, 'set_product_data' ), 10 );
 			add_action( 'after_setup_theme', array( $this, 'remove_default_widgets' ) );
@@ -397,6 +398,34 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			}
 
 			return $query_args;
+		}
+
+		/**
+		 * Override product categories when displaying starter content.
+		 *
+		 * @since 2.5.0
+		 * @param array $categories Starter content.
+		 * @return array $categories
+		 */
+		public function filter_product_categories_shortcode( $categories ) {
+			if ( ! is_customize_preview() || true !== (bool) get_option( 'fresh_site' ) ) {
+				return $categories;
+			}
+
+			// Get empty categories.
+			$categories = get_terms(
+				'product_cat', array(
+					'hide_empty' => false,
+				)
+			);
+
+			foreach ( $categories as $key => $cat ) {
+
+				// Fake number of products in category.
+				$categories[ $key ]->count = 1;
+			}
+
+			return $categories;
 		}
 
 		/**

--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -273,6 +273,14 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				return $content;
 			}
 
+			// Get hero image and save for later.
+			$hero_image = false;
+
+			if ( array_key_exists( 'attachments', $content ) && array_key_exists( 'hero-image', $content['attachments'] ) ) {
+				$hero_image = $content['attachments']['hero-image'];
+			}
+
+			// Remove some of the content if necessary.
 			$tasks = array();
 
 			if ( isset( $_GET['sf_tasks'] ) && '' !== sanitize_text_field( wp_unslash( $_GET['sf_tasks'] ) ) ) { // WPCS: input var ok.
@@ -315,6 +323,13 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				unset( $content['posts']['contact'] );
 				unset( $content['nav_menus'] );
 				unset( $content['widgets'] );
+			}
+
+			// Add homepage attachment image.
+			if ( $hero_image && ! array_key_exists( 'attachments', $content ) ) {
+				$content['attachments'] = array(
+					'hero-image' => $hero_image,
+				);
 			}
 
 			return $content;

--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -26,8 +26,8 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			add_filter( 'get_theme_starter_content', array( $this, 'filter_start_content' ), 10, 2 );
 			add_action( 'woocommerce_product_query', array( $this, 'wc_query' ) );
 			add_filter( 'woocommerce_shortcode_products_query', array( $this, 'shortcode_loop_products' ), 10, 3 );
-			add_action( 'customize_preview_init', array( $this, 'add_product_tax' ), -1 );
-			add_action( 'customize_preview_init', array( $this, 'set_product_data' ), -1 );
+			add_action( 'customize_preview_init', array( $this, 'add_product_tax' ), 10 );
+			add_action( 'customize_preview_init', array( $this, 'set_product_data' ), 10 );
 			add_action( 'after_setup_theme', array( $this, 'remove_default_widgets' ) );
 			add_action( 'transition_post_status', array( $this, 'transition_post_status' ), 10, 3 );
 			add_filter( 'the_title', array( $this, 'filter_auto_draft_title' ), 10, 2 );

--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -325,8 +325,12 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				unset( $content['widgets'] );
 			}
 
-			// Add homepage attachment image.
-			if ( $hero_image && ! array_key_exists( 'attachments', $content ) ) {
+			// Add homepage attachment image, if necessary for blocks.
+			if ( $hero_image &&
+				array_key_exists( 'posts', $content ) &&
+				array_key_exists( 'home', $content['posts'] ) &&
+				! array_key_exists( 'attachments', $content )
+			) {
 				$content['attachments'] = array(
 					'hero-image' => $hero_image,
 				);

--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -404,8 +404,8 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 * Override product categories when displaying starter content.
 		 *
 		 * @since 2.5.0
-		 * @param array $categories Starter content.
-		 * @return array $categories
+		 * @param array $categories Product categories.
+		 * @return array $categories Modified product categories.
 		 */
 		public function filter_product_categories_shortcode( $categories ) {
 			if ( ! is_customize_preview() || true !== (bool) get_option( 'fresh_site' ) ) {

--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -1034,10 +1034,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 */
 		private function _homepage_blocks_content() {
 			$content = '
-				<!-- wp:cover {"url":"{{hero-image-url}}","id":{{hero-image-id}},"dimRatio":0,"customOverlayColor":"#ffffff","align":"full"} -->
-				<div class="wp-block-cover alignfull" style="background-image:url({{hero-image-url}});background-color:#ffffff"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":1,"align":"center"} -->
-				<h1 style="text-align:center">' . __( 'Welcome', 'storefront' ) . '</h1>
-				<!-- /wp:heading -->
+				{{cover}}
 
 				<!-- wp:paragraph {"align":"center","customTextColor":"#000000"} -->
 				<p style="color:#000000;text-align:center" class="has-text-color">' . __( 'This is your homepage which is what most visitors will see when they first visit your shop.', 'storefront' ) . '</p>
@@ -1064,13 +1061,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				<div class="wp-block-woocommerce-product-new">[products limit="4" columns="4" orderby="date" order="DESC"]</div>
 				<!-- /wp:woocommerce/product-new -->
 
-				<!-- wp:heading {"align":"center"} -->
-				<h2 style="text-align:center">' . __( 'We Recommend', 'storefront' ) . '</h2>
-				<!-- /wp:heading -->
-
-				<!-- wp:woocommerce/handpicked-products {"columns":4,"editMode":false,"products":[{{handpicked-products}}]} -->
-				<div class="wp-block-woocommerce-handpicked-products">[products limit="4" columns="4" orderby="date" order="DESC" ids="{{handpicked-products}}"]</div>
-				<!-- /wp:woocommerce/handpicked-products -->
+				{{handpicked-products}}
 
 				<!-- wp:heading {"align":"center"} -->
 				<h2 style="text-align:center">' . __( 'Fan Favorites', 'storefront' ) . '</h2>
@@ -1113,9 +1104,19 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			$hero = $this->_query_starter_content( 'attachment', 'hero-image', true );
 
 			if ( ! empty( $hero ) ) {
+				$cover = '
+					<!-- wp:cover {"url":"{{hero-image-url}}","id":{{hero-image-id}},"dimRatio":0,"customOverlayColor":"#ffffff","align":"full"} -->
+					<div class="wp-block-cover alignfull" style="background-image:url({{hero-image-url}});background-color:#ffffff"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":1,"align":"center"} -->
+					<h1 style="text-align:center">' . __( 'Welcome', 'storefront' ) . '</h1>
+					<!-- /wp:heading -->
+				';
+
 				$attachment = $hero[0];
-				$content    = str_replace( '{{hero-image-id}}', $attachment, $content );
-				$content    = str_replace( '{{hero-image-url}}', wp_get_attachment_url( $attachment ), $content );
+				$cover      = str_replace( '{{hero-image-id}}', $attachment, $cover );
+				$cover      = str_replace( '{{hero-image-url}}', wp_get_attachment_url( $attachment ), $cover );
+				$content    = str_replace( '{{cover}}', $cover, $content );
+			} else {
+				$content = str_replace( '{{cover}}', '', $content );
 			}
 
 			// Replace handpicked products placeholders.
@@ -1129,7 +1130,20 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			$products = $this->_query_starter_content( 'product', $featured, true );
 
 			if ( ! empty( $products ) ) {
-				$content = str_replace( '{{handpicked-products}}', implode( ',', $products ), $content );
+				$handpicked = '
+					<!-- wp:heading {"align":"center"} -->
+					<h2 style="text-align:center">' . __( 'We Recommend', 'storefront' ) . '</h2>
+					<!-- /wp:heading -->
+
+					<!-- wp:woocommerce/handpicked-products {"columns":4,"editMode":false,"products":[{{handpicked-products}}]} -->
+					<div class = "wp-block-woocommerce-handpicked-products">[products limit="4" columns="4" orderby="date" order="DESC" ids="{{handpicked-products}}"]</div>
+					<!-- /wp:woocommerce/handpicked-products -->
+				';
+
+				$handpicked = str_replace( '{{handpicked-products}}', implode( ',', $products ), $handpicked );
+				$content    = str_replace( '{{handpicked-products}}', $handpicked, $content );
+			} else {
+				$content = str_replace( '{{handpicked-products}}', '', $content );
 			}
 
 			return $content;

--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -26,6 +26,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			add_filter( 'get_theme_starter_content', array( $this, 'filter_start_content' ), 10, 2 );
 			add_action( 'woocommerce_product_query', array( $this, 'wc_query' ) );
 			add_filter( 'woocommerce_shortcode_products_query', array( $this, 'shortcode_loop_products' ), 10, 3 );
+			add_filter( 'woocommerce_shortcode_products_query', array( $this, 'filter_on_sale_products' ), 20, 3 );
 			add_filter( 'woocommerce_product_categories', array( $this, 'filter_product_categories_shortcode' ) );
 			add_action( 'customize_preview_init', array( $this, 'add_product_tax' ), 10 );
 			add_action( 'customize_preview_init', array( $this, 'set_product_data' ), 10 );
@@ -395,6 +396,38 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 
 				// Allow for multiple status.
 				$query_args['post_status'] = get_post_stati();
+			}
+
+			return $query_args;
+		}
+
+		/**
+		 * Filter shortcode products loop in WooCommerce.
+		 *
+		 * @since 2.5.0
+		 * @param array  $query_args Query args.
+		 * @param array  $atts Shortcode attributes.
+		 * @param string $type Loop type.
+		 * @return array $query_args
+		 */
+		public function filter_on_sale_products( $query_args, $atts, $type ) {
+			if ( ! is_customize_preview() || true !== (bool) get_option( 'fresh_site' ) ) {
+				return $query_args;
+			}
+
+			if ( 'sale_products' === $type ) {
+				$onsale = array(
+					'beanie',
+					'belt',
+					'cap',
+					'hoodie-with-pocket',
+				);
+
+				$products = $this->_query_starter_content( 'product', $onsale, true );
+
+				if ( ! empty( $products ) ) {
+					$query_args['post__in'] = $products;
+				}
 			}
 
 			return $query_args;

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -312,6 +312,10 @@ if ( ! function_exists( 'storefront_page_header' ) ) {
 	 * @since 1.0.0
 	 */
 	function storefront_page_header() {
+		if ( is_front_page() && is_page_template( 'template-fullwidth.php' ) ) {
+			return;
+		}
+
 		?>
 		<header class="entry-header">
 			<?php


### PR DESCRIPTION
<p>With the new WC blocks in WooCommerce 3.6, we can now replace our old homepage page template (template-homepage.php) with a new editable block based homepage.</p>

<h3>New cover block in WordPress 5.2</h3>

<p>Starting in 5.2, the cover blocks now includes an inner container where it&#8217;s possible to add headings, paragraphs, and buttons.</p>

<p>Here&#8217;s an example:</p>

<img width="1117" alt="Screenshot 2019-04-11 at 18 27 35" src="https://user-images.githubusercontent.com/1177726/55979913-2efc3180-5c8b-11e9-8308-eeae1a163d18.png">

<p><strong>How to test</strong></p>

<ul>
<li>Install WP 5.2 beta or Gutenberg plugin from WordPress.org</li>
<li>Create a new post/page and add a cover block</li>
<li>Add blocks inside the cover block, check that the styling matches that of Storefront.</li>
<li>Colors can be adjusted in the sidebar.</li>
</ul>

<h3>Blocks homepage</h3>

<p><code>_homepage_blocks_content()</code> is the content to add to the page, but with some placeholders that we then update in <code>_replace_homepage_blocks_symbols()</code>.</p>

<p><code>filter_on_sale_products()</code> and <code>filter_product_categories_shortcode()</code> both filter the related shortcodes used in the homepage when <strong>previewing</strong> the homepage in the Customizer. The shortcodes don&#8217;t display any data without these workarounds.</p>

<p>This only applies to when the homepage is being previewed in the Customizer.</p>

<p><strong>How to test</strong></p>

<ul>
<li>Start with an empty WordPress site.</li>
<li>Install WP 5.2 (or comment out the conditional statements in <code>class-storefront-nux-starter-content.php</code>) and WC 3.6.</li>
<li>Activate Storefront and follow the instructions to install &amp; activate WooCommerce.</li>
<li>After installing WooCommerce, go back to the dashboard. Click on the &#8220;Let&#8217;s go&#8221; button in the Storefront notification. This should redirect you to the Customizer:</li>
<img width="1253" alt="Screenshot 2019-04-11 at 18 43 02" src="https://user-images.githubusercontent.com/1177726/55980007-64088400-5c8b-11e9-9f4d-54a78e25229d.png">

<li>In the Customizer you should see the new Homepage. Check that blocks are being used by looking at the HTML. Search for <code>wp-block-</code> in the content of the homepage.</li>
<li>Hit the save button in the Customizer.</li>
<li>Go back to wp-admin, edit the &#8220;Homepage&#8221; page. Check that it is possible to edit the blocks:</li>
</ul>

<img width="1092" alt="Screenshot 2019-04-11 at 18 44 36" src="https://user-images.githubusercontent.com/1177726/55979937-40ddd480-5c8b-11e9-86cb-6fc790e75b37.png">

Closes #1087.