### PR TITLE
Blocks homepage css customizer

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -79,19 +79,27 @@
 		margin-bottom: 0;
 
 		.entry-content {
-			> .wp-block-cover.alignfull,
-			> .wp-block-image.alignfull {
-				width: auto;
-				max-width: 1000%;
-				margin-left: calc(50% - 50vw);
-				margin-right: calc(50% - 50vw);
-				margin-top: - ms(7);
+			> .wp-block-cover,
+			> .wp-block-image {
 				margin-bottom: ms(7);
 			}
 
 			h2 + .woocommerce,
 			h2 + [class*='wp-block-woocommerce-'] {
 				margin-top: ms(4);
+			}
+		}
+	}
+}
+
+.home.storefront-align-wide.page-template-template-fullwidth {
+	.hentry {
+		.entry-content {
+			> .wp-block-cover,
+			> .wp-block-image {
+				&.alignfull {
+					margin-top: - ms(7);
+				}
 			}
 		}
 	}

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -253,7 +253,6 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 						'section'         => 'storefront_typography',
 						'settings'        => 'storefront_hero_heading_color',
 						'priority'        => 50,
-						'active_callback' => array( $this, 'is_homepage_template' ),
 					)
 				)
 			);
@@ -275,7 +274,6 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 						'section'         => 'storefront_typography',
 						'settings'        => 'storefront_hero_text_color',
 						'priority'        => 60,
-						'active_callback' => array( $this, 'is_homepage_template' ),
 					)
 				)
 			);

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -907,7 +907,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				.wp-block-cover .wp-block-cover__inner-container h4,
 				.wp-block-cover .wp-block-cover__inner-container h5,
 				.wp-block-cover .wp-block-cover__inner-container h6 {
-					color: ' . $storefront_theme_mods['hero_text_color'] . ';
+					color: ' . $storefront_theme_mods['hero_heading_color'] . ';
 				}
 			';
 


### PR DESCRIPTION
This PR:

* Updates Blocks homepage negative margin to apply only to layouts that support wide blocks.
* Updates dynamic Customizer values for Cover block headings from `hero_text_color` to `hero_heading_color`

How to test:

* Test with WordPress 5.2
* Create a new page, add a Cover block to it and a heading inside (h1, h2, ...)

Changing the color of the "Hero heading color" (Customizer > Typography) should change the color of the heading.