### PR TITLE
fix bug with absolute positioned show password icon when password strength indicator is visible

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1575,13 +1575,16 @@ ul.order_details {
 }
 
 .password-input {
+	display: block;
 	position: relative;
 }
 
 .show-password-input {
 	position: absolute;
-	right: 0.7em;
+	right: 0;
 	top: 0;
+	padding: 0.618em;
+	line-height: 1.618;
 	cursor: pointer;
 }
 


### PR DESCRIPTION
Fixes #1289

The recent changes to support the show password icon button (#1236 #1238) had a layout problem when the password strength indicator is visible. This PR tweaks css to prevent the strength indicator from breaking the position of the eye icon.

The fix is to force the wrapper element `span.password-input` to use display block. As this is a span, it defaults to inline. The strength indicator `div.woocommerce-password-strength` is contained within the wrapper element but is display block. As the wrapper element is intended to display on it's own line it's more consistent to make it block. This ensures that the eye icon is always positioned relative to the container span.

As part of this fix I've tweaked the size/positioning of the eye icon to use line-height and margin to match the input, so it's easier to keep it updated if the input styling changes. Happy to revert to pixel-offset approach if we find an issue with that :)

### Screenshots
This change affects all password fields. The two affected by the issue were my account and sign up.

<img width="863" alt="Screen Shot 2020-04-22 at 11 36 42 AM" src="https://user-images.githubusercontent.com/4167300/79925360-4f5def00-848e-11ea-9e7b-844d0d88c059.png">
<img width="852" alt="Screen Shot 2020-04-22 at 11 40 18 AM" src="https://user-images.githubusercontent.com/4167300/79925369-51c04900-848e-11ea-9c81-13d9ce2cad57.png">

### How to test the changes in this Pull Request:
#### Test my account reset password flow
1. Visit my account page, click `Account Details`.
2. Test editing a new password, hiding/showing password, good and bad passwords etc.

#### Test signup flow
1. Tick ` Allow customers to create an account on the "My account" page` in woo account settings.
1. Untick `When creating an account, automatically generate an account password` in woo account settings (to allow users to choose a password when sign up).
1. Log out or use incognito window. Visit my account page and see sign up form.
2. Test entering a new password, hiding/showing password, good and bad passwords etc.

#### Smoke test
- Check all password fields and surrounding UI to ensure no regressions.
- Test in a range of browsers and screen sizes.

### Changelog

> Fix – Show password icon button is now positioned correctly in new password fields (my account change password and signup).
