### PR TITLE
Add outline to T&C checkbox and country select

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1515,6 +1515,16 @@ ul.order_details {
 		input.input-text {
 			box-shadow: inset 2px 0 0 $error;
 		}
+
+		input.input-checkbox {
+			outline: 2px solid $error;
+			outline-offset: 1px;
+		}
+
+		.select2-selection {
+			border-color: $error;
+			border-width: 2px;
+		}
 	}
 }
 
@@ -1529,7 +1539,7 @@ ul.order_details {
 
 .required {
 	border-bottom: 0 !important;
-	color: red;
+	color: $error;
 }
 
 .demo_store {


### PR DESCRIPTION
Before:

<img width="1107" alt="Screenshot 2019-04-15 at 16 15 15" src="https://user-images.githubusercontent.com/1177726/56144181-d3d38300-5f99-11e9-97a8-7ed22201742a.png">

After:

<img width="1100" alt="Screenshot 2019-04-15 at 16 15 37" src="https://user-images.githubusercontent.com/1177726/56144190-dd5ceb00-5f99-11e9-900c-2849a4aa8654.png">

Notice the outline around the country and Terms & Conditions checkbox.

To test:

* Add a product to card and then go to the Checkout page
* Hit the "Place order" button

Closes #778 .