### PR TITLE
i18n: fix wrong usage of context instead of translator comment

### DIFF
--- a/inc/admin/class-storefront-plugin-install.php
+++ b/inc/admin/class-storefront-plugin-install.php
@@ -110,7 +110,7 @@ if ( ! class_exists( 'Storefront_Plugin_Install' ) ) :
 				?>
 				<span class="plugin-card-<?php echo esc_attr( $plugin_slug ); ?>">
 					<a href="<?php echo esc_url( $button['url'] ); ?>" class="<?php echo esc_attr( $button['classes'] ); ?>" data-originaltext="<?php echo esc_attr( $button['message'] ); ?>" data-name="<?php echo esc_attr( $plugin_name ); ?>" data-slug="<?php echo esc_attr( $plugin_slug ); ?>" aria-label="<?php echo esc_attr( $button['message'] ); ?>"><?php echo esc_attr( $button['message'] ); ?></a>
-				</span> <?php echo esc_html( _x( 'or', 'Translators: conjunction of two alternative options user can choose (in missing plugin admin notice). Example: "Activate WooCommerce or learn more"', 'storefront' ) ); ?>
+				</span> <?php echo /* translators: conjunction of two alternative options user can choose (in missing plugin admin notice). Example: "Activate WooCommerce or learn more" */ esc_html__( 'or', 'storefront' ); ?>
 				<a href="https://wordpress.org/plugins/<?php echo esc_attr( $plugin_slug ); ?>" target="_blank"><?php esc_attr_e( 'learn more', 'storefront' ); ?></a>
 				<?php
 			}


### PR DESCRIPTION
<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
Fixes usage of a string context, where a translator comment should have been used.

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1. Run `npm run deploy`
2. Make sure the entry for this string looks like this:

```
#: inc/admin/class-storefront-plugin-install.php:113
#. translators: conjunction of two alternative options user can choose (in
#. missing plugin admin notice). Example: "Activate WooCommerce or learn more"
msgid "or"
msgstr ""
```

The current entry is as follows. This is an inappropriate use of `context` - [this string does not need disambiguation](https://developer.wordpress.org/apis/handbook/internationalization/internationalization-guidelines/#disambiguation-by-context).

```
#: inc/admin/class-storefront-plugin-install.php:113
msgctxt ""
"Translators: conjunction of two alternative options user can choose (in "
"missing plugin admin notice). Example: \"Activate WooCommerce or learn more\""
msgid "or"
msgstr ""
```

### Changelog

> i18n – Fix inappropriate use of disambiguation context in admin notice 'or' string.
