### PR TITLE
Adjust margin of aligned embeds

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -304,6 +304,18 @@
 		}
 	}
 
+	// Embed
+	.wp-block-embed {
+		&.alignleft {
+			margin-right: ms(5);
+		}
+
+		&.alignright {
+			margin-left: ms(5);
+		}
+
+	}
+
 	// Image
 	.wp-block-image:not( .block-editor-media-placeholder ) {
 		display: inline;


### PR DESCRIPTION
Fixes #1271 

## Left aligned

<table>
<tr>
<td>Before:
<br><br>

![#1271-alignleft-before](https://user-images.githubusercontent.com/3323310/75110845-c846f300-5665-11ea-8789-96638054a8f2.png)
</td>
<td>After:
<br><br>

![#1271-alignleft-after](https://user-images.githubusercontent.com/3323310/75110841-c67d2f80-5665-11ea-9f7a-d943fdd33e76.png)
</td>
</tr>
</table>

## Right aligned

<table>
<tr>
<td>Before:
<br><br>

![#1271-alignright-before](https://user-images.githubusercontent.com/3323310/75110847-ca10b680-5665-11ea-948f-1cf8203e717e.png)
</td>
<td>After:
<br><br>

![#1271-alignright-after](https://user-images.githubusercontent.com/3323310/75110846-c9782000-5665-11ea-9cd1-a10658565173.png)
</td>
</tr>
</table>