### PR TITLE
Make notices conform to new theme rules

### DIFF
--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -15,7 +15,7 @@
 	}
 
 	.notice-content {
-		margin: 19px 0 20px 0;
+		margin: 19px 0 20px;
 	}
 
 	.sf-icon {

--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -99,6 +99,10 @@
 		&:hover {
 			color: #00a0d2;
 		}
+
+		&:focus {
+			color: #00a0d2;
+		}
 	}
 }
 

--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -27,6 +27,7 @@
 		background: #fff;
 		border-radius: 100%;
 		margin: 20px 17px 20px 5px;
+		flex-shrink: 0;
 
 		img {
 			position: absolute;

--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -54,11 +54,15 @@
 
 	label {
 		display: block;
-		margin-bottom: 8px;
+		margin-top: 0.5em;
 		text-align: left;
 
+		&:first-of-type {
+			margin-top: 0.8em;
+		}
+
 		&:last-of-type {
-			margin-bottom: 2em;
+			margin-bottom: 0.5em;
 		}
 	}
 
@@ -76,6 +80,21 @@
 		box-shadow: initial;
 		color: #0073aa;
 		line-height: initial;
+
+		&:hover {
+			color: #00a0d2;
+		}
+	}
+
+	.sf-nux-button {
+		border: 0;
+		background: initial;
+		text-decoration: underline;
+		color: #0073aa;
+		margin: 5px 0 0;
+		padding: 0;
+		font-size: inherit;
+		cursor: pointer;
 
 		&:hover {
 			color: #00a0d2;

--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -63,7 +63,7 @@
 		}
 
 		&:last-of-type {
-			margin-bottom: 0.5em;
+			margin-bottom: 0.2em;
 		}
 	}
 

