### PR TITLE
Fix several :focus rings

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -1357,6 +1357,7 @@ button.menu-toggle {
 	.page-numbers {
 		list-style: none;
 		margin: 0;
+		vertical-align: middle;
 
 		li {
 			display: inline-block;

--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -464,6 +464,7 @@ a.remove {
 	line-height: 1.618;
 	font-weight: 400;
 	text-indent: -9999px;
+	overflow: hidden;
 	position: relative;
 
 	&::before {
@@ -513,14 +514,14 @@ a.remove {
 .woocommerce-pagination {
 	.next,
 	.prev {
-		text-indent: -9999px;
+		color: transparent;
 		display: inline-block;
 		position: relative;
 
 		&::after {
 			@include sf-fa-icon;
+			color: initial;
 			content: fa-content( $fa-var-caret-left );
-			text-indent: 0;
 			position: absolute;
 			top: 50%;
 			left: 50%;

--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -514,21 +514,18 @@ a.remove {
 .woocommerce-pagination {
 	.next,
 	.prev {
-		color: transparent;
-		display: inline-block;
+		text-indent: -9999px;
 		position: relative;
+		overflow: hidden;
 
 		&::after {
 			@include sf-fa-icon;
-			color: initial;
 			content: fa-content( $fa-var-caret-left );
+			text-indent: 0;
 			position: absolute;
 			top: 50%;
 			left: 50%;
-			width: 1em;
-			height: 1em;
 			transform: translateX(-50%) translateY(-50%);
-			line-height: 1;
 		}
 	}
 

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -144,6 +144,12 @@
 				text-indent: -9999px;
 				z-index: 999;
 				border-right: 1px solid rgba( #fff, 0.2 );
+				overflow: hidden;
+
+				// Raise it so focus outline is shown.
+				&:focus {
+					z-index: 1000;
+				}
 			}
 
 			&.search {
@@ -1669,6 +1675,7 @@ p.stars {
 		height: 1em;
 		width: 1em;
 		text-indent: -999em;
+		overflow: hidden;
 		display: inline-block;
 		text-decoration: none;
 		margin-right: 1px;

--- a/inc/woocommerce/class-storefront-woocommerce-customizer.php
+++ b/inc/woocommerce/class-storefront-woocommerce-customizer.php
@@ -207,6 +207,16 @@ if ( ! class_exists( 'Storefront_WooCommerce_Customizer' ) ) :
 				color: ' . $storefront_theme_mods['text_color'] . ';
 			}
 
+			.woocommerce-pagination .page-numbers li .page-numbers.prev,
+			.woocommerce-pagination .page-numbers li .page-numbers.next {
+				color: transparent;
+			}
+
+			.woocommerce-pagination .page-numbers li .page-numbers.prev::after,
+			.woocommerce-pagination .page-numbers li .page-numbers.next::after {
+				color: ' . $storefront_theme_mods['text_color'] . ';
+			}
+
 			p.stars a:before,
 			p.stars a:hover~a:before,
 			p.stars.selected a.active~a:before {

--- a/inc/woocommerce/class-storefront-woocommerce-customizer.php
+++ b/inc/woocommerce/class-storefront-woocommerce-customizer.php
@@ -207,16 +207,6 @@ if ( ! class_exists( 'Storefront_WooCommerce_Customizer' ) ) :
 				color: ' . $storefront_theme_mods['text_color'] . ';
 			}
 
-			.woocommerce-pagination .page-numbers li .page-numbers.prev,
-			.woocommerce-pagination .page-numbers li .page-numbers.next {
-				color: transparent;
-			}
-
-			.woocommerce-pagination .page-numbers li .page-numbers.prev::after,
-			.woocommerce-pagination .page-numbers li .page-numbers.next::after {
-				color: ' . $storefront_theme_mods['text_color'] . ';
-			}
-
 			p.stars a:before,
 			p.stars a:hover~a:before,
 			p.stars.selected a.active~a:before {


### PR DESCRIPTION
Fixes #1221. This PR fixes several issues with `:focus` rings.

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/79469892-07a81500-8001-11ea-995d-62461c38d0ec.png)

### How to test the changes in this Pull Request:
1. In Firefox, try focusing the _Remove_ button from Cart elements (try in the _Cart_ page and the _Cart_ header dropdown).
2. In Firefox, try focusing the stars from the Product page when adding a review.
3. In Firefox, try focusing the _next_/_previous_ buttons in the pagination of the _Shop_ page.
5. In any browser, with a narrow viewport, try focusing the search button in the lower bar:
![imatge](https://user-images.githubusercontent.com/3616980/79473083-ee08cc80-8004-11ea-8ca0-06b231293754.png)
4. In all cases verify the focus ring wraps only that item, without encompassing anything else neither reaching the end of the screen.

### Changelog

> Fixes several :focus rings mispositioned.