### PR TITLE
Added input type styles to the 'select' type

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -935,6 +935,7 @@ input[type='tel'],
 input[type='url'],
 input[type='password'],
 input[type='search'],
+input[type='select'],
 textarea,
 .input-text {
 	padding: ms(-2);


### PR DESCRIPTION
I was recently working on a plugin that adds a select field to the Checkout form and noticed that the stylesheet doesn't have the select type added to it's CSS.

Before:

![storefront-select-before](https://user-images.githubusercontent.com/9917957/59565188-1fe48780-901e-11e9-8abf-aeaa55f5b865.jpg)

After:

![storefront-select-after](https://user-images.githubusercontent.com/9917957/59565187-19eea680-901e-11e9-8e58-c1fd0b3c0273.jpg)
