### PR TITLE
Don't show sticky add to cart if product cannot be purchased

### DIFF
--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -757,6 +757,18 @@ if ( ! function_exists( 'storefront_sticky_single_add_to_cart' ) ) {
 			return;
 		}
 
+		$show = false;
+
+		if ( $product->is_purchasable() && $product->is_in_stock() ) {
+			$show = true;
+		} else if ( $product->is_type( 'external' ) ) {
+			$show = true;
+		}
+
+		if ( ! $show ) {
+			return;
+		}
+
 		$params = apply_filters(
 			'storefront_sticky_add_to_cart_params', array(
 				'trigger_class' => 'entry-summary',


### PR DESCRIPTION
This PR ensures that the "sticky add to cart" top bar only is displayed when a product can be purchased, is in stock, or is external.

* To test, create products with no price, or no stock.
* In the single product page, scroll down and check if the top bar is displayed in the single product page

<img width="1210" alt="Screenshot 2019-04-16 at 16 38 30" src="https://user-images.githubusercontent.com/1177726/56223725-34c88d00-6066-11e9-9633-d798c188699a.png">

Closes #866.