### PR TITLE
Fix mini cart double scrollbar

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -2006,13 +2006,19 @@ dl.variation {
 				display: none;
 			}
 
-			.product_list_widget li a.remove {
-				position: relative;
-				float: left;
-				top: auto;
+			.product_list_widget {
+				height: 0;
 
-				&::before {
-					text-align: left;
+				li {
+					a.remove {
+						position: relative;
+						float: left;
+						top: auto;
+
+						&::before {
+							text-align: left;
+						}
+					}
 				}
 			}
 		}
@@ -2022,6 +2028,10 @@ dl.variation {
 			.widget_shopping_cart {
 				left: 0;
 				display: block;
+
+				.product_list_widget {
+					height: auto;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
if the original length of the mini shopping cart surpasses the end of the page, we get an additional scrollbar showing up.

This only happens when the cart contents is really long and the page contents is relatively short. So it's best to reproduce with a short page, or lots of variable products in the cart which take up more horizontal space.

On initial page load the double scrollbar is shown, but as soon as we hover over the mini cart it disappears. This is because the JavaScript code is triggered which reduces the height of the cart and adds the scrollbar.

In this PR we set the height to 0 and then back to auto when the cart is revealed on hover.

![image](https://user-images.githubusercontent.com/11388669/54827797-b832d080-4caa-11e9-83a6-814653aeb2e1.png)

To test:

* Add a lot of products to the cart
* Resize the height of your browser window
* You should see a double scrollbar without this PR

Closes #1088.