### PR TITLE
#856: Sticky Add-to-Cart - Add support for small screens

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1942,7 +1942,57 @@ dl.variation {
  * Sticky Add to Cart
  */
 .storefront-sticky-add-to-cart {
-	display: none;
+	display: block;
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: 99998;
+	transform: translate3d( 0, -100%, 0 );
+	padding: ms(1) 0;
+	overflow: hidden;
+	zoom: 1;
+	box-shadow: 0 1px 2px rgba( #000000, 0.2 );
+	animation-duration: 0.5s;
+	animation-fill-mode: both;
+
+	&--slideInDown {
+		animation-name: slideInDown;
+	}
+
+	&--slideOutUp {
+		animation-name: slideOutUp;
+	}
+
+	&__content {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		&-title {
+			display: block;
+		}
+
+		&-price {
+			margin-right: ms(-1);
+			opacity: 0.5;
+		}
+
+		&-button {
+			margin-left: auto;
+			min-width: 125px;
+		}
+	}
+
+	img {
+		display: none;
+	}
+
+	.star-rating {
+		display: inline-block;
+		margin: 0;
+		vertical-align: bottom;
+	}
 }
 
 @include susy-media($desktop) {
@@ -2934,58 +2984,14 @@ dl.variation {
 	 * Sticky Add to Cart
 	 */
 	.storefront-sticky-add-to-cart {
-		display: block;
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		z-index: 99998;
-		transform: translate3d( 0, -100%, 0 );
 		padding: ms(1);
-		overflow: hidden;
-		zoom: 1;
-		box-shadow: 0 1px 2px rgba( #000000, 0.2 );
-		animation-duration: 0.5s;
-		animation-fill-mode: both;
-
-		&--slideInDown {
-			animation-name: slideInDown;
-		}
-
-		&--slideOutUp {
-			animation-name: slideOutUp;
-		}
-
-		&__content {
-			display: flex;
-			align-items: center;
-			justify-content: center;
-
-			&-title {
-				display: block;
-			}
-
-			&-price {
-				margin-right: ms(-1);
-				opacity: 0.5;
-			}
-
-			&-button {
-				margin-left: auto;
-			}
-		}
 
 		img {
+			display: block;
 			max-width: ms(6);
 			margin: 0 ms(2) 0 0;
 			padding: 3px;
 			border: 1px solid rgba( #000000, 0.1 );
-		}
-
-		.star-rating {
-			display: inline-block;
-			margin: 0;
-			vertical-align: bottom;
 		}
 	}
 


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #856 Added support for Sticky Add-to-cart on small screens

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
Changes were made in woocommerce.scss file. The stick add to cart block was moved out of media query to apply globally and media query styles were reduced and updated only for desktop.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
![image](https://user-images.githubusercontent.com/17396599/79297757-aff49700-7ea4-11ea-9073-50d2cd7c5119.png)


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1. Make sure this feature is enabled by going to Customize then WooCommerce > Product Page  and check Sticky Add-To-Cart
2. Go to any product page. Open brower and enable mobile emulator
3. Scroll past add to cart button of the product to see the sticky section and scroll back up to see the section hide.

### Changelog

> Added support for sticky add-to-cart button for small screens
