### PR TITLE
Move Gutenberg assets to Gutenberg hooks

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -27,6 +27,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 			add_action( 'widgets_init', array( $this, 'widgets_init' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'scripts' ), 10 );
 			add_action( 'wp_enqueue_scripts', array( $this, 'child_scripts' ), 30 ); // After WooCommerce.
+			add_action( 'enqueue_block_assets', array( $this, 'block_assets' ) );
 			add_action( 'enqueue_block_editor_assets', array( $this, 'block_editor_assets' ) );
 			add_filter( 'body_class', array( $this, 'body_classes' ) );
 			add_filter( 'wp_page_menu_args', array( $this, 'page_menu_args' ) );
@@ -283,9 +284,6 @@ if ( ! class_exists( 'Storefront' ) ) :
 			wp_enqueue_style( 'storefront-style', get_template_directory_uri() . '/style.css', '', $storefront_version );
 			wp_style_add_data( 'storefront-style', 'rtl', 'replace' );
 
-			wp_enqueue_style( 'storefront-gutenberg-blocks', get_template_directory_uri() . '/assets/css/base/gutenberg-blocks.css', '', $storefront_version );
-			wp_style_add_data( 'storefront-gutenberg-blocks', 'rtl', 'replace' );
-
 			wp_enqueue_style( 'storefront-icons', get_template_directory_uri() . '/assets/css/base/icons.css', '', $storefront_version );
 			wp_style_add_data( 'storefront-icons', 'rtl', 'replace' );
 
@@ -346,16 +344,25 @@ if ( ! class_exists( 'Storefront' ) ) :
 		}
 
 		/**
+		 * Enqueue block assets.
+		 *
+		 * @since 2.5.0
+		 */
+		public function block_assets() {
+			global $storefront_version;
+
+			// Styles.
+			wp_enqueue_style( 'storefront-gutenberg-blocks', get_template_directory_uri() . '/assets/css/base/gutenberg-blocks.css', '', $storefront_version );
+			wp_style_add_data( 'storefront-gutenberg-blocks', 'rtl', 'replace' );
+		}
+
+		/**
 		 * Enqueue supplemental block editor assets.
 		 *
 		 * @since 2.4.0
 		 */
 		public function block_editor_assets() {
 			global $storefront_version;
-
-			// Styles.
-			wp_enqueue_style( 'storefront-editor-block-styles', get_theme_file_uri( '/assets/css/base/gutenberg-blocks.css' ), false, $storefront_version, 'all' );
-			wp_style_add_data( 'storefront-editor-block-styles', 'rtl', 'replace' );
 
 			// JS.
 			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			add_action( 'wp_enqueue_scripts', array( $this, 'add_customizer_css' ), 130 );
 			add_action( 'customize_controls_print_styles', array( $this, 'customizer_custom_control_css' ) );
 			add_action( 'customize_register', array( $this, 'edit_default_customizer_settings' ), 99 );
-			add_action( 'enqueue_block_editor_assets', array( $this, 'block_editor_customizer_css' ) );
+			add_action( 'enqueue_block_assets', array( $this, 'block_editor_customizer_css' ) );
 			add_action( 'init', array( $this, 'default_theme_mod_values' ), 10 );
 		}
 
@@ -922,52 +922,56 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 		public function block_editor_customizer_css() {
 			$storefront_theme_mods = $this->get_storefront_theme_mods();
 
-			$styles = '
-			.editor-styles-wrapper table th {
-				background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -7 ) . ';
-			}
+			$styles = '';
 
-			.editor-styles-wrapper table tbody td {
-				background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -2 ) . ';
-			}
+			if ( is_admin() ) {
+				$styles .= '
+				.editor-styles-wrapper table th {
+					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -7 ) . ';
+				}
 
-			.editor-styles-wrapper table tbody tr:nth-child(2n) td,
-			.editor-styles-wrapper fieldset,
-			.editor-styles-wrapper fieldset legend {
-				background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -4 ) . ';
-			}
+				.editor-styles-wrapper table tbody td {
+					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -2 ) . ';
+				}
 
