### PR TITLE
force (reset) no underline on form required field indicator

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1571,6 +1571,7 @@ ul.order_details {
 
 .required {
 	border-bottom: 0 !important;
+	text-decoration: none;
 	color: $error;
 }
 


### PR DESCRIPTION
Fixes #1262 

In WooCommerce, an asterisk is used to indicate required fields, e.g. checkout form. An `abbr` tag is used for this, and many browsers style this with a dotted underline. The dotted underline is not desirable :)

To fix this, this PR resets `.required` to have no underline - `text-decoration: none`.

Here's a screenshot of the checkout with the fix:

<img width="808" alt="Screen Shot 2020-02-20 at 3 41 24 PM" src="https://user-images.githubusercontent.com/4167300/74895784-79942180-53f7-11ea-9d2b-e81ed40ab6ed.png">

However .. it seems to me this should be handled by WooCommerce core. It looks like WooCommerce has style overrides for various themes, but not Storefront, e.g. [twenty twenty](https://github.com/woocommerce/woocommerce/blob/master/assets/css/twenty-twenty.scss#L64). This could be fixed in Woo for Storefront also, or perhaps this underline should be reset for all themes by default. I'm curious why it's an `abbr` tag too.

I'll leave this PR open for now, and I'll report this issue to Woo core. cc @mikkamp 