### PR TITLE
Add focus color override to all input methods

### DIFF
--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -730,17 +730,23 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['text_color'], 5 ) . ';
 			}
 
-			a  {
+			a {
 				color: ' . $storefront_theme_mods['accent_color'] . ';
 			}
 
 			a:focus,
-			.button:focus,
-			.button.alt:focus,
 			button:focus,
+			.button.alt:focus,
+			input:focus,
+			textarea:focus,
 			input[type="button"]:focus,
 			input[type="reset"]:focus,
-			input[type="submit"]:focus {
+			input[type="submit"]:focus,
+			input[type="email"]:focus,
+			input[type="tel"]:focus,
+			input[type="url"]:focus,
+			input[type="password"]:focus,
+			input[type="search"]:focus {
 				outline-color: ' . $storefront_theme_mods['accent_color'] . ';
 			}
 


### PR DESCRIPTION
Adds custom color set in the Customizer to missing elements.

To test:

* Go to the Customizer > Typography
* Change the "Link / accent color"
* Go back to the frontend
* Click on the Search form in the header
* Focus color should be the same as set in the Customizer

<img width="501" alt="Screenshot 2019-04-16 at 15 36 14" src="https://user-images.githubusercontent.com/1177726/56218847-8e788980-605d-11e9-95f9-92249f3f804f.png">

Closes #1091 