### PR TITLE
Wrap long product names in grouped product, cart and checkout

### DIFF
--- a/assets/css/sass/utils/_mixins.scss
+++ b/assets/css/sass/utils/_mixins.scss
@@ -66,5 +66,6 @@
 	overflow-wrap: anywhere;
 	// Safari supports word-break.
 	word-break: break-word;
-	// (We may also need word-wrap for IE.)
+	// We also need word-wrap and for IE.
+	-ms-word-break: break-all;
 }

--- a/assets/css/sass/utils/_mixins.scss
+++ b/assets/css/sass/utils/_mixins.scss
@@ -58,3 +58,13 @@
 	border-radius: 0;
 	box-shadow: inset 0 -1px 0 rgba( #000, 0.3 );
 }
+
+@mixin wrapBreakWord {
+	// https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap
+	// https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
+	// This is the current standard, works in most browsers.
+	overflow-wrap: anywhere;
+	// Safari supports word-break.
+	word-break: break-word;
+	// (We may also need word-wrap for IE.)
+}

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -572,7 +572,7 @@ ul.products,
 
 			table.woocommerce-grouped-product-list {
 				.woocommerce-grouped-product-list-item__label {
-					word-break: break-word;
+					@include wrapBreakWord();
 				}
 
 				.woocommerce-grouped-product-list-item__quantity {
@@ -1095,7 +1095,7 @@ table.cart {
 	}
 
 	td.product-name {
-		word-break: break-word;
+		@include wrapBreakWord();
 	}
 
 	td,
@@ -1374,7 +1374,7 @@ form.checkout {
 table.woocommerce-checkout-review-order-table {
 	.product-name {
 		width: 45%;
-		word-break: break-word;
+		@include wrapBreakWord();
 	}
 }
 

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1374,7 +1374,7 @@ form.checkout {
 table.woocommerce-checkout-review-order-table {
 	.product-name {
 		width: 45%;
-		word-wrap: break-word;
+		word-break: break-word;
 	}
 }
 

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -571,6 +571,10 @@ ul.products,
 			}
 
 			table.woocommerce-grouped-product-list {
+				.woocommerce-grouped-product-list-item__label {
+					word-break: break-word;
+				}
+
 				.woocommerce-grouped-product-list-item__quantity {
 					float: none;
 					margin-right: 0;

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1094,6 +1094,10 @@ table.cart {
 		}
 	}
 
+	td.product-name {
+		word-break: break-word;
+	}
+
 	td,
 	th {
 		padding: ms(-1) ms(-1) 0;


### PR DESCRIPTION
Fixes #1259

This PR fixes layout issues with lengthy product names on grouped product page, cart, and checkout.

`overflow-wrap: anywhere` is used to instruct the browser to wrap preserving word boundaries and if necessary, break words. (Previously the checkout used `word-wrap: break-word` which is a [deprecated alias](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap).)

I've added this as a mixin, including `word-break: break-word;` which is needed for current Safari.

### Screenshots

<img width="821" alt="Screen Shot 2020-04-22 at 4 37 54 PM" src="https://user-images.githubusercontent.com/4167300/79941963-cbb9f780-84b9-11ea-9b6d-744bbb655af9.png">

<img width="1003" alt="Screen Shot 2020-04-22 at 4 38 20 PM" src="https://user-images.githubusercontent.com/4167300/79941975-d7a5b980-84b9-11ea-9cf4-600720be7aa6.png">

<img width="789" alt="Screen Shot 2020-04-22 at 4 54 31 PM" src="https://user-images.githubusercontent.com/4167300/79942027-f60bb500-84b9-11ea-9114-b0b00bb90632.png">


### How to test the changes in this Pull Request:
1. Add/edit some products and give them names with long words - e.g. long part number `PPXJOF123456789234-5678 Semi-circular O-ring, polycarbonate, perforated`.
2. Add these products to a grouped product.
3. Test product page - confirm layout works well on all screen sizes and browsers.
2. Add to cart.
1. Test cart and checkout and confirm layout works correctly.

Prizes should always be visible and text/content should not overlap.

Please test in a variety of browsers – I haven't tested in IE yet so would appreciate if someone can test there :) 

### Changelog

> Fix – Product page, cart, and checkout layout fixes when product names are long.
