### PR TITLE
Declare HTML5 scripts and styles support for better HTML5 compliance

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -111,6 +111,8 @@ if ( ! class_exists( 'Storefront' ) ) :
 						'gallery',
 						'caption',
 						'widgets',
+						'style',
+						'script',
 					)
 				)
 			);


### PR DESCRIPTION
<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
Hi,

Given this theme is written in HTML5, it should declare HTML5 support for styles and script to avoid using `type` attributes in styles and scripts.

Otherwise, W3C validator will throw a warning because of the `type` element.

This option was introduced in WordPress 5.3. For reference, see:
- https://make.wordpress.org/core/2019/10/15/miscellaneous-developer-focused-changes-in-5-3/
- https://core.trac.wordpress.org/ticket/42804#comment:32

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1. Open the website on front-end.
2. Now there is no `type` attribute anymore on styles and script (and we don't have any HTML5 warning anymore on W3C HTML5 validator).

### Changelog

> Better HTML5 compliance for enqueued scripts and styles.