--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -129,7 +129,7 @@
 		}
 
 		form {
-			margin-top: 30px;
+			margin-top: 5px;
 		}
 
 		label {

--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -1,12 +1,8 @@
 @import 'buttons';
 
 .sf-notice-nux {
-	background: #e9eff3;
-	border: 10px solid #fff;
-	color: #608299;
-	padding: 60px;
-	text-align: center;
-	box-shadow: none;
+	background: #e7f5f9;
+	display: flex;
 
 	&::before,
 	&::after {
@@ -19,18 +15,17 @@
 	}
 
 	.notice-content {
-		max-width: 420px;
-		margin: 0 auto;
+		margin: 19px 0 20px 0;
 	}
 
 	.sf-icon {
 		position: relative;
 		display: block;
-		width: 100px;
-		height: 100px;
+		width: 75px;
+		height: 75px;
 		background: #fff;
 		border-radius: 100%;
-		margin: 0 auto 30px;
+		margin: 20px 12px 20px 0;
 
 		img {
 			position: absolute;
@@ -39,7 +34,7 @@
 			left: 0;
 			right: 0;
 			margin: auto;
-			padding: 16px;
+			padding: 10px;
 			box-sizing: border-box;
 			max-width: 100%;
 		}
@@ -47,14 +42,13 @@
 
 	h2 {
 		margin: 0 0 10px;
-		font-weight: normal;
+		font-weight: bolder;
 		color: #2e4453;
 	}
 
 	p {
-		margin: 0 0 2em;
+		margin: 0;
 		padding: 0;
-		line-height: 1.6;
 	}
 
 	label {
@@ -91,6 +85,7 @@
 		.sf-icon {
 			width: 65px;
 			height: 65px;
+			flex-shrink: 0;
 
 			img {
 				padding: 10px;

--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -65,6 +65,22 @@
 	.sf-plugin-card {
 		display: block;
 	}
+
+	a.sf-install-now.install-woocommerce.activate-now.button-primary {
+		background: initial;
+		border: none;
+		text-shadow: none;
+		text-decoration: underline;
+		display: initial;
+		padding: 0;
+		box-shadow: initial;
+		color: #0073aa;
+		line-height: initial;
+
+		&:hover {
+			color: #00a0d2;
+		}
+	}
 }
 
 .sf-nux-button {

--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -3,6 +3,7 @@
 .sf-notice-nux {
 	background: #e7f5f9;
 	display: flex;
+	align-items: center;
 
 	&::before,
 	&::after {
@@ -15,17 +16,17 @@
 	}
 
 	.notice-content {
-		margin: 19px 0 20px;
+		margin: 22px 0 23px;
 	}
 
 	.sf-icon {
 		position: relative;
 		display: block;
-		width: 75px;
-		height: 75px;
+		width: 70px;
+		height: 70px;
 		background: #fff;
 		border-radius: 100%;
-		margin: 20px 12px 20px 0;
+		margin: 20px 17px 20px 5px;
 
 		img {
 			position: absolute;
@@ -34,7 +35,7 @@
 			left: 0;
 			right: 0;
 			margin: auto;
-			padding: 10px;
+			padding: 12px;
 			box-sizing: border-box;
 			max-width: 100%;
 		}

--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -138,8 +138,12 @@
 		}
 
 		label {
+			&:first-of-type {
+				margin-top: 1.5em;
+			}
+
 			&:last-of-type {
-				margin-top: 20px;
+				margin: 20px 0;
 			}
 		}
 	}

--- a/assets/css/admin/buttons.scss
+++ b/assets/css/admin/buttons.scss
@@ -1,3 +1,5 @@
+@import 'bourbon';
+
 .sf-nux .sf-nux-button,
 a.sf-nux-button {
 	background: #00aadc;

--- a/assets/js/admin/plugin-install.js
+++ b/assets/js/admin/plugin-install.js
@@ -33,6 +33,13 @@
 				} );
 			}
 
+			$( document ).on( 'wp-plugin-install-success', function() {
+				setTimeout( function() {
+					var $message = $( '.sf-install-now.activate-now' );
+					$message.removeClass( 'button-primary' );
+				}, 1050 );
+			} );
+
 			wp.updates.installPlugin( {
 				slug: $button.data( 'slug' )
 			} );

--- a/assets/js/admin/plugin-install.js
+++ b/assets/js/admin/plugin-install.js
@@ -33,13 +33,6 @@
 				} );
 			}
 
-			$( document ).on( 'wp-plugin-install-success', function() {
-				setTimeout( function() {
-					var $message = $( '.sf-install-now.activate-now' );
-					$message.removeClass( 'button-primary' );
-				}, 1050 );
-			} );
-
 			wp.updates.installPlugin( {
 				slug: $button.data( 'slug' )
 			} );

--- a/inc/admin/class-storefront-plugin-install.php
+++ b/inc/admin/class-storefront-plugin-install.php
@@ -108,10 +108,10 @@ if ( ! class_exists( 'Storefront_Plugin_Install' ) ) :
 				$button['classes'] = implode( ' ', $button['classes'] );
 
 				?>
-				<span class="sf-plugin-card plugin-card-<?php echo esc_attr( $plugin_slug ); ?>">
+				<span class="plugin-card-<?php echo esc_attr( $plugin_slug ); ?>">
 					<a href="<?php echo esc_url( $button['url'] ); ?>" class="<?php echo esc_attr( $button['classes'] ); ?>" data-originaltext="<?php echo esc_attr( $button['message'] ); ?>" data-name="<?php echo esc_attr( $plugin_name ); ?>" data-slug="<?php echo esc_attr( $plugin_slug ); ?>" aria-label="<?php echo esc_attr( $button['message'] ); ?>"><?php echo esc_attr( $button['message'] ); ?></a>
-				</span>
-				<a href="https://wordpress.org/plugins/<?php echo esc_attr( $plugin_slug ); ?>" target="_blank"><?php esc_attr_e( 'Learn more', 'storefront' ); ?></a>
+				</span> or
+				<a href="https://wordpress.org/plugins/<?php echo esc_attr( $plugin_slug ); ?>" target="_blank"><?php esc_attr_e( 'learn more', 'storefront' ); ?></a>
 				<?php
 			}
 		}

