### PR TITLE
Pulling from block Editor JS module in WP 5.2

### DIFF
--- a/assets/js/src/editor.js
+++ b/assets/js/src/editor.js
@@ -69,7 +69,7 @@
 	 * @return {void}
 	 */
 	const updateAlignAttribute = ( alignWide ) => {
-		let blocks = wp.data.select( 'core/editor' ).getBlocks();
+		let blocks = wp.data.select( 'core/block-editor' ).getBlocks();
 
 		blocks.forEach( ( block ) => {
 			if ( block.attributes.hasOwnProperty( 'align' ) ) {


### PR DESCRIPTION
This PR pulls `getBlocks` from `core/block-editor` to make the call without any dependency to the post object.

More info [documented](https://make.wordpress.org/core/2019/04/09/the-block-editor-javascript-module-in-5-2/) here.