### PR TITLE
Price widget styling on small screens

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -935,6 +935,18 @@ a.reset_variations {
 		}
 	}
 
+	@media (min-width: $desktop) and (max-width: 1024px) {
+		.price_slider_amount {
+			text-align: left;
+
+			.button {
+				display: block;
+				float: none;
+				width: 100%;
+			}
+		}
+	}
+
 	.ui-slider {
 		position: relative;
 		text-align: left;


### PR DESCRIPTION
Styles the price filter on resolutions between 768px and 1024px.

Before:

<img width="124" alt="Screenshot 2019-05-22 at 17 50 41" src="https://user-images.githubusercontent.com/1177726/58184849-9231a880-7cba-11e9-8df5-c186340dffaa.png">

After:

<img width="144" alt="Screenshot 2019-05-22 at 17 50 23" src="https://user-images.githubusercontent.com/1177726/58184863-978ef300-7cba-11e9-8b47-c1e6e251b4df.png">

To test:

* Add the Price Filter widget to the sidebar.
* Go to the "Shop" page and resize your browser
* You should see the new styles between 768px and 1024px.