### PR TITLE
Fix floated image alignment

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -306,14 +306,16 @@
 
 	// Image
 	.wp-block-image {
-		margin-bottom: ms(2);
+		figure {
+			margin-bottom: ms(2);
+		}
 
 		.alignleft {
-			margin-right: ms(1);
+			margin-right: ms(2);
 		}
 
 		.alignright {
-			margin-left: ms(1);
+			margin-left: ms(2);
 		}
 
 		figcaption {
@@ -324,6 +326,15 @@
 		}
 	}
 
+	figure.wp-block-image {
+		margin: 0 0 ms(2);
+	}
+
+	div.wp-block-image {
+		display: inline;
+	}
+
+	// Cover
 	.wp-block-cover {
 		flex-flow: row wrap;
 		min-height: 350px;


### PR DESCRIPTION
Before:

<img width="1090" alt="Screenshot 2019-06-17 at 16 05 20" src="https://user-images.githubusercontent.com/1177726/59615464-73d49680-911a-11e9-8f84-4756c1ce9256.png">

After:

<img width="1105" alt="Screenshot 2019-06-17 at 16 04 58" src="https://user-images.githubusercontent.com/1177726/59615471-7800b400-911a-11e9-9f89-a03364c9aaff.png">

Notice how the image in the "before" screenshot is not aligned with the text.

To test:

* Create a new post/page and add a few paragraphs.
* Add an image and float it to the left/right.
* Ensure that the image aligns with the text.

Closes #1127.
