### PR TITLE
Fix uneven form input widths on checkout page

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -2564,11 +2564,11 @@ dl.variation {
 		@include span(5 of 9);
 
 		.form-row-first {
-			@include span(2 of 5);
+			@include span(2.5 of 5);
 		}
 
 		.form-row-last {
-			@include span(last 3 of 5);
+			@include span(last 2.5 of 5);
 		}
 
 		.col-1,


### PR DESCRIPTION
On checkout page first name and last name form inputs were of
uneven widths. Fix #1144 by making them of equal width.