### PR TITLE
Fix separator block styles preview

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -503,6 +503,10 @@
 	.wp-block-separator {
 		border: 0;
 		margin: 0 auto ms(2);
+
+		&:not( .is-style-wide ):not( .is-style-dots ) {
+			max-width: 10%;
+		}
 	}
 
 	// Twitter Embed

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -503,6 +503,7 @@
 	.wp-block-separator {
 		border: 0;
 		margin: 0 auto ms(2);
+		overflow: hidden;
 
 		&:not( .is-style-wide ):not( .is-style-dots ) {
 			max-width: 10%;

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -340,3 +340,9 @@ ul.wp-block-latest-posts {
 	margin-right: 0;
 	list-style: none;
 }
+
+// Separator
+.wp-block-separator {
+	margin-top: ms(2);
+	margin-bottom: ms(2);
+}

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -357,4 +357,12 @@ ul.wp-block-latest-posts {
 			}
 		}
 	}
+
+	&:not( .is-style-dots ) {
+		height: 2px;
+
+		.wp-block & {
+			height: 1px;
+		}
+	}
 }

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -345,4 +345,16 @@ ul.wp-block-latest-posts {
 .wp-block-separator {
 	margin-top: ms(2);
 	margin-bottom: ms(2);
+
+	&.is-style-dots {
+		&::before {
+			padding-left: 1em;
+			letter-spacing: 1em;
+
+			.wp-block & {
+				padding-left: 2em;
+				letter-spacing: 2em;
+			}
+		}
+	}
 }


### PR DESCRIPTION
Add a "separator" block to the editor and then in the sidebar, select a different style. Currently the break line is not vertically align in the preview.

Before:

<img width="274" alt="Screenshot 2019-06-18 at 01 00 32" src="https://user-images.githubusercontent.com/1177726/59644482-fbdf8e00-9164-11e9-8653-43e16c2a7e8d.png">

After:

<img width="277" alt="Screenshot 2019-06-18 at 00 59 54" src="https://user-images.githubusercontent.com/1177726/59644473-f3875300-9164-11e9-9104-30c4fa0deaf6.png">

Closes #1156.