### PR TITLE
Prevent indexing of add to cart link

### DIFF
--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -788,7 +788,7 @@ if ( ! function_exists( 'storefront_sticky_single_add_to_cart' ) ) {
 							<span class="storefront-sticky-add-to-cart__content-price"><?php echo wp_kses_post( $product->get_price_html() ); ?></span>
 							<?php echo wp_kses_post( wc_get_rating_html( $product->get_average_rating() ) ); ?>
 						</div>
-						<a href="<?php echo esc_url( $product->add_to_cart_url() ); ?>" class="storefront-sticky-add-to-cart__content-button button alt">
+						<a href="<?php echo esc_url( $product->add_to_cart_url() ); ?>" class="storefront-sticky-add-to-cart__content-button button alt" rel="nofollow">
 							<?php echo esc_attr( $product->add_to_cart_text() ); ?>
 						</a>
 					</div>


### PR DESCRIPTION
Search engines are indexing the add to cart link from this tag. This doesn't occur within Woocommerce as an <a> tag isn't used for the button.