### PR TITLE
Reset display of editor images

### DIFF
--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -247,7 +247,6 @@ figure {
 img {
 	height: auto; // Make sure images are scaled correctly.
 	max-width: 100%; // Adhere to container width.
-	display: block;
 }
 
 a {


### PR DESCRIPTION
Fixes #1255. It centers the inner block image in the _Cart_ block.

![imatge](https://user-images.githubusercontent.com/3616980/74251560-9d1ae600-4cec-11ea-8eda-b7b130bd0656.png)

This change will affect all images in the editor. I did some basic testing and everything was looking good to me, but we might consider deferring merging this PR until the next version of Storefront is released so we give more time for testing.

## Steps to test
1. Install the last version of Gutenberg and the dev version of WooCommerce Blocks.
2. Add a _Cart_ block and switch to the _Empty Cart_ view.
3. Verify the image is centered by default.