--- a/inc/admin/class-storefront-plugin-install.php
+++ b/inc/admin/class-storefront-plugin-install.php
@@ -74,7 +74,7 @@ if ( ! class_exists( 'Storefront_Plugin_Install' ) ) :
 					$button = array(
 						'message' => esc_attr__( 'Activate', 'storefront' ),
 						'url'     => $url,
-						'classes' => array( 'storefront-button', 'activate-now' ),
+						'classes' => array( 'activate-now' ),
 					);
 
 					if ( '' !== $activate ) {
@@ -93,7 +93,7 @@ if ( ! class_exists( 'Storefront_Plugin_Install' ) ) :
 					$button = array(
 						'message' => esc_attr__( 'Install now', 'storefront' ),
 						'url'     => $url,
-						'classes' => array( 'storefront-button', 'sf-install-now', 'install-now', 'install-' . $plugin_slug ),
+						'classes' => array( 'sf-install-now', 'install-now', 'install-' . $plugin_slug ),
 					);
 
 					if ( '' !== $install ) {

--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -67,10 +67,7 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 				return;
 			}
 
-			// Coming from the WooCommerce Wizard?
-			if ( wp_get_referer() && 'index.php?page=wc-setup&step=next_steps' === basename( wp_get_referer() ) && 'post-new.php' === $pagenow ) {
-				return;
-			}
+			if ( ! storefront_is_woocommerce_activated() && current_user_can( 'install_plugins' ) && current_user_can( 'activate_plugins' ) ) {
 			?>
 
 			<div class="notice notice-info sf-notice-nux is-dismissible">
@@ -79,14 +76,13 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 				</span>
 
 				<div class="notice-content">
-				<?php if ( ! storefront_is_woocommerce_activated() && current_user_can( 'install_plugins' ) && current_user_can( 'activate_plugins' ) ) : ?>
 					<h2><?php esc_attr_e( 'Thanks for installing Storefront, you rock! 🤘', 'storefront' ); ?></h2>
 					<p><?php esc_attr_e( 'To enable eCommerce features you need to install the WooCommerce plugin.', 'storefront' ); ?></p>
 					<p><?php Storefront_Plugin_Install::install_plugin_button( 'woocommerce', 'woocommerce.php', 'WooCommerce', array(), __( 'WooCommerce activated', 'storefront' ), __( 'Activate WooCommerce', 'storefront' ), __( 'Install WooCommerce', 'storefront' ) ); ?></p>
-				<?php endif; ?>
 				</div>
 			</div>
 			<?php
+			}
 		}
 
 		/**

--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -84,53 +84,6 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 					<p><?php esc_attr_e( 'To enable eCommerce features you need to install the WooCommerce plugin.', 'storefront' ); ?></p>
 					<p><?php Storefront_Plugin_Install::install_plugin_button( 'woocommerce', 'woocommerce.php', 'WooCommerce', array( 'sf-nux-button' ), __( 'WooCommerce activated', 'storefront' ), __( 'Activate WooCommerce', 'storefront' ), __( 'Install WooCommerce', 'storefront' ) ); ?></p>
 				<?php endif; ?>
-
-				<?php if ( storefront_is_woocommerce_activated() ) : ?>
-					<h2><?php esc_html_e( 'Design your store 🎨', 'storefront' ); ?></h2>
-					<p>
-					<?php
-					if ( true === (bool) get_option( 'storefront_nux_fresh_site' ) && 'post-new.php' === $pagenow ) {
-						echo esc_attr__( 'Before you add your first product let\'s design your store. We\'ll add some example products for you. When you\'re ready let\'s get started by adding your logo.', 'storefront' );
-					} else {
-						echo esc_attr__( 'You\'ve set up WooCommerce, now it\'s time to give it some style! Let\'s get started by entering the Customizer and adding your logo.', 'storefront' );
-					}
-					?>
-					</p>
-					<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
-						<input type="hidden" name="action" value="storefront_starter_content">
-						<?php wp_nonce_field( 'storefront_starter_content' ); ?>
-
-						<?php if ( true === (bool) get_option( 'storefront_nux_fresh_site' ) ) : ?>
-							<input type="hidden" name="homepage" value="on">
-						<?php endif; ?>
-
-						<?php if ( true === (bool) get_option( 'storefront_nux_fresh_site' ) && true === $this->_is_woocommerce_empty() ) : ?>
-							<input type="hidden" name="products" value="on">
-						<?php endif; ?>
-
-						<?php if ( false === (bool) get_option( 'storefront_nux_fresh_site' ) ) : ?>
-							<label>
-								<input type="checkbox" name="homepage" checked>
-								<?php
-								if ( 'page' === get_option( 'show_on_front' ) ) {
-									esc_attr_e( 'Apply the Storefront homepage template', 'storefront' );
-								} else {
-									esc_attr_e( 'Create a homepage using Storefront\'s homepage template', 'storefront' );
-								}
-								?>
-							</label>
-
-							<?php if ( true === $this->_is_woocommerce_empty() ) : ?>
-							<label>
-								<input type="checkbox" name="products" checked>
-								<?php esc_attr_e( 'Add example products', 'storefront' ); ?>
-							</label>
-							<?php endif; ?>
-						<?php endif; ?>
-
-						<input type="submit" name="storefront-guided-tour" class="sf-nux-button" value="<?php esc_attr_e( 'Let\'s go!', 'storefront' ); ?>">
-					</form>
-				<?php endif; ?>
 				</div>
 			</div>
 			<?php

--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -216,34 +216,6 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 		}
 
 		/**
-		 * Check if WooCommerce is installed.
-		 *
-		 * @since 2.2.0
-		 */
-		private function _is_woocommerce_installed() {
-			if ( file_exists( WP_PLUGIN_DIR . '/woocommerce' ) ) {
-				$plugins = get_plugins( '/woocommerce' );
-
-				if ( ! empty( $plugins ) ) {
-					$keys        = array_keys( $plugins );
-					$plugin_file = 'woocommerce/' . $keys[0];
-					$url         = wp_nonce_url(
-						add_query_arg(
-							array(
-								'action' => 'activate',
-								'plugin' => $plugin_file,
-							), admin_url( 'plugins.php' )
-						), 'activate-plugin_' . $plugin_file
-					);
-
-					return $url;
-				}
-			}
-
-			return false;
-		}
-
-		/**
 		 * Set WooCommerce pages to use the full width template.
 		 *
 		 * @since 2.2.0
@@ -270,22 +242,6 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 			}
 
 			update_post_meta( $page_id, '_wp_page_template', $template );
-		}
-
-		/**
-		 * Check if WooCommerce is empty.
-		 *
-		 * @since 2.2.0
-		 * @return bool
-		 */
-		private function _is_woocommerce_empty() {
-			$products = wp_count_posts( 'product' );
-
-			if ( 0 < $products->publish ) {
-				return false;
-			}
-
-			return true;
 		}
 	}
 

