### PR TITLE
Adjust margin of aligned images

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -325,11 +325,11 @@
 		}
 
 		.alignleft {
-			margin-right: ms(2);
+			margin-right: ms(5);
 		}
 
 		.alignright {
-			margin-left: ms(2);
+			margin-left: ms(5);
 		}
 
 		figcaption {


### PR DESCRIPTION
Fixes #1273 / Related to #1271 

<table>
<tr>
<td>Before:
<br><br>

![#1273-before](https://user-images.githubusercontent.com/3323310/75412482-24a35e80-5955-11ea-80ab-226f8ee3c628.png)
</td>
<td>After:
<br><br>

![#1273-after](https://user-images.githubusercontent.com/3323310/75412487-279e4f00-5955-11ea-8149-e8ee0812350b.png)
</td>
</tr>
</table>