### PR TITLE
Fixed: Missing styling for number input type #1140

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -929,6 +929,7 @@ input::-moz-focus-inner { /* Corrects inner padding and border displayed oddly i
 }
 
 input[type='text'],
+input[type='number'],
 input[type='email'],
 input[type='tel'],
 input[type='url'],


### PR DESCRIPTION
Currently, storefront doesn't have styling for number input type. This PR adds number input selector to Form styling to fix it. Close #1140.