### PR TITLE
#1208: Add support for the wp_body_open hook

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -31,6 +31,7 @@ $storefront = (object) array(
 require 'inc/storefront-functions.php';
 require 'inc/storefront-template-hooks.php';
 require 'inc/storefront-template-functions.php';
+require 'inc/wordpress-shims.php';
 
 if ( class_exists( 'Jetpack' ) ) {
 	$storefront->jetpack = require 'inc/jetpack/class-storefront-jetpack.php';

--- a/header.php
+++ b/header.php
@@ -20,6 +20,8 @@
 
 <body <?php body_class(); ?>>
 
+<?php wp_body_open(); ?>
+
 <?php do_action( 'storefront_before_site' ); ?>
 
 <div id="page" class="hfeed site">

--- a/inc/wordpress-shims.php
+++ b/inc/wordpress-shims.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * WordPress shims.
+ *
+ * @package storefront
+ */
+
+if ( ! function_exists( 'wp_body_open' ) ) {
+    /**
+     * Adds backwards compatibility for wp_body_open() introduced with WordPress 5.2
+     *
+     * @since 2.5.3
+     * @see https://developer.wordpress.org/reference/functions/wp_body_open/
+     * @return void
+     */
+    function wp_body_open() {
+        do_action( 'wp_body_open' );
+    }
+}

--- a/inc/wordpress-shims.php
+++ b/inc/wordpress-shims.php
@@ -9,7 +9,7 @@ if ( ! function_exists( 'wp_body_open' ) ) {
     /**
      * Adds backwards compatibility for wp_body_open() introduced with WordPress 5.2
      *
-     * @since 2.5.3
+     * @since 2.5.4
      * @see https://developer.wordpress.org/reference/functions/wp_body_open/
      * @return void
      */


### PR DESCRIPTION
Fixes #1208 

Change: Adds the `wp_body_open` hook after the opening body tag and added backwards compatibility to it via a separate file. This change is the result of the introduced `wp_body_open` hook in https://make.wordpress.org/themes/2019/03/29/addition-of-new-wp_body_open-hook/.