### PR TITLE
Fix cover block placeholder layout

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -325,9 +325,6 @@
 	}
 
 	.wp-block-cover {
-		flex-flow: row wrap;
-		min-height: 350px;
-
 		// < 5.2 styling
 		p.wp-block-cover-text {
 			font-size: ms(3);


### PR DESCRIPTION
When adding a block, the placeholder layout is currently broken.

Before:

<img width="805" alt="Screenshot 2019-06-18 at 00 26 46" src="https://user-images.githubusercontent.com/1177726/59643232-c6847180-915f-11e9-9cd4-82ad44e26267.png">

After:

<img width="803" alt="Screenshot 2019-06-18 at 00 25 52" src="https://user-images.githubusercontent.com/1177726/59643207-ad7bc080-915f-11e9-8b20-cf818fb7723d.png">

Closes #1155.