### PR TITLE
Move privacy link outside credit link conditional

### DIFF
--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -134,17 +134,23 @@ if ( ! function_exists( 'storefront_credit' ) ) {
 	 * @return void
 	 */
 	function storefront_credit() {
+		$links_output = '';
+
+		if ( apply_filters( 'storefront_credit_link', true ) ) {
+			$links_output .= '<a href="https://woocommerce.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="author">' . esc_html__( 'Built with Storefront &amp; WooCommerce', 'storefront' ) . '</a>.';
+		}
+
+		if ( apply_filters( 'storefront_privacy_policy_link', true ) && function_exists( 'the_privacy_policy_link' ) ) {
+			$separator = '<span role="separator" aria-hidden="true"></span>';
+			$links_output = get_the_privacy_policy_link( '', ( ! empty( $links_output ) ? $separator : '' ) ) . $links_output;
+		}
 		?>
 		<div class="site-info">
 			<?php echo esc_html( apply_filters( 'storefront_copyright_text', $content = '&copy; ' . get_bloginfo( 'name' ) . ' ' . date( 'Y' ) ) ); ?>
-			<?php if ( apply_filters( 'storefront_credit_link', true ) ) { ?>
-			<br />
-				<?php
-				if ( apply_filters( 'storefront_privacy_policy_link', true ) && function_exists( 'the_privacy_policy_link' ) ) {
-					the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
-				}
-				?>
-				<?php echo '<a href="https://woocommerce.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="author">' . esc_html__( 'Built with Storefront &amp; WooCommerce', 'storefront' ) . '</a>.'; ?>
+
+			<?php if ( ! empty( $links_output ) ) { ?>
+				<br />
+				<?php echo wp_kses_post( $links_output ); ?>
 			<?php } ?>
 		</div><!-- .site-info -->
 		<?php


### PR DESCRIPTION
Right now it is not possible to remove the Storefront credits link in the footer without also removing the privacy link.

This PR separates separates both pieces so that they can be toggled on/off independently. It also adds a bit of extra logic in case there's no credit link, in that case we don't want the separator ` |  ` to show up.

To test, try to toggle the filters on/off and see if everything displays as expected:

```
add_filter( 'storefront_credit_link', '__return_false' );
```

```
add_filter( 'storefront_privacy_policy_link', '__return_false' );
```

Closes #1175.
