### PR TITLE
All Products block: don't make sale badge transparent to avoid constrast issues

### DIFF
--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -377,7 +377,6 @@ ul.wp-block-latest-posts {
 			border: 1px solid;
 			border-color: $color_body;
 			color: $color_body;
-			background: transparent;
 			padding: 0.202em ms(-2);
 			font-size: ms(-1);
 			text-transform: uppercase;

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1715,7 +1715,6 @@ p.stars {
 	border: 1px solid;
 	border-color: $color_body;
 	color: $color_body;
-	background: transparent;
 	padding: 0.202em ms(-2);
 	font-size: ms(-1);
 	text-transform: uppercase;


### PR DESCRIPTION
### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/73288002-7c399780-41fa-11ea-9c1a-dcee5e6f4d6d.png)

### How to test the changes in this Pull Request:

1. Make sure you have at least one product on sale.
2. Create a post and add the _All Products_ block.
3. Observe it in the frontend and verify the `Sale` badge has white background. Before, it was transparent and it would cause accessibility issues with dark images.