### PR TITLE
Fix Products grid overflowing on Webkit browsers

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -296,12 +296,15 @@ table.shop_table_responsive {
 /**
  * Products
  */
+ul.products {
+	@include clearfix;
+}
+
 ul.products,
 .wc-block-grid__products {
 	margin-left: 0;
 	margin-bottom: 0;
 	clear: both;
-	@include clearfix;
 
 	li.product,
 	.wc-block-grid__product {


### PR DESCRIPTION
Fixes #1197.

### Screenshots
**Before**
![image](https://user-images.githubusercontent.com/3616980/65890392-18fe3c80-e3a3-11e9-84ca-5a15cac082f4.png)

**After**
![image](https://user-images.githubusercontent.com/3616980/65890444-303d2a00-e3a3-11e9-94ec-e4c44a27e6d3.png)

### Steps to test

- Create a post with a product grid block (for example _Top Rated Products_).
- Preview the post with a Webkit browser (Safari, for example).
- Verify the first row doesn't overflow.

This PR should replace #1200 created by @vedanshujain.