### PR TITLE
Fix logo image overlap on small screens

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -304,6 +304,7 @@ body {
 		margin-bottom: 0;
 
 		img {
+			width: 100%;
 			max-width: 210px;
 		}
 	}


### PR DESCRIPTION
On small screens the logo extends beyond the its container causing it to go under the mobile menu toggle.

Before:

<img width="282" alt="Screenshot 2019-06-20 at 13 24 58" src="https://user-images.githubusercontent.com/1177726/59849226-ef268a00-935e-11e9-9025-fb1487255302.png">

After:

<img width="282" alt="Screenshot 2019-06-20 at 13 26 29" src="https://user-images.githubusercontent.com/1177726/59849272-0bc2c200-935f-11e9-967d-3fe7a8152333.png">

How to test:

* Go to the Customizer and a custom logo
* Resize your browser and ensure the logo doesn't overlap

Closes #1135.