### PR TITLE
Introduce extra block styles

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -848,13 +848,20 @@ textarea {
 	/* stylelint-enable */
 }
 
+/* Override gutenberg styles. */
+.wp-block-button__link {
+	border-radius: 0 !important;
+}
+
 button,
 input[type='button'],
 input[type='reset'],
 input[type='submit'],
 .button,
+.wc-block-grid__products .wc-block-grid__product .wp-block-button__link,
 .added_to_cart {
 	border: 0;
+	border-radius: 0;
 	background: none;
 	background-color: $color_body;
 	border-color: $color_body;
@@ -866,7 +873,10 @@ input[type='submit'],
 	text-shadow: none;
 	display: inline-block;
 	-webkit-appearance: none;
-	border-radius: 0;
+
+	&::after {
+		display: none;
+	}
 
 	&.cta,
 	&.alt {

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -387,5 +387,10 @@ ul.wp-block-latest-posts {
 			border-radius: 3px;
 			position: relative;
 		}
+		.wc-block-grid__product-title {
+			font-weight: 400;
+			font-size: 1rem;
+			color: #000000;
+		}
 	}
 }

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -366,3 +366,26 @@ ul.wp-block-latest-posts {
 		}
 	}
 }
+
+// Grid blocks
+.wc-block-grid__products {
+	.wc-block-grid__product {
+		.wp-block-button__link {
+			color: #333333;
+		}
+		.wc-block-grid__product-onsale {
+			border: 1px solid;
+			border-color: $color_body;
+			color: $color_body;
+			background: transparent;
+			padding: 0.202em ms(-2);
+			font-size: ms(-1);
+			text-transform: uppercase;
+			font-weight: 600;
+			display: inline-block;
+			margin-bottom: 1em;
+			border-radius: 3px;
+			position: relative;
+		}
+	}
+}

--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -88,6 +88,7 @@ input[type='button'],
 input[type='reset'],
 input[type='submit'],
 .button,
