### PR TITLE
Reinstate `display: block` (centering) and margins for product-related images

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -347,6 +347,11 @@ ul.products,
 			font-size: ms(-1);
 		}
 
+		img {
+			display: block;
+			margin: 0 auto ms(3);
+		}
+
 		&.product-category {
 			h2, // @todo Remove when WooCommerce 2.8 is live
 			h3, // @todo Remove when WooCommerce 2.8 is live


### PR DESCRIPTION
Fixes #1296 #1298 #1283 (images not centering)
Fixes #1288 (no margin under product images on shop/homepage)

This PR reinstates display and margin css properties for `img` elements in product lists. Specifically:

```css
ul.products, .wc-block-grid__products {
  li.products, .wc-block-grid__product {
     img { 
       /* affects these elements */
     }
   }
}
```

This is essentially a revert of [this commit](https://github.com/woocommerce/storefront/commit/b4d01df9163cc2c463a348f225ea93fa3706e3ce) from [this PR](https://github.com/woocommerce/storefront/pull/1267). Based on the discussion on that PR, I think this is safe to reinstate as it was assumed redundant. 

### Screenshots
Before (2.5.5 no bottom margin, no centering):
<img width="853" alt="Screen Shot 2020-04-16 at 4 21 32 PM" src="https://user-images.githubusercontent.com/4167300/79414333-759f0d00-7ffe-11ea-9e6d-c1caf91d916e.png">

After (fixed) 🎉:
<img width="845" alt="Screen Shot 2020-04-16 at 4 19 09 PM" src="https://user-images.githubusercontent.com/4167300/79414166-04f7f080-7ffe-11ea-8fe6-27ff45f88d05.png">

### How to test the changes in this Pull Request:
1. Set some small images on products - e.g. crop the existing images so they are small.
2. Set up some product categories, with (small) images.
3. Set up Storefront home page template - easiest to click the prompt in NUX welcome admin notice.

- Test homepage - product and category images should be centered (at all window sizes).
- Test category page - product should be centered.
- Test in different browsers and screen sizes.
- Product images should have appropriate margins.

Also test #1276 - set up a page with product image and separator / other content and verify appropriate margins/spacing on front end.

And as always wider testing is appreciated:

- Anywhere there's a product or category image.
- Retest #1267.
- Regression testing of [other fixes included in 2.5.5](https://github.com/woocommerce/storefront/releases/tag/version%2F2.5.5) (a short list).

### Changelog

> Fix – Fix issue where product and category images were not centered on homepage & category pages.
> Fix – Ensure product images have appropriate bottom margin.
