### PR TITLE
admin: make sure the admin nux notice has RTL css support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -422,6 +422,7 @@ module.exports = function( grunt ) {
 					'assets/css/woocommerce/extensions/product-recommendations.css',
 					'assets/css/woocommerce/woocommerce.css',
 					'assets/css/woocommerce/woocommerce-legacy.css',
+					'assets/css/admin/admin.css',
 					'assets/css/admin/welcome-screen/welcome.css',
 					'assets/css/admin/customizer/customizer.css',
 					'assets/css/jetpack/infinite-scroll.css',

--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -45,6 +45,7 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 			wp_enqueue_style( 'storefront-admin-nux', get_template_directory_uri() . '/assets/css/admin/admin.css', '', $storefront_version );
+			wp_style_add_data( 'storefront-admin-nux', 'rtl', 'replace' );
 
 			wp_enqueue_script( 'storefront-admin-nux', get_template_directory_uri() . '/assets/js/admin/admin' . $suffix . '.js', array( 'jquery' ), $storefront_version, 'all' );
 


### PR DESCRIPTION
<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
The CSS for the admin nux notice does not have an RTL counterpart, and the layout is broken in RTL languages.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
Before:
<img width="973" alt="Screen Shot 2020-04-03 at 14 42 55" src="https://user-images.githubusercontent.com/844866/78369275-982c3180-75cd-11ea-836c-3e5c4b23b219.png">

After:
<img width="954" alt="Screen Shot 2020-04-03 at 17 04 51" src="https://user-images.githubusercontent.com/844866/78369259-93677d80-75cd-11ea-875c-c6d538816f24.png">

### How to test the changes in this Pull Request:
1. On a new install, see the notice with and without this patch.
### Changelog

> Fix – Improve RTL support in onboarding (NUX) welcome admin notice. 
