### PR TITLE
#1280: Fix broken image captions

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -320,10 +320,6 @@
 	.wp-block-image:not( .block-editor-media-placeholder ) {
 		display: inline;
 
-		figure {
-			margin-bottom: ms(2);
-		}
-
 		.alignleft {
 			margin-right: ms(5);
 		}
@@ -332,11 +328,16 @@
 			margin-left: ms(5);
 		}
 
+		figure {
+			margin-bottom: ms(2);
+		}
+
 		figcaption {
-			margin: 0;
-			padding: ms(-1) 0;
+			display: block;
 			font-size: ms(-1);
 			font-style: italic;
+			margin: 0;
+			padding: ms(-1) 0;
 		}
 	}
 


### PR DESCRIPTION
Fixes #1280 

<table>
<tr>
<td>Before:
<br><br>

![#1280-before](https://user-images.githubusercontent.com/3323310/75626069-dc0ad000-5bf6-11ea-9443-5ab1a14545a8.png)
</td>
<td>After:
<br><br>

![#1280-after](https://user-images.githubusercontent.com/3323310/75626065-d7deb280-5bf6-11ea-818b-7ade58871625.png)
</td>
</tr>
</table>

Note: While editing the *.scss file, I also adjusted the order of the CSS statements from

```
figure { ... }
.alignleft { ... }
.alignright { ... }
figcaption { ... }
```

to 

```
.alignleft { ... }
.alignright { ... }
figure { ... }
figcaption { ... }
```

to improve maintainability. As this is such a minor change, I didn't want to create a separate issue for this. Let me know if that ok of if you prefer keeping re factorings like this separate.