### PR TITLE
Add left margin to view cart link

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1768,6 +1768,7 @@ p.no-comments {
 		color: #fff;
 		box-shadow: none;
 		line-height: 1.618;
+		margin-left: 1em;
 		padding-left: 1em;
 		border-width: 0;
 		border-left-width: 1px;


### PR DESCRIPTION
Add left margin to view cart link in the "Added to cart" notice.

To test, browse to a product page and click the add to cart button. Then, resize the window and you should see some margin to the left of the "Add to cart" link where previously the link would clash with notice text.

<img width="406" alt="Screenshot 2019-04-16 at 17 07 54" src="https://user-images.githubusercontent.com/1177726/56226042-60e60d00-606a-11e9-8bdd-92d8f8d2e87d.png">

Closes #818.