### PR TITLE
Disable footer bar when using cart or checkout block

### DIFF
--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -632,6 +632,10 @@ if ( ! function_exists( 'storefront_handheld_footer_bar' ) ) {
 			),
 		);
 
+		if ( did_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after' ) || did_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after' ) ) {
+			return;
+		}
+
 		if ( wc_get_page_id( 'myaccount' ) === -1 ) {
 			unset( $links['my-account'] );
 		}


### PR DESCRIPTION
From https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1999, when the actions are fired from the cart block or checkout block, disable the Storefront footer bar.

### How to test the changes in this Pull Request:

1. Use with cart/checkout blocks from the product blocks plugin
2. View cart and checkout pages on mobile, or in mobile view,
3. Confirm no footer bar is shown.

### Changelog

> Disable the footer bar when used in conjunction with Checkout or Cart Gutenberg blocks.
