### PR TITLE
Move calls to storefront_credit filters to their rendering location

### DIFF
--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -134,24 +134,26 @@ if ( ! function_exists( 'storefront_credit' ) ) {
 	 * @return void
 	 */
 	function storefront_credit() {
-		$links_output = '';
-
-		if ( apply_filters( 'storefront_credit_link', true ) ) {
-			$links_output .= '<a href="https://woocommerce.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="author">' . esc_html__( 'Built with Storefront &amp; WooCommerce', 'storefront' ) . '</a>.';
-		}
-
-		if ( apply_filters( 'storefront_privacy_policy_link', true ) && function_exists( 'the_privacy_policy_link' ) ) {
-			$separator = '<span role="separator" aria-hidden="true"></span>';
-			$links_output = get_the_privacy_policy_link( '', ( ! empty( $links_output ) ? $separator : '' ) ) . $links_output;
-		}
 		?>
 		<div class="site-info">
 			<?php echo esc_html( apply_filters( 'storefront_copyright_text', $content = '&copy; ' . get_bloginfo( 'name' ) . ' ' . date( 'Y' ) ) ); ?>
 
-			<?php if ( ! empty( $links_output ) ) { ?>
-				<br />
-				<?php echo wp_kses_post( $links_output ); ?>
-			<?php } ?>
+			<div>
+				<?php
+				$links_output = '';
+
+				if ( apply_filters( 'storefront_credit_link', true ) ) {
+					$links_output .= '<a href="https://woocommerce.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="author">' . esc_html__( 'Built with Storefront &amp; WooCommerce', 'storefront' ) . '</a>.';
+				}
+
+				if ( apply_filters( 'storefront_privacy_policy_link', true ) && function_exists( 'the_privacy_policy_link' ) ) {
+					$separator = '<span role="separator" aria-hidden="true"></span>';
+					$links_output = get_the_privacy_policy_link( '', ( ! empty( $links_output ) ? $separator : '' ) ) . $links_output;
+				}
+
+				echo wp_kses_post( $links_output );
+				?>
+			</div>
 		</div><!-- .site-info -->
 		<?php
 	}


### PR DESCRIPTION
Fixes #1182

This moves the calls to the `storefront_credit_link` and `storefront_privacy_policy_link` filters back inside the `.site-info` div, so those filters are called at the location where they are rendered.

This keeps the separation of the filters introduced in #1178 while also preserving the usage of _adding_ content to this location by `echo`ing it from one of the filters.

I had to replace the `<br />` linebreak with a `<div>`, because the linebreak would have always be rendered after the filter call. The DIV has the same functionality here (breaking into a new line) and does not take up space when both filters are disabled (it just becomes a zero-height DIV then).