### PR TITLE
Replace CSS calc with Sass math

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -366,7 +366,7 @@
 				&.columns-#{$i} .blocks-gallery-image,
 				&.columns-#{$i} .blocks-gallery-item {
 					margin-right: gutter(12);
-					width: calc(( 100% - #{gutter(12)} * #{$i - 1} ) / #{$i});
+					width: ( 100% - ( gutter(12) * ( $i - 1 ) ) ) / $i;
 
 					&:nth-of-type( #{$i}n ) {
 						margin-right: 0;
@@ -385,7 +385,7 @@
 					&.columns-#{$i} .blocks-gallery-image,
 					&.columns-#{$i} .blocks-gallery-item {
 						margin-right: gutter(9);
-						width: calc(( 100% - #{gutter(9)} * #{$i - 1} ) / #{$i});
+						width: ( 100% - ( gutter(9) * ( $i - 1 ) ) ) / $i;
 
 						&:nth-of-type( #{$i}n ) {
 							margin-right: 0;


### PR DESCRIPTION
For some reason in MS Edge the CSS calc function calculation is a bit off which causes block gallery items to not align correctly. This PR switches the calculation of the width to use Sass math instead.

To test, add a gallery block with 4 columns to a page. Then test in Edge and check that 4 images are displayed per row.

Closes #1095.