### PR TITLE
Change product pagination z-index for compatibility with PhotoSwipe

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -2844,7 +2844,7 @@ dl.variation {
 			top: 50%;
 			width: 500px;
 			box-shadow: 0 0 5px rgba( #000, 0.2 );
-			z-index: 999999;
+			z-index: 1499; /* Lower than PhotoSwipe */
 			display: flex;
 			align-items: center;
 


### PR DESCRIPTION
At the moment the Product Pagination is showing up on top of the PhotoSwipe full width image preview, this PR updates the z-index values to be lower than PhotoSwipe.

To test, check that Product Pagination is enabled in the Customizer. Then visit a product page and click on the magnifier icon to go full width on the image preview. You shouldn't see the product navigation buttons.

Before:

<img width="1222" alt="Screenshot 2019-04-29 at 18 08 05" src="https://user-images.githubusercontent.com/1177726/56913521-c47c2b80-6aa9-11e9-9d89-b99d65998be5.png">

Closes #1113.
