### PR TITLE
Make skip-link focusable, keyboard accessibility

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -520,6 +520,10 @@ body {
 	z-index: 100000; /* Above WP toolbar */
 	outline: none;
 }
+	
+.screen-reader-text.skip-link:focus {
+	clip-path: none;
+}
 
 /**
  * Clearing


### PR DESCRIPTION
This is a simple patch. Removing `clip-path` on focus fixes the issue.

We don't want ***all*** `.screen-reader-text` to be visible on focus, but we do want `.screen-reader-text.skip-link` to be visible.
