### PR TITLE
Increase shipping methods cell size

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1354,7 +1354,7 @@ form.checkout {
 
 table.woocommerce-checkout-review-order-table {
 	.product-name {
-		width: 300px;
+		width: 45%;
 		word-wrap: break-word;
 	}
 }


### PR DESCRIPTION
Changes the size of the "Product Name" section in the checkout cart table to leave more for the sipping methods.

With sidebar (before/after)

![with_sidebar](https://user-images.githubusercontent.com/1177726/59885851-9eda1700-93b4-11e9-8db4-e7b439a6abf6.png)

Full width (before/after)

![no_sidebar1](https://user-images.githubusercontent.com/1177726/59885896-c29d5d00-93b4-11e9-8efd-783252cdc0f8.png)

To test:

* Go to WooCommerce > Settings and add a few Shipping Zones/Methods
* Add a few products to the cart and proceed to the checkout
* Check the "Your order" table

Closes #1164.