--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -67,7 +67,10 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 				return;
 			}
 
-			if ( ! storefront_is_woocommerce_activated() && current_user_can( 'install_plugins' ) && current_user_can( 'activate_plugins' ) ) {
+			// Coming from the WooCommerce Wizard?
+			if ( wp_get_referer() && 0 === strpos( basename( wp_get_referer() ), 'index.php?page=wc-setup' ) && 'post-new.php' === $pagenow ) {
+				return;
+			}
 			?>
 
 			<div class="notice notice-info sf-notice-nux is-dismissible">
@@ -76,13 +79,61 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 				</span>
 
 				<div class="notice-content">
-					<h2><?php esc_attr_e( 'Thanks for installing Storefront, you rock! 🤘', 'storefront' ); ?></h2>
-					<p><?php esc_attr_e( 'To enable eCommerce features you need to install the WooCommerce plugin.', 'storefront' ); ?></p>
-					<p><?php Storefront_Plugin_Install::install_plugin_button( 'woocommerce', 'woocommerce.php', 'WooCommerce', array(), __( 'WooCommerce activated', 'storefront' ), __( 'Activate WooCommerce', 'storefront' ), __( 'Install WooCommerce', 'storefront' ) ); ?></p>
+					<?php if ( ! storefront_is_woocommerce_activated() && current_user_can( 'install_plugins' ) && current_user_can( 'activate_plugins' ) ) : ?>
+						<h2><?php esc_attr_e( 'Thanks for installing Storefront, you rock! 🤘', 'storefront' ); ?></h2>
+						<p><?php esc_attr_e( 'To enable eCommerce features you need to install the WooCommerce plugin.', 'storefront' ); ?></p>
+						<p><?php Storefront_Plugin_Install::install_plugin_button( 'woocommerce', 'woocommerce.php', 'WooCommerce', array(), __( 'WooCommerce activated', 'storefront' ), __( 'Activate WooCommerce', 'storefront' ), __( 'Install WooCommerce', 'storefront' ) ); ?></p>
+					<?php endif; ?>
+
+					<?php if ( storefront_is_woocommerce_activated() ) : ?>
+						<h2><?php esc_html_e( 'Design your store 🎨', 'storefront' ); ?></h2>
+						<p>
+							<?php
+							if ( true === (bool) get_option( 'storefront_nux_fresh_site' ) && 'post-new.php' === $pagenow ) {
+								echo esc_attr__( 'Before you add your first product let\'s design your store. We\'ll add some example products for you. When you\'re ready let\'s get started by adding your logo.', 'storefront' );
+							} else {
+								echo esc_attr__( 'You\'ve set up WooCommerce, now it\'s time to give it some style! Let\'s get started by entering the Customizer and adding your logo.', 'storefront' );
+							}
+							?>
+						</p>
+						<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+							<input type="hidden" name="action" value="storefront_starter_content">
+							<?php wp_nonce_field( 'storefront_starter_content' ); ?>
+
+							<?php if ( true === (bool) get_option( 'storefront_nux_fresh_site' ) ) : ?>
+								<input type="hidden" name="homepage" value="on">
+							<?php endif; ?>
+
+							<?php if ( true === (bool) get_option( 'storefront_nux_fresh_site' ) && true === $this->_is_woocommerce_empty() ) : ?>
+								<input type="hidden" name="products" value="on">
+							<?php endif; ?>
+
+							<?php if ( false === (bool) get_option( 'storefront_nux_fresh_site' ) ) : ?>
+								<label>
+									<input type="checkbox" name="homepage" checked>
+									<?php
+									if ( 'page' === get_option( 'show_on_front' ) ) {
+										esc_attr_e( 'Apply the Storefront homepage template', 'storefront' );
+									} else {
+										esc_attr_e( 'Create a homepage using Storefront\'s homepage template', 'storefront' );
+									}
+									?>
+								</label>
+
+								<?php if ( true === $this->_is_woocommerce_empty() ) : ?>
+									<label>
+										<input type="checkbox" name="products" checked>
+										<?php esc_attr_e( 'Add example products', 'storefront' ); ?>
+									</label>
+								<?php endif; ?>
+							<?php endif; ?>
+
+							<input type="submit" name="storefront-guided-tour" class="sf-nux-button" value="<?php esc_attr_e( 'Let\'s go!', 'storefront' ); ?>">
+						</form>
+					<?php endif; ?>
 				</div>
 			</div>
 			<?php
-			}
 		}
 
 		/**
@@ -238,6 +289,22 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 			}
 
 			update_post_meta( $page_id, '_wp_page_template', $template );
+		}
+
+		/**
+		 * Check if WooCommerce is empty.
+		 *
+		 * @since 2.2.0
+		 * @return bool
+		 */
+		private function _is_woocommerce_empty() {
+			$products = wp_count_posts( 'product' );
+
+			if ( 0 < $products->publish ) {
+				return false;
+			}
+
+			return true;
 		}
 	}
 

