### PR TITLE
fix untranslatable string ("or") in admin notice when WooCommerce plugin is deactivated

### DIFF
--- a/inc/admin/class-storefront-plugin-install.php
+++ b/inc/admin/class-storefront-plugin-install.php
@@ -110,7 +110,7 @@ if ( ! class_exists( 'Storefront_Plugin_Install' ) ) :
 				?>
 				<span class="plugin-card-<?php echo esc_attr( $plugin_slug ); ?>">
 					<a href="<?php echo esc_url( $button['url'] ); ?>" class="<?php echo esc_attr( $button['classes'] ); ?>" data-originaltext="<?php echo esc_attr( $button['message'] ); ?>" data-name="<?php echo esc_attr( $plugin_name ); ?>" data-slug="<?php echo esc_attr( $plugin_slug ); ?>" aria-label="<?php echo esc_attr( $button['message'] ); ?>"><?php echo esc_attr( $button['message'] ); ?></a>
-				</span> or
+				</span> <?php esc_html_e( 'or', 'storefront' ); ?>
 				<a href="https://wordpress.org/plugins/<?php echo esc_attr( $plugin_slug ); ?>" target="_blank"><?php esc_attr_e( 'learn more', 'storefront' ); ?></a>
 				<?php
 			}

--- a/inc/admin/class-storefront-plugin-install.php
+++ b/inc/admin/class-storefront-plugin-install.php
@@ -110,7 +110,7 @@ if ( ! class_exists( 'Storefront_Plugin_Install' ) ) :
 				?>
 				<span class="plugin-card-<?php echo esc_attr( $plugin_slug ); ?>">
 					<a href="<?php echo esc_url( $button['url'] ); ?>" class="<?php echo esc_attr( $button['classes'] ); ?>" data-originaltext="<?php echo esc_attr( $button['message'] ); ?>" data-name="<?php echo esc_attr( $plugin_name ); ?>" data-slug="<?php echo esc_attr( $plugin_slug ); ?>" aria-label="<?php echo esc_attr( $button['message'] ); ?>"><?php echo esc_attr( $button['message'] ); ?></a>
-				</span> <?php esc_html_e( 'or', 'storefront' ); ?>
+				</span> <?php echo esc_html( _x( 'or', 'Translators: conjunction of two alternative options user can choose (in missing plugin admin notice)', 'storefront' ) ); ?>
 				<a href="https://wordpress.org/plugins/<?php echo esc_attr( $plugin_slug ); ?>" target="_blank"><?php esc_attr_e( 'learn more', 'storefront' ); ?></a>
 				<?php
 			}

--- a/inc/admin/class-storefront-plugin-install.php
+++ b/inc/admin/class-storefront-plugin-install.php
@@ -110,7 +110,7 @@ if ( ! class_exists( 'Storefront_Plugin_Install' ) ) :
 				?>
 				<span class="plugin-card-<?php echo esc_attr( $plugin_slug ); ?>">
 					<a href="<?php echo esc_url( $button['url'] ); ?>" class="<?php echo esc_attr( $button['classes'] ); ?>" data-originaltext="<?php echo esc_attr( $button['message'] ); ?>" data-name="<?php echo esc_attr( $plugin_name ); ?>" data-slug="<?php echo esc_attr( $plugin_slug ); ?>" aria-label="<?php echo esc_attr( $button['message'] ); ?>"><?php echo esc_attr( $button['message'] ); ?></a>
-				</span> <?php echo esc_html( _x( 'or', 'Translators: conjunction of two alternative options user can choose (in missing plugin admin notice)', 'storefront' ) ); ?>
+				</span> <?php echo esc_html( _x( 'or', 'Translators: conjunction of two alternative options user can choose (in missing plugin admin notice). Example: "Activate WooCommerce or learn more"', 'storefront' ) ); ?>
 				<a href="https://wordpress.org/plugins/<?php echo esc_attr( $plugin_slug ); ?>" target="_blank"><?php esc_attr_e( 'learn more', 'storefront' ); ?></a>
 				<?php
 			}


### PR DESCRIPTION
Fixes #1195 

In Storefront, there's an admin notice displayed when WooCommerce is not active. One of the strings used for this was not translatable. This PR wraps it in a translation function so that it can be translated.

The string is the `or` in this notice:

<img width="820" alt="Screen Shot 2020-02-12 at 1 15 40 PM" src="https://user-images.githubusercontent.com/4167300/74292159-2dfcca80-4d9c-11ea-8517-defe74495f3d.png">

### How to test this PR

1. Clone this branch as a theme in your dev environment, and activate the theme.
2. Deactivate WooCommerce plugin.
3. View an admin page - should see notice. Confirm the notice is working correctly.

Note – if you've previously dismissed this notice you may need to re-enable it.
