### PR TITLE
Change homepage template product_categories orderby

### DIFF
--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -255,7 +255,7 @@ if ( ! function_exists( 'storefront_product_categories' ) ) {
 				'limit'            => 3,
 				'columns'          => 3,
 				'child_categories' => 0,
-				'orderby'          => 'name',
+				'orderby'          => 'menu_order',
 				'title'            => __( 'Shop by Category', 'storefront' ),
 			)
 		);


### PR DESCRIPTION
Since pretty much the very beginning, we had the `orderby` for the products shortcode used in the Homepage template set to `name`, but due to a bug in WooCommerce this value was never enforced. 

WC 3.6.2 fixed the issue and now several customers reached out saying that the expected behaviour is for the categories in the homepage to follow the order set in the backend, which makes sense.

This PR updates the `orderby` value from `name` to `menu_order`.

To test, create a page and assign the "Homepage" template to it. Then, reorder product categories in wp-admin and check that the order changed in the Homepage.

Closes #1111.