### PR TITLE
Honor background and font color in the editor

### DIFF
--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -924,6 +924,10 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			if ( is_admin() ) {
 				$styles .= '
+				.editor-styles-wrapper {
+					background-color: ' . $storefront_theme_mods['background_color'] . ';
+				}
+
 				.editor-styles-wrapper table:not( .has-background ) th {
 					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -7 ) . ';
 				}

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -952,7 +952,10 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 					color: ' . $storefront_theme_mods['heading_color'] . ';
 				}
 
-				.editor-styles-wrapper .editor-block-list__block {
+				/* WP <=5.3 */
+				.editor-styles-wrapper .editor-block-list__block,
+				/* WP >=5.4 */
+				.editor-styles-wrapper .block-editor-block-list__block {
 					color: ' . $storefront_theme_mods['text_color'] . ';
 				}
 


### PR DESCRIPTION
Fixes #1181.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/79452010-be979700-7fe7-11ea-9456-642a85cc958b.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/79451882-90b25280-7fe7-11ea-8f57-cd52d2b6130e.png)

### How to test the changes in this Pull Request:
You will need the changes from `fix/block-editor-classnames`, so after checking out this branch, run `git merge fix/block-editor-classnames`.
1. In the customizer set your background color to `#000000` and the typography color to `#ffffff`.
2. Open the editor and type something.
3. Verify colors are honored and text is visible.

### Changelog

> Site's background color is now honored in the editor.