-			.editor-post-title__block .editor-post-title__input,
-			.editor-styles-wrapper h1,
-			.editor-styles-wrapper h2,
-			.editor-styles-wrapper h3,
-			.editor-styles-wrapper h4,
-			.editor-styles-wrapper h5,
-			.editor-styles-wrapper h6 {
-				color: ' . $storefront_theme_mods['heading_color'] . ';
-			}
+				.editor-styles-wrapper table tbody tr:nth-child(2n) td,
+				.editor-styles-wrapper fieldset,
+				.editor-styles-wrapper fieldset legend {
+					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -4 ) . ';
+				}
 
-			.editor-styles-wrapper .editor-block-list__block {
-				color: ' . $storefront_theme_mods['text_color'] . ';
-			}
+				.editor-post-title__block .editor-post-title__input,
+				.editor-styles-wrapper h1,
+				.editor-styles-wrapper h2,
+				.editor-styles-wrapper h3,
+				.editor-styles-wrapper h4,
+				.editor-styles-wrapper h5,
+				.editor-styles-wrapper h6 {
+					color: ' . $storefront_theme_mods['heading_color'] . ';
+				}
 
-			.editor-styles-wrapper a,
-			.wp-block-freeform.block-library-rich-text__tinymce a {
-				color: ' . $storefront_theme_mods['accent_color'] . ';
-			}
+				.editor-styles-wrapper .editor-block-list__block {
+					color: ' . $storefront_theme_mods['text_color'] . ';
+				}
 
-			.editor-styles-wrapper a:focus,
-			.wp-block-freeform.block-library-rich-text__tinymce a:focus {
-				outline-color: ' . $storefront_theme_mods['accent_color'] . ';
-			}
+				.editor-styles-wrapper a,
+				.wp-block-freeform.block-library-rich-text__tinymce a {
+					color: ' . $storefront_theme_mods['accent_color'] . ';
+				}
 
-			body.post-type-post .editor-post-title__block::after {
-				content: "";
-			}';
+				.editor-styles-wrapper a:focus,
+				.wp-block-freeform.block-library-rich-text__tinymce a:focus {
+					outline-color: ' . $storefront_theme_mods['accent_color'] . ';
+				}
+
+				body.post-type-post .editor-post-title__block::after {
+					content: "";
+				}';
+			}
 
 			$styles .= $this->gutenberg_get_css();
 
-			wp_add_inline_style( 'storefront-editor-block-styles', apply_filters( 'storefront_gutenberg_block_editor_customizer_css', $styles ) );
+			wp_add_inline_style( 'storefront-gutenberg-blocks', apply_filters( 'storefront_gutenberg_block_editor_customizer_css', $styles ) );
 		}
 
 		/**
@@ -978,7 +982,6 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 		 */
 		public function add_customizer_css() {
 			wp_add_inline_style( 'storefront-style', $this->get_css() );
-			wp_add_inline_style( 'storefront-gutenberg-blocks', $this->gutenberg_get_css() );
 		}
 
 		/**


### PR DESCRIPTION
There are two Gutenberg hooks to enqueue assets, `enqueue_block_assets` (frontend + backend) and  `enqueue_block_editor_assets` (backend only).

Until now we've been enqueuing the same stylesheet in two different places and that's not really necessary.

This PR adds a new method `block_assets()` that will load the common stylesheets to both the frontend and backend. There's also a change to the `block_editor_customizer_css()` which adds a `is_admin()` conditional to ensure inline styles for the editor are not present in the frontend.

To test, first run `npm run build`. Then, check that `gutenberg-blocks.css` is loaded in the frontend and also in the Gutenberg editor.

Also check if the inline styles are conditionally loaded in the Customizer. Look for `.editor-styles-wrapper table th` (or other selectors) in the Inspector.

One way to check in the Editor is to add a table block and check if background colors are being applied:

<img width="1068" alt="Screenshot 2019-05-02 at 14 41 22" src="https://user-images.githubusercontent.com/1177726/57079514-6426fd00-6ce8-11e9-9354-3cad6456bf87.png">

Closes #1121 