+.wc-block-grid__products .wc-block-grid__product .wp-block-button__link,
 .added_to_cart {
 	&.loading {
 		position: relative;
@@ -105,6 +106,7 @@ input[type='submit'],
 			left: 50%;
 			margin-left: -10px;
 			margin-top: -10px;
+			display: block;
 		}
 	}
 }

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -296,13 +296,15 @@ table.shop_table_responsive {
 /**
  * Products
  */
-ul.products {
+ul.products,
+.wc-block-grid__products {
 	margin-left: 0;
 	margin-bottom: 0;
 	clear: both;
 	@include clearfix;
 
-	li.product {
+	li.product,
+	.wc-block-grid__product {
 		list-style: none;
 		margin-left: 0;
 		margin-bottom: ms(7);
@@ -331,7 +333,8 @@ ul.products {
 
 		h2, // @todo Remove when WooCommerce 2.8 is live
 		h3, // @todo Remove when WooCommerce 2.8 is live
-		.woocommerce-loop-product__title {
+		.woocommerce-loop-product__title,
+		.wc-block-grid__product-title {
 			font-size: 1rem;
 			font-weight: 400;
 			margin-bottom: ms(-3);
@@ -365,11 +368,10 @@ ul.products {
 }
 
 .hentry .entry-content {
-	ul.products {
-		li.product {
-			> a {
-				text-decoration: none;
-			}
+	.wc-block-grid__products .wc-block-grid__product,
+	ul.products li.product {
+		> a {
+			text-decoration: none;
 		}
 	}
 }
@@ -1705,10 +1707,12 @@ p.stars {
 	}
 }
 
+.wc-block-grid__product-onsale,
 .onsale {
 	border: 1px solid;
 	border-color: $color_body;
 	color: $color_body;
+	background: transparent;
 	padding: 0.202em ms(-2);
 	font-size: ms(-1);
 	text-transform: uppercase;
@@ -1716,6 +1720,7 @@ p.stars {
 	display: inline-block;
 	margin-bottom: 1em;
 	border-radius: 3px;
+	position: relative;
 }
 
 .quantity {
@@ -2059,8 +2064,10 @@ dl.variation {
 	/**
 	 * Reset mobile product styles
 	 */
-	ul.products {
-		li.product {
+	ul.products,
+	.wc-block-grid__products {
+		li.product,
+		.wc-block-grid__product {
 			clear: none;
 			width: 100%;
 			float: left;

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -707,7 +707,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				background-color: ' . $storefront_theme_mods['header_link_color'] . ';
 			}
 
-			h1, h2, h3, h4, h5, h6 {
+			h1, h2, h3, h4, h5, h6, .wc-block-grid__product-title {
 				color: ' . $storefront_theme_mods['heading_color'] . ';
 			}
 

--- a/inc/woocommerce/class-storefront-woocommerce-customizer.php
+++ b/inc/woocommerce/class-storefront-woocommerce-customizer.php
@@ -134,6 +134,7 @@ if ( ! class_exists( 'Storefront_WooCommerce_Customizer' ) ) :
 			.woocommerce-tabs ul.tabs li.active a,
 			ul.products li.product .price,
 			.onsale,
+			.wc-block-grid__product-onsale,
 			.widget_search form:before,
 			.widget_product_search form:before {
 				color: ' . $storefront_theme_mods['text_color'] . ';
@@ -145,6 +146,7 @@ if ( ! class_exists( 'Storefront_WooCommerce_Customizer' ) ) :
 				color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['text_color'], 5 ) . ';
 			}
 
+			.wc-block-grid__product-onsale,
 			.onsale {
 				border-color: ' . $storefront_theme_mods['text_color'] . ';
 			}
@@ -198,6 +200,7 @@ if ( ! class_exists( 'Storefront_WooCommerce_Customizer' ) ) :
 				color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['text_color'], -10 ) . ';
 			}
 
+			.wc-block-grid__product-onsale,
 			.onsale,
 			.woocommerce-pagination .page-numbers li .page-numbers:not(.current) {
 				color: ' . $storefront_theme_mods['text_color'] . ';
@@ -232,13 +235,17 @@ if ( ! class_exists( 'Storefront_WooCommerce_Customizer' ) ) :
 				outline-color: ' . $storefront_theme_mods['accent_color'] . ';
 			}
 
-			.added_to_cart, .site-header-cart .widget_shopping_cart a.button {
+			.added_to_cart,
+			.site-header-cart .widget_shopping_cart a.button,
+			.wc-block-grid__products .wc-block-grid__product .wp-block-button__link {
 				background-color: ' . $storefront_theme_mods['button_background_color'] . ';
 				border-color: ' . $storefront_theme_mods['button_background_color'] . ';
 				color: ' . $storefront_theme_mods['button_text_color'] . ';
 			}
 
-			.added_to_cart:hover, .site-header-cart .widget_shopping_cart a.button:hover {
+			.added_to_cart:hover,
+			.site-header-cart .widget_shopping_cart a.button:hover,
+			.wc-block-grid__products .wc-block-grid__product .wp-block-button__link:hover {
 				background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_background_color'], $darken_factor ) . ';
 				border-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_background_color'], $darken_factor ) . ';
 				color: ' . $storefront_theme_mods['button_text_color'] . ';


### PR DESCRIPTION
Adds extra style rules targeting the new markup within blocks. This also fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/795.

Requires https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/796 which reduces CSS specificity to allow these rules to take precedence. 

Before:
![Screenshot 2019-08-02 at 12 47 36](https://user-images.githubusercontent.com/90977/62368191-d1367280-b523-11e9-8208-10d9687f7432.png)

After:
![Screenshot 2019-08-02 at 12 48 12](https://user-images.githubusercontent.com/90977/62368188-cf6caf00-b523-11e9-84e3-4dba70d1b0df.png)

Not sure who is managing SF to review @peterfabian.
