### PR TITLE
#1224: Move 'Product Page' customizer menu under 'WooCommerce'

### DIFF
--- a/inc/woocommerce/class-storefront-woocommerce-customizer.php
+++ b/inc/woocommerce/class-storefront-woocommerce-customizer.php
@@ -57,7 +57,8 @@ if ( ! class_exists( 'Storefront_WooCommerce_Customizer' ) ) :
 			$wp_customize->add_section(
 				'storefront_single_product_page', array(
 					'title'    => __( 'Product Page', 'storefront' ),
-					'priority' => 60,
+					'priority' => 10,
+					'panel'    => 'woocommerce',
 				)
 			);
 


### PR DESCRIPTION
Fixes #1224 

<table>
<tr>
<td>Before:
<br><br>

![#1224-before](https://user-images.githubusercontent.com/3323310/71519065-cc1df980-28f0-11ea-8696-95a7d20ba958.png)
</td>
<td>After (Customizer » Root Section):
<br><br>

![#1224-after-1](https://user-images.githubusercontent.com/3323310/71519077-d213da80-28f0-11ea-9885-aa05e6709f6b.png)
</td>
<td>After (Customizer » WooCommerce Section):
<br><br>

![#1224-after-2](https://user-images.githubusercontent.com/3323310/71519078-d2ac7100-28f0-11ea-898e-0cd6177a97e3.png)
</td>
</tr>
</table>

**Note:**

Due to the priority settings in https://github.com/woocommerce/woocommerce/blob/7701d4b57cb20dc89e25bb7bf2ff872d85f4c535/includes/customizer/class-wc-shop-customizer.php#L298, https://github.com/woocommerce/woocommerce/blob/7701d4b57cb20dc89e25bb7bf2ff872d85f4c535/includes/customizer/class-wc-shop-customizer.php#L368, https://github.com/woocommerce/woocommerce/blob/7701d4b57cb20dc89e25bb7bf2ff872d85f4c535/includes/customizer/class-wc-shop-customizer.php#L543 and https://github.com/woocommerce/woocommerce/blob/7701d4b57cb20dc89e25bb7bf2ff872d85f4c535/includes/customizer/class-wc-shop-customizer.php#L679 it's not possible to position the Customizer section `Product Page` above `Product Catalog` or below `Product Images`. 
