### PR TITLE
#1230: Image block options left aligned in Storefront

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -330,10 +330,6 @@
 		margin: 0 0 ms(2);
 	}
 
-	div.wp-block-image {
-		display: inline;
-	}
-
 	// Cover
 	.wp-block-cover {
 		// < 5.2 styling


### PR DESCRIPTION
Fixes #1230

<table>
<tr>
<td>Before:
<br><br>

![#1230-before](https://user-images.githubusercontent.com/3323310/71511381-1ee5ba00-28cd-11ea-91d7-8425bd151c1e.png)

</td>
<td>After:
<br><br>

![#1230-after](https://user-images.githubusercontent.com/3323310/71511390-24db9b00-28cd-11ea-8e2d-9f0921672517.png)

</td>
</tr>
</table>