### PR TITLE
Fix margin issue of non-aligned image blocks

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -317,7 +317,7 @@
 	}
 
 	// Image
-	.wp-block-image:not( .block-editor-media-placeholder ) {
+	div.wp-block-image:not( .block-editor-media-placeholder ) {
 		display: inline;
 
 		figure {

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -341,7 +341,7 @@
 	}
 
 	figure.wp-block-image {
-		margin-bottom: ms(2);
+		margin: 0 0 ms(2);
 	}
 
 	// Cover

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -341,7 +341,7 @@
 	}
 
 	figure.wp-block-image {
-		margin: 0 0 ms(2);
+		margin-bottom: ms(2);
 	}
 
 	// Cover


### PR DESCRIPTION
Fixes #1276 
Fixes #1280

<table>
<tr>
<td>Before:
<br><br>

![#1276-before](https://user-images.githubusercontent.com/3323310/75601672-fc039c00-5aef-11ea-81ba-bec5c2fbbe8b.png)
</td>
<td>After:
<br><br>

![#1276-after](https://user-images.githubusercontent.com/3323310/75601673-fdcd5f80-5aef-11ea-98d7-90450333cf09.png)
</td>
</tr>
</table>

I also checked this PR against https://github.com/woocommerce/storefront/pull/1265 to ensure that it does not break that change.