### PR TITLE
Do not force 0 border radius on buttons

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -848,11 +848,6 @@ textarea {
 	margin: 0; /* Addresses margins set differently in IE6/7, F3/4, S5, Chrome */
 }
 
-/* Override gutenberg styles. */
-.wp-block-button__link {
-	border-radius: 0 !important;
-}
-
 button,
 input[type='button'],
 input[type='reset'],

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -161,6 +161,7 @@
 		margin-bottom: ms(2);
 
 		.wp-block-button__link {
+			border-radius: 0;
 			font-size: ms(1);
 			line-height: 1.618;
 			border: 0;
@@ -171,13 +172,6 @@
 			text-shadow: none;
 			display: inline-block;
 			-webkit-appearance: none;
-			border-radius: 0;
-		}
-
-		&:not( .is-style-squared ) {
-			.wp-block-button__link {
-				border-radius: 5px;
-			}
 		}
 
 		&.is-style-outline .wp-block-button__link,


### PR DESCRIPTION
Fixes #1285.

This PR is like #1311, but it keeps the default border-radius for buttons to 0. So only buttons that have explicitly a different border-radius will change with this PR.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/79817732-687b7880-8386-11ea-935c-105119a63863.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/79817690-57cb0280-8386-11ea-9e2c-8dd6aaec6e29.png)

### How to test the changes in this Pull Request:
#### Border radius attribute is honored in buttons
1. Add a _Buttons_ block and add three buttons: one without changing any attribute, one setting the border radius to 0, and the other one setting the border radius to 10.
2. Verify the border radius is honored in all of them but the one where we didn't change the border-radius is rendered as a rectangle.

#### Default button styles have no border radius
1. Add an _All Products_ and _Top Rated Products_.
2. Verify in the editor + frontend their border radius is 0.

### Changelog

> Fix – Button blocks now respect the border radius set by the user.