### PR TITLE
Prevent overlap of site title and handheld menu button

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -341,6 +341,7 @@ body {
 .site-branding {
 	float: left;
 	margin-bottom: 0;
+	width: calc( 100% - 120px );
 
 	.site-title {
 		font-size: 2em;
@@ -1143,6 +1144,7 @@ button.menu-toggle {
 	background-image: none;
 	padding: ms(-2) ms(-1) ms(-2) ms(5);
 	font-size: ms(-1);
+	max-width: 120px;
 
 	&:hover {
 		background-image: none;


### PR DESCRIPTION
Prevents the overlap of the site title and the Menu button on small screens. 

To test, add a big title to your test store, then resize the browser and check if the site title and the button display correctly.

Before:

<img width="451" alt="Screenshot 2019-04-16 at 17 19 06" src="https://user-images.githubusercontent.com/1177726/56226760-df8f7a00-606b-11e9-88ba-37846416bbe0.png">

After:

<img width="451" alt="Screenshot 2019-04-16 at 17 19 34" src="https://user-images.githubusercontent.com/1177726/56226770-e5855b00-606b-11e9-85bd-2aa1e0bf7323.png">

Closes #822.