### PR TITLE
ensure footer bar icon links use header link color, to match header bg

### DIFF
--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -650,7 +650,6 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			.site-title a,
 			ul.menu li a,
 			.site-branding h1 a,
-			.site-footer .storefront-handheld-footer-bar a:not(.button),
 			button.menu-toggle,
 			button.menu-toggle:hover,
 			.handheld-navigation .dropdown-toggle {
@@ -788,6 +787,10 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			.site-footer a:not(.button):not(.components-button) {
 				color: ' . $storefront_theme_mods['footer_link_color'] . ';
+			}
+
+			.site-footer .storefront-handheld-footer-bar a:not(.button):not(.components-button) {
+				color: ' . $storefront_theme_mods['header_link_color'] . ';
 			}
 
 			.site-footer h1, .site-footer h2, .site-footer h3, .site-footer h4, .site-footer h5, .site-footer h6, .site-footer .widget .widget-title, .site-footer .widget .widgettitle {


### PR DESCRIPTION
Fixes #1302 

See also related issues #1260 and #1227 

This PR patches a regression introduced recently which caused the mobile footer bar icons to use the footer link color.

The mobile footer bar previously used the header colours, as it is part of the primary navigation. In certain combinations of header/footer colors the previous issue made the footer icons invisible (#1302). This PR is focused on fixing that regression, and restoring the use of header color scheme for the footer bar (as in previous versions).

### Screenshots
These two images show a store set up with a dark theme header and body, and a light theme footer. Note the consistency of the main nav color scheme in the first screenshot. (Screenshots show new behaviour.)

<img width="399" alt="Screen Shot 2020-04-21 at 11 25 33 AM" src="https://user-images.githubusercontent.com/4167300/79808750-e1002a80-83c2-11ea-8374-124a57821864.png">
<img width="399" alt="Screen Shot 2020-04-21 at 11 25 19 AM" src="https://user-images.githubusercontent.com/4167300/79808751-e2c9ee00-83c2-11ea-8a2c-eae0fba7ed61.png">

Compare with the buggy previous behaviour - the footer icons are hard to distinguish because they use the footer link color on the header background color. Also the link color clashes with the cart item count badge.

<img width="398" alt="Screen Shot 2020-04-21 at 11 25 53 AM" src="https://user-images.githubusercontent.com/4167300/79808820-0a20bb00-83c3-11ea-85e1-e02a1370becc.png">

### How to test the changes in this Pull Request:
1. Customise colours for header, typography and footer so different page sections use dark or light themes. Add some widgets to the footer and header so you can retest #1260 & confirm header/footer use customised colors consistently.
2. View front end of site on mobile, ensure footer bar links are visible and usable.
3. Add stuff to cart, confirm cart count badge is consistent.
4. Test on a range of browsers, screen sizes and (most important) color schemes 👩‍🎨 
999. Bonus points for testing on real mobile devices ☎️ 🏅 

### Changelog

> Fix: Ensure mobile sticky footer navigation links are visible when colours are customised (use header/nav colour scheme as in 2.5.4 and previous).
