### PR TITLE
Fix cover block paragraph size and default color

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -406,11 +406,12 @@
 			}
 
 			p {
-				&:not( .has-small-font-size ),
-				&:not( .has-medium-font-size ),
-				&:not( .has-large-font-size ),
-				&:not( .has-huge-font-size ) {
+				&:not( .has-small-font-size ):not( .has-medium-font-size ):not( .has-large-font-size ):not( .has-huge-font-size ) {
 					font-size: 1.1em;
+				}
+
+				&:not( .has-text-color ) {
+					color: #fff;
 				}
 			}
 

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -182,6 +182,37 @@ if ( ! class_exists( 'Storefront' ) ) :
 			add_theme_support( 'editor-styles' );
 
 			/**
+			 * Add support for editor font sizes.
+			 */
+			add_theme_support( 'editor-font-sizes', array(
+				array(
+					'name' => __( 'Small', 'storefront' ),
+					'size' => 14,
+					'slug' => 'small',
+				),
+				array(
+					'name' => __( 'Normal', 'storefront' ),
+					'size' => 16,
+					'slug' => 'normal',
+				),
+				array(
+					'name' => __( 'Medium', 'storefront' ),
+					'size' => 23,
+					'slug' => 'medium',
+				),
+				array(
+					'name' => __( 'Large', 'storefront' ),
+					'size' => 26,
+					'slug' => 'large',
+				),
+				array(
+					'name' => __( 'Huge', 'storefront' ),
+					'size' => 37,
+					'slug' => 'huge',
+				),
+			) );
+
+			/**
 			 * Enqueue editor styles.
 			 */
 			add_editor_style( array( 'assets/css/base/gutenberg-editor.css', $this->google_fonts() ) );


### PR DESCRIPTION
This PR fixes two issues related to the cover block:

* Font size was fixed at `1.1em`
* Default paragraph color not matching frontend color

### To test:

 **Font size was fixed to `1.1em`**

* Add a cover block
* Add a paragraph inside the cover and add some text
* Default font size should be the same in the editor and frontend
* In the editor sidebar change the size of the paragraph text (Small, Medium, Large, Huge). Size should be the same in the editor and frontend.

**Default paragraph color not matching frontend color**

* Add a cover block
* Add a paragraph inside the cover and add some text
* By default the text color for paragraphs should be **white** both in the editor and then in the frontend
* In the editor sidebar change the color of the paragraph. Ensure the color changes in the editor and frontend

Closes #1153.