### PR TITLE
Add 'display=swap' to avoid invisible text

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -367,6 +367,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 			$query_args = array(
 				'family' => implode( '|', $google_fonts ),
 				'subset' => rawurlencode( 'latin,latin-ext' ),
+				'display' => 'swap',
 			);
 
 			$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );


### PR DESCRIPTION
As documented [here](https://web.dev/font-display/?utm_source=lighthouse) it's pretty easy to avoid invisible texts by using (google-) webfonts.

Some more infos are available on the linked page.