### PR TITLE
Cross-sells grid issues when customizing columns count

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -2480,16 +2480,6 @@ dl.variation {
 
 		.cross-sells {
 			@include span(4 of 9);
-
-			ul.products {
-				li.product {
-					@include span(2 of 4);
-
-					&:nth-child( 2n ) {
-						margin-right: 0 !important;
-					}
-				}
-			}
 		}
 
 		.cart_totals,
@@ -2514,12 +2504,6 @@ dl.variation {
 		.cart-collaterals {
 			.cross-sells {
 				@include span(6 of 12);
-
-				ul.products {
-					li.product {
-						@include span(3 of 6);
-					}
-				}
 			}
 
 			.cart_totals,


### PR DESCRIPTION
### Description

Storefront forces a 2-column cross-sells layout. The grid breaks when using the `woocommerce_cross_sells_columns` filter to customize the cross-sells column count. Here's what happens when we set the column count equal to 3:

<img width="1191" alt="Image 2019-05-27 at 4 30 52 p m" src="https://user-images.githubusercontent.com/1783726/58469553-6134f600-8148-11e9-95d5-41da7a509b39.png">

Ths PR removes the forced cross-sells rule and lets the core product grid styles do their job:

<img width="1048" alt="Image 2019-05-27 at 4 36 52 p m" src="https://user-images.githubusercontent.com/1783726/58469571-6abe5e00-8148-11e9-9fe9-1b2258583860.png">

closes #1149 