### PR TITLE
Add Composite Products 4.0 support

### DIFF
--- a/assets/css/woocommerce/extensions/composite-products.scss
+++ b/assets/css/woocommerce/extensions/composite-products.scss
@@ -19,6 +19,7 @@
 .composite_summary .summary_element {
 
 	.summary_element_wrapper {
+
 		box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0 );
 
 		&.selected,
@@ -83,6 +84,10 @@
 				&.selected,
 				&.selected:hover {
 					box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0.06 );
+				}
+
+				&.selected:not( .loading ) button {
+					border-radius: 50%;
 				}
 
 				&:hover {

--- a/assets/js/footer.js
+++ b/assets/js/footer.js
@@ -24,8 +24,8 @@
 		var footer_bar = document.getElementsByClassName( 'storefront-handheld-footer-bar' );
 		var forms      = document.forms;
 		var isFocused  = function( focused ) {
-			return function() {
-				if ( !! focused ) {
+			return function( event ) {
+				if ( !! focused && event.target.tabIndex !== -1 ) {
 					document.body.classList.add( 'sf-input-focused' );
 				} else {
 					document.body.classList.remove( 'sf-input-focused' );


### PR DESCRIPTION
Changes in this PR:

(1)

Composite Products 4.0 has introduced buttons in **Options Style > Thumbnail** grid elements, and dropped box shadows previously used in various places. No changes are necessary in Storefront, aside from a small visual enhancement: https://cl.ly/14dbc63ce1e6

(2)

CP 4.0 includes many accessibility improvements. One of them is to move focus when transitioning between steps, or choosing new component options, which also allows screen readers to announce the newly focused elements (in all cases non-form elements with `tabIndex=-1`).

Storefront includes some code to show/hide the mobile footer bar when _any_ page element takes focus. This is done by adding/removing an element on `body`. Long-term, it might be a good idea to limit this behavior to input/textarea elements only. Right now, any focus event happening inside a product form will cause the SF footer bar to disappear.

I avoided making any big changes here as the scope of this issue is CP compatibility. For the time being, I thought it was safe to check the `tabIndex` attribute and prevent SF from changing the body class if `tabIndex=-1`.