### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATES/1-Bug-report.md
+++ b/.github/ISSUE_TEMPLATES/1-Bug-report.md
@@ -1,0 +1,44 @@
+---
+name: "\U0001F41E Bug report"
+about: Report a bug if something isn't working as expected in Storefront.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Describe the bug
+Clearly describe the issue. Please be as descriptive as possible; issues lacking detail, or for any other reason than to report a bug, may be closed without action.
+
+Isolating the problem (mark completed items with an [x]):
+- [ ] I have deactivated other plugins and themes and confirmed this bug occurs when only WooCommerce + Storefront theme are active.
+- [ ] I can reproduce this bug consistently using the steps below.
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Browser Environment
+Please provide as much detail as possible about your testing environment.
+
+- Platform: e.g. macOS, Windows, iOS
+- Browser(s):
+
+### WordPress Environment
+Please provide relevant details of your WordPress setup and server environment.
+
+<details>
+```
+Copy and paste the system status report from WooCommerce > System Status in WordPress admin.
+```
+</details>
+

--- a/.github/ISSUE_TEMPLATES/2-Enhancement.md
+++ b/.github/ISSUE_TEMPLATES/2-Enhancement.md
@@ -1,0 +1,20 @@
+---
+name: "✨ Enhancement"
+about: If you have an idea to improve Storefront, please let us know – or submit a Pull Request!
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Adds two issue templates to the repo - one for bugs and one for enhancements. 

When this is merged, the "New Issue" button should guide users to report issues using one of these templates.