### PR TITLE
WordPress 5.4. compatibility - rename some .editor- classes to .block-editor-

### DIFF
--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -19,12 +19,21 @@
  * Base styles
  */
 
+// WP <=5.3
+.editor-block-list__block,
+.editor-default-block-appender textarea.editor-default-block-appender__content,
+// WP >=5.4
 .block-editor-block-list__block,
 .block-editor-default-block-appender textarea.block-editor-default-block-appender__content,
 .editor-post-title__block .editor-post-title__input {
 	font-family: $base-font;
 }
 
+// WP <=5.3
+.editor-block-list__block,
+.editor-block-list__block p,
+.editor-default-block-appender textarea.editor-default-block-appender__content,
+// WP >=5.4
 .block-editor-block-list__block,
 .block-editor-block-list__block p,
 .block-editor-default-block-appender textarea.block-editor-default-block-appender__content {

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -53,7 +53,7 @@
 		bottom: 0;
 		right: 14px;
 		left: 14px;
-		border-bottom: 1px solid rgba( 0, 0, 0, 0.05);
+		border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 	}
 
 	@media ( min-width: $desktop ) {

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -19,15 +19,15 @@
  * Base styles
  */
 
-.editor-block-list__block,
-.editor-default-block-appender textarea.editor-default-block-appender__content,
+.block-editor-block-list__block,
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content,
 .editor-post-title__block .editor-post-title__input {
 	font-family: $base-font;
 }
 
-.editor-block-list__block,
-.editor-block-list__block p,
-.editor-default-block-appender textarea.editor-default-block-appender__content {
+.block-editor-block-list__block,
+.block-editor-block-list__block p,
+.block-editor-default-block-appender textarea.block-editor-default-block-appender__content {
 	font-size: 16px;
 	line-height: 1.618;
 }

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -15,28 +15,9 @@
 @import '../sass/utils/variables';
 @import '../sass/utils/mixins';
 
-/**
- * Base styles
- */
-
-// WP <=5.3
-.editor-block-list__block,
-.editor-default-block-appender textarea.editor-default-block-appender__content,
-// WP >=5.4
-.block-editor-block-list__block,
-.block-editor-default-block-appender textarea.block-editor-default-block-appender__content,
-.editor-post-title__block .editor-post-title__input {
+// Base typography
+body {
 	font-family: $base-font;
-}
-
-// WP <=5.3
-.editor-block-list__block,
-.editor-block-list__block p,
-.editor-default-block-appender textarea.editor-default-block-appender__content,
-// WP >=5.4
-.block-editor-block-list__block,
-.block-editor-block-list__block p,
-.block-editor-default-block-appender textarea.block-editor-default-block-appender__content {
 	font-size: 16px;
 	line-height: 1.618;
 }
@@ -63,6 +44,7 @@
 
 .editor-post-title__block .editor-post-title__input {
 	clear: both;
+	font-family: $base-font;
 	font-weight: 300;
 	font-size: ms(5);
 	line-height: 1.214;

--- a/assets/js/src/editor.js
+++ b/assets/js/src/editor.js
@@ -96,7 +96,7 @@
 	 * @return {void}
 	 */
 	const toggleCustomSidebarClass = ( showSidebar ) => {
-		let editorWrapper = document.getElementsByClassName( 'editor-writing-flow' );
+		let editorWrapper = document.getElementsByClassName( 'block-editor-writing-flow' );
 
 		if ( ! editorWrapper.length ) {
 			return;

--- a/assets/js/src/editor.js
+++ b/assets/js/src/editor.js
@@ -96,21 +96,17 @@
 	 * @return {void}
 	 */
 	const toggleCustomSidebarClass = ( showSidebar ) => {
-		let editorWrapper = [
-			// WP <=5.3
-			...document.getElementsByClassName( 'editor-writing-flow' ),
-			// WP >=5.4
-			...document.getElementsByClassName( 'block-editor-writing-flow' ),
-		];
+		// First class for WP<=5.3 and second class for WP>=5.4.
+		const editorWrapper = document.querySelector( '.editor-writing-flow, .block-editor-writing-flow' );
 
-		if ( ! editorWrapper.length ) {
+		if ( ! editorWrapper ) {
 			return;
 		}
 
 		if ( !! showSidebar ) {
-			editorWrapper[0].classList.add( 'storefront-has-sidebar' );
+			editorWrapper.classList.add( 'storefront-has-sidebar' );
 		} else {
-			editorWrapper[0].classList.remove( 'storefront-has-sidebar' );
+			editorWrapper.classList.remove( 'storefront-has-sidebar' );
 		}
 	};
 

--- a/assets/js/src/editor.js
+++ b/assets/js/src/editor.js
@@ -96,7 +96,12 @@
 	 * @return {void}
 	 */
 	const toggleCustomSidebarClass = ( showSidebar ) => {
-		let editorWrapper = document.getElementsByClassName( 'block-editor-writing-flow' );
+		let editorWrapper = [
+			// WP <=5.3
+			...document.getElementsByClassName( 'editor-writing-flow' ),
+			// WP >=5.4
+			...document.getElementsByClassName( 'block-editor-writing-flow' ),
+		];
 
 		if ( ! editorWrapper.length ) {
 			return;

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -948,7 +948,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 					color: ' . $storefront_theme_mods['heading_color'] . ';
 				}
 
-				.editor-styles-wrapper .editor-block-list__block {
+				.editor-styles-wrapper .block-editor-block-list__block {
 					color: ' . $storefront_theme_mods['text_color'] . ';
 				}
 

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -948,6 +948,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 					color: ' . $storefront_theme_mods['heading_color'] . ';
 				}
 
+				// WP <=5.3
+				.editor-styles-wrapper .editor-block-list__block,
+				// WP >=5.4
 				.editor-styles-wrapper .block-editor-block-list__block {
 					color: ' . $storefront_theme_mods['text_color'] . ';
 				}

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -948,10 +948,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 					color: ' . $storefront_theme_mods['heading_color'] . ';
 				}
 
-				/* WP <=5.3 */
-				.editor-styles-wrapper .editor-block-list__block,
-				/* WP >=5.4 */
-				.editor-styles-wrapper .block-editor-block-list__block {
+				.editor-styles-wrapper .editor-block-list__block {
 					color: ' . $storefront_theme_mods['text_color'] . ';
 				}
 

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -948,9 +948,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 					color: ' . $storefront_theme_mods['heading_color'] . ';
 				}
 
-				// WP <=5.3
+				/* WP <=5.3 */
 				.editor-styles-wrapper .editor-block-list__block,
-				// WP >=5.4
+				/* WP >=5.4 */
 				.editor-styles-wrapper .block-editor-block-list__block {
 					color: ' . $storefront_theme_mods['text_color'] . ';
 				}


### PR DESCRIPTION
Part of #1287.

See the section _Block Editor Markup and Style Changes_ in this [article from WP Tavern about WP 5.4](https://wptavern.com/preparing-for-wordpress-5-4-changes-theme-and-plugin-developers-should-know-about). See also this [article on make.wordpress](https://make.wordpress.org/core/2020/03/02/markup-and-style-related-changes/).

Fixing this was a bit tricky, I searched `editor-` in the codebase and with the browser devtools I checked which of those classes were renamed to `block-editor-`. I hope I didn't miss any, but would be good to double-check.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/79443194-d0723d80-7fd9-11ea-94fb-ac52d535659b.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/79443222-dbc56900-7fd9-11ea-87f8-ca98eaaa298f.png)

### How to test the changes in this Pull Request:
#### Test customizer honors font styles
1. Go to the editor and add a few blocks.
3. Verify the font is sans-serif and looks like in the frontend (see _before_ and _after_ screenshots above).

#### Test block editor adapts its width depending on sidebar visibility
1. Go to _Appearance_ > _Widgets_ and remove all widgets from _Sidebar_.
2. Go to the editor and write some text.
3. Verify paragraphs are wide.
4. Go back to _Appearance_ > _Widgets_ and add some widgets to the _Sidebar_.
3. Go back to the editor and verify paragraphs are narrower.

### Changelog

> Fix – WordPress 5.4. compatibility – Ensure block editor uses theme typography styling. #1316 
> Fix – WordPress 5.4. compatibility – Adapt block editor width if sidebar widgets are present/disabled. #1316 