### PR TITLE
Remove underline from button blocks

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -455,13 +455,15 @@ body {
 		color: mix( $color_body, #222 );
 	}
 
-	a:not( .button ):not( .components-button ):not( .wp-block-button__link ) {
+	a {
 		color: $color_links;
 		text-decoration: underline;
 
 		&:hover {
 			text-decoration: none;
 		}
+
+		@include notUnderlinedWhenButton;
 	}
 }
 
@@ -783,12 +785,14 @@ table {
 	}
 
 	.entry-content {
-		a:not( .button ):not( .components-button ):not( .wp-block-button__link ) {
+		a {
 			text-decoration: underline;
 
 			&:hover {
 				text-decoration: none;
 			}
+
+			@include notUnderlinedWhenButton;
 		}
 	}
 
@@ -1545,8 +1549,9 @@ button.menu-toggle {
 			font-size: ms(2);
 		}
 
-		a:not( .button ):not( .components-button ):not( .wp-block-button__link ) {
+		a {
 			@include underlinedLink();
+			@include notUnderlinedWhenButton;
 		}
 	}
 }

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -463,7 +463,7 @@ body {
 			text-decoration: none;
 		}
 
-		@include notUnderlinedWhenButton;
+		@include removeButtonUnderline();
 	}
 }
 
@@ -792,7 +792,7 @@ table {
 				text-decoration: none;
 			}
 
-			@include notUnderlinedWhenButton;
+			@include removeButtonUnderline();
 		}
 	}
 
@@ -1551,7 +1551,7 @@ button.menu-toggle {
 
 		a {
 			@include underlinedLink();
-			@include notUnderlinedWhenButton;
+			@include removeButtonUnderline();
 		}
 	}
 }

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -455,7 +455,7 @@ body {
 		color: mix( $color_body, #222 );
 	}
 
-	a:not( .button ):not( .components-button ) {
+	a:not( .button ):not( .components-button ):not( .wp-block-button__link ) {
 		color: $color_links;
 		text-decoration: underline;
 
@@ -783,7 +783,7 @@ table {
 	}
 
 	.entry-content {
-		a:not( .button ):not( .components-button ) {
+		a:not( .button ):not( .components-button ):not( .wp-block-button__link ) {
 			text-decoration: underline;
 
 			&:hover {
@@ -1545,7 +1545,7 @@ button.menu-toggle {
 			font-size: ms(2);
 		}
 
-		a:not( .button ):not( .components-button ) {
+		a:not( .button ):not( .components-button ):not( .wp-block-button__link ) {
 			@include underlinedLink();
 		}
 	}

--- a/assets/css/sass/utils/_mixins.scss
+++ b/assets/css/sass/utils/_mixins.scss
@@ -33,7 +33,7 @@
 }
 
 // Remove underline if element has a button class.
-@mixin notUnderlinedWhenButton() {
+@mixin removeButtonUnderline() {
 	&.button,
 	&.components-button:not( .is-link ),
 	&.wp-block-button__link {

--- a/assets/css/sass/utils/_mixins.scss
+++ b/assets/css/sass/utils/_mixins.scss
@@ -32,6 +32,15 @@
 	}
 }
 
+// Remove underline if element has a button class.
+@mixin notUnderlinedWhenButton() {
+	&.button,
+	&.components-button,
+	&.wp-block-button__link {
+		text-decoration: none;
+	}
+}
+
 @mixin button() {
 	border: 0;
 	background: none;

--- a/assets/css/sass/utils/_mixins.scss
+++ b/assets/css/sass/utils/_mixins.scss
@@ -35,7 +35,7 @@
 // Remove underline if element has a button class.
 @mixin notUnderlinedWhenButton() {
 	&.button,
-	&.components-button,
+	&.components-button:not(.is-link),
 	&.wp-block-button__link {
 		text-decoration: none;
 	}

--- a/assets/css/sass/utils/_mixins.scss
+++ b/assets/css/sass/utils/_mixins.scss
@@ -35,7 +35,7 @@
 // Remove underline if element has a button class.
 @mixin notUnderlinedWhenButton() {
 	&.button,
-	&.components-button:not(.is-link),
+	&.components-button:not( .is-link ),
 	&.wp-block-button__link {
 		text-decoration: none;
 	}


### PR DESCRIPTION
See related issue #1285

The underline was intended to be added to links that look like links.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/79196321-2905d700-7e30-11ea-8bc8-d6762c8ca41f.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/79196278-125f8000-7e30-11ea-9544-f6cf038d5f95.png)

### How to test the changes in this Pull Request:

1. Add a _Buttons_ block.
2. In the frontend, verify they don't have an underline.

### Changelog

> Buttons blocks no longer show an underline.