### PR TITLE
Update header.php to replace storefront_before_site with wp_body_open

### DIFF
--- a/header.php
+++ b/header.php
@@ -20,7 +20,14 @@
 
 <body <?php body_class(); ?>>
 
-<?php do_action( 'storefront_before_site' ); ?>
+<?php 
+	<?php 
+	if ( function_exists( 'wp_body_open' ) ) {
+		wp_body_open();
+	} else {
+		do_action( 'wp_body_open' );
+	}
+?>
 
 <div id="page" class="hfeed site">
 	<?php do_action( 'storefront_before_header' ); ?>


### PR DESCRIPTION
WordPress 5.2 introduces natively the 'wp_body_open' action hook, that essentially serves the same purpose of 'storefront_before_site' introduced in 2.2.4.
It might be worthwhile (for greater compatibility with plugins that can use that hook) to consider replacing 'storefront_before_site' hook with the standardized one.

See: https://make.wordpress.org/core/2019/04/24/miscellaneous-developer-updates-in-5-2/

