### PR TITLE
Add edit link to posts, pages, and products

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -634,6 +634,11 @@ ul.products {
 				@include underlinedLink();
 			}
 		}
+
+		.edit-link {
+			font-size: ms(-1);
+			margin-top: 1em;
+		}
 	}
 }
 

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -491,6 +491,32 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 	}
 }
 
+if ( ! function_exists( 'storefront_edit_post_link' ) ) {
+	/**
+	 * Display the edit link
+	 *
+	 * @since 2.5.0
+	 */
+	function storefront_edit_post_link() {
+		edit_post_link(
+			sprintf(
+				wp_kses(
+					/* translators: %s: Name of current post. Only visible to screen readers */
+					__( 'Edit <span class="screen-reader-text">%s</span>', 'storefront' ),
+					array(
+						'span' => array(
+							'class' => array(),
+						),
+					)
+				),
+				get_the_title()
+			),
+			'<div class="edit-link">',
+			'</div>'
+		);
+	}
+}
+
 if ( ! function_exists( 'storefront_post_taxonomy' ) ) {
 	/**
 	 * Display the post taxonomies

--- a/inc/storefront-template-hooks.php
+++ b/inc/storefront-template-hooks.php
@@ -64,6 +64,7 @@ add_action( 'storefront_loop_post', 'storefront_post_taxonomy', 40 );
 add_action( 'storefront_loop_after', 'storefront_paging_nav', 10 );
 add_action( 'storefront_single_post', 'storefront_post_header', 10 );
 add_action( 'storefront_single_post', 'storefront_post_content', 30 );
+add_action( 'storefront_single_post_bottom', 'storefront_edit_post_link', 5 );
 add_action( 'storefront_single_post_bottom', 'storefront_post_taxonomy', 5 );
 add_action( 'storefront_single_post_bottom', 'storefront_post_nav', 10 );
 add_action( 'storefront_single_post_bottom', 'storefront_display_comments', 20 );
@@ -79,6 +80,7 @@ add_action( 'storefront_post_content_before', 'storefront_post_thumbnail', 10 );
  */
 add_action( 'storefront_page', 'storefront_page_header', 10 );
 add_action( 'storefront_page', 'storefront_page_content', 20 );
+add_action( 'storefront_page', 'storefront_edit_post_link', 30 );
 add_action( 'storefront_page_after', 'storefront_display_comments', 10 );
 
 /**

--- a/inc/woocommerce/storefront-woocommerce-template-hooks.php
+++ b/inc/woocommerce/storefront-woocommerce-template-hooks.php
@@ -66,8 +66,13 @@ if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.3', '<' ) ) {
 /**
  * Products
  *
+ * @see storefront_edit_post_link()
  * @see storefront_upsell_display()
+ * @see storefront_single_product_pagination()
+ * @see storefront_sticky_single_add_to_cart()
  */
+add_action( 'woocommerce_single_product_summary', 'storefront_edit_post_link', 60 );
+
 remove_action( 'woocommerce_after_single_product_summary', 'woocommerce_upsell_display', 15 );
 add_action( 'woocommerce_after_single_product_summary', 'storefront_upsell_display', 15 );
 


### PR DESCRIPTION
Adds an edit link to posts, pages, and products.

Posts/pages:

<img width="1084" alt="Screenshot 2019-04-16 at 23 31 39" src="https://user-images.githubusercontent.com/1177726/56248424-da4c2280-609f-11e9-8125-06307a428887.png">

Products:

<img width="1077" alt="Screenshot 2019-04-16 at 23 31 57" src="https://user-images.githubusercontent.com/1177726/56248431-e1733080-609f-11e9-808d-ad5247974492.png">

To test, check that the edit links shows up in all the locations listed above.

Closes #1083.