--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -82,7 +82,7 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 				<?php if ( ! storefront_is_woocommerce_activated() && current_user_can( 'install_plugins' ) && current_user_can( 'activate_plugins' ) ) : ?>
 					<h2><?php esc_attr_e( 'Thanks for installing Storefront, you rock! 🤘', 'storefront' ); ?></h2>
 					<p><?php esc_attr_e( 'To enable eCommerce features you need to install the WooCommerce plugin.', 'storefront' ); ?></p>
-					<p><?php Storefront_Plugin_Install::install_plugin_button( 'woocommerce', 'woocommerce.php', 'WooCommerce', array( 'sf-nux-button' ), __( 'WooCommerce activated', 'storefront' ), __( 'Activate WooCommerce', 'storefront' ), __( 'Install WooCommerce', 'storefront' ) ); ?></p>
+					<p><?php Storefront_Plugin_Install::install_plugin_button( 'woocommerce', 'woocommerce.php', 'WooCommerce', array(), __( 'WooCommerce activated', 'storefront' ), __( 'Activate WooCommerce', 'storefront' ), __( 'Install WooCommerce', 'storefront' ) ); ?></p>
 				<?php endif; ?>
 				</div>
 			</div>


### PR DESCRIPTION
This PR introduces a couple of changes:
- redesigned the Install WC notice to look ± as design from p7bje6-1pr-p2
- removed unused functions

Side by side browser rendering vs design:
![Screenshot 2019-08-02 at 16 45 02](https://user-images.githubusercontent.com/2207451/62386326-c8f82a80-b557-11e9-85bd-75975c70afd4.png)

'Design your store' notice updates:
![Screenshot 2019-08-06 at 18 28 02](https://user-images.githubusercontent.com/2207451/62558224-e7706580-b878-11e9-98a0-1892e9c6d7b3.png)

![Screenshot 2019-08-06 at 18 25 22](https://user-images.githubusercontent.com/2207451/62558228-eb03ec80-b878-11e9-8118-6b0a5b960d95.png)


### TODO: 
- [x] JS part is wonky, not sure how to prevent adding `button-primary` class to the link when the `Installing` changes into `Activate` (Update: fixed it by overriding style for `button-primary` in CSS)
- [x] Maybe WC installed but not activated will still give option to Install WC, but that's not a new problem (Update: nope, it's actually smart and the code checks for that already)

### Testing instructions:
1. Install Storefront on a clean WP without WC, it should show notice that allows user to install WC. Check the notice design in different widths of viewport, i.e. mobile/desktop mode.
2. Test WC installation and Activation via the notice.
3. Test that 'Design your store' notice appears after going through the WC OBW. Check the notice in mobile and desktop layout.
4. Test that `Let's go` link takes you to the customizer and tour through customizer works correctly.
6. Test dismissing of the notice.
7. Test that 'Design your store' notice is displayed when WC is installed and Storefront is installed afterwards. 
 i. if you go through the WC OBW, it should show checkboxes that allow adding dummy content and Storefront homepage.
 ii. if you dismiss OBW, it shows no checkboxes.
