### PR TITLE
Override content:'' from included clearfix to none.

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -303,6 +303,11 @@ ul.products,
 	clear: both;
 	@include clearfix;
 
+	// Override content from included clearfix. See https://github.com/woocommerce/storefront/issues/1197.
+	&::before {
+		content: none;
+	}
+
 	li.product,
 	.wc-block-grid__product {
 		list-style: none;


### PR DESCRIPTION
We were including `content: ''` from `@include clearfix;` which was causing issues in Safari. Adding a rule to override the specific rule which was causing issues.

Fixes https://github.com/woocommerce/storefront/issues/1197.