### PR TITLE
icons: convert a couple additional arrows in RTL

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -391,6 +391,10 @@ module.exports = function( grunt ) {
 											value = '"\\f152"';
 										} else if ( value === '"\\f152"' ) { // toggle-right
 											value = '"\\f191"';
+										} else if ( value === '"\\f30b"' ) { // long-arrow-alt-right
+											value = '"\\f30a"';
+										} else if ( value === '"\\f30a"' ) { // long-arrow-alt-left
+											value = '"\\f30b"';
 										}
 										return { prop: prop, value: value };
 									}


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
Grunt takes care of replacing directional icon arrows with their RTL counterparts, but a couple of heavily used icons are missing.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
Before - the arrows are pointing to the wrong direction:
<img width="260" alt="Screen Shot 2020-04-05 at 11 36 06" src="https://user-images.githubusercontent.com/844866/78470599-8795cb80-7733-11ea-91ad-78b224424413.png">
 
After:
<img width="246" alt="Screen Shot 2020-04-05 at 11 35 59" src="https://user-images.githubusercontent.com/844866/78470607-94b2ba80-7733-11ea-8ec0-72232643bff5.png">

### How to test the changes in this Pull Request:

1. Set your site language to a RTL language (Hebrew, Arabic) or use the RTL Tester plugin
2. Add a product to the cart and check out the card popover arrows

### Changelog

> Fix Next/Previous and forward icons in RTL mode.
