### PR TITLE
De-emphasise the "remove" icon in the cart

### DIFF
--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -472,7 +472,7 @@ a.remove {
 		left: 0;
 		right: 0;
 		bottom: 0;
-		color: $error;
+		color: lighten( $color-body, 20% );
 		line-height: 1.618;
 		text-indent: 0;
 		text-align: center;

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -2397,6 +2397,7 @@ dl.variation {
 				position: relative;
 				top: auto;
 				right: auto;
+				font-size: ms(1);
 			}
 		}
 


### PR DESCRIPTION
To test, add product to the cart and check the color and size of the remove icon.

Before:

<img width="1074" alt="Screenshot 2019-04-17 at 17 01 02" src="https://user-images.githubusercontent.com/1177726/56302809-69a21600-6132-11e9-8bdf-b876b576f39a.png">

After:

<img width="1090" alt="Screenshot 2019-04-17 at 16 59 17" src="https://user-images.githubusercontent.com/1177726/56302754-52632880-6132-11e9-8e49-00307e93bc25.png">

Closes #812.