### PR TITLE
Fix Query Monitor missing dependency warning

### DIFF
--- a/inc/jetpack/class-storefront-jetpack.php
+++ b/inc/jetpack/class-storefront-jetpack.php
@@ -101,8 +101,10 @@ if ( ! class_exists( 'Storefront_Jetpack' ) ) :
 		public function jetpack_scripts() {
 			global $storefront_version;
 
-			wp_enqueue_style( 'storefront-jetpack-infinite-scroll', get_template_directory_uri() . '/assets/css/jetpack/infinite-scroll.css', array( 'the-neverending-homepage' ), $storefront_version );
-			wp_style_add_data( 'storefront-jetpack-infinite-scroll', 'rtl', 'replace' );
+			if ( wp_style_is( 'the-neverending-homepage', 'enqueued' ) ) {
+				wp_enqueue_style( 'storefront-jetpack-infinite-scroll', get_template_directory_uri() . '/assets/css/jetpack/infinite-scroll.css', array( 'the-neverending-homepage' ), $storefront_version );
+				wp_style_add_data( 'storefront-jetpack-infinite-scroll', 'rtl', 'replace' );
+			}
 
 			wp_enqueue_style( 'storefront-jetpack-widgets', get_template_directory_uri() . '/assets/css/jetpack/widgets.css', array(), $storefront_version );
 			wp_style_add_data( 'storefront-jetpack-widgets', 'rtl', 'replace' );


### PR DESCRIPTION
The Query Monitor plugin is currently throwing a warning when Jetpack is enabled and the Infinite Scroll module is not active, or not in an archive.

To test:

1. Install Jetpack
2. Install Query Monitor
3. Activate Jetpack and go the frontend, you should see a warning without this PR.
4. When testing with this PR, the warning should be gone.

Also, enable Infinite Scroll in Jetpack > Settings > Writing. You shouldn't see a warning. 

Go to an archive or products archive and double check that `/assets/css/jetpack/infinite-scroll.css` is being enqueued.

Closes #1126.