### PR TITLE
Wordpress 5.4 compatibility - Make calendar styles shared between the widget and the block

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -1512,6 +1512,7 @@ button.menu-toggle {
 	}
 }
 
+#wp-calendar, // Required by WP <=5.3 widget.
 .wp-calendar-table {
 	th,
 	td {

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -1512,14 +1512,11 @@ button.menu-toggle {
 	}
 }
 
-.widget-area,
-.footer-widgets {
-	#wp-calendar {
-		th,
-		td {
-			padding: 0.236em;
-			text-align: center;
-		}
+.wp-calendar-table {
+	th,
+	td {
+		padding: 0.236em;
+		text-align: center;
 	}
 }
 


### PR DESCRIPTION
Spun off from  #1287 - https://make.wordpress.org/core/2020/02/12/changes-related-to-calendar-widget-markup-in-wordpress-5-4/

Make the styles for the _Calendar_ widget shared with the _Calendar_ block. The only visual change is that the letter & numbers of the _Calendar_ block will now be centered.

### Screenshots
These screenshots show the _Calendar_ block on the left and the _Calendar_ widget on the right.
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/79438853-5f7c5700-7fd4-11ea-9eb6-c9b50d14397b.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/79438765-41165b80-7fd4-11ea-9da4-0e5a9c9596b6.png)

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1. Add a _Calendar_ widget in a sidebar and a _Calendar_ block in a post.
2. View them in the frontend and notice text is centered in the block.

### Changelog

> Text inside the Calendar block is now centered, in line with the Calendar widget.