### PR TITLE
Rename camelCase mixins to use hyphens

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -463,7 +463,7 @@ body {
 			text-decoration: none;
 		}
 
-		@include removeButtonUnderline();
+		@include remove-button-underline();
 	}
 }
 
@@ -779,7 +779,7 @@ table {
 			font-size: ms(-1);
 
 			a {
-				@include underlinedLink();
+				@include underlined-link();
 			}
 		}
 	}
@@ -792,7 +792,7 @@ table {
 				text-decoration: none;
 			}
 
-			@include removeButtonUnderline();
+			@include remove-button-underline();
 		}
 	}
 
@@ -1551,8 +1551,8 @@ button.menu-toggle {
 		}
 
 		a {
-			@include underlinedLink();
-			@include removeButtonUnderline();
+			@include underlined-link();
+			@include remove-button-underline();
 		}
 	}
 }

--- a/assets/css/sass/utils/_mixins.scss
+++ b/assets/css/sass/utils/_mixins.scss
@@ -23,7 +23,7 @@
 	word-wrap: normal !important;
 }
 
-@mixin underlinedLink() {
+@mixin underlined-link() {
 	font-weight: 600;
 	text-decoration: underline;
 
@@ -33,7 +33,7 @@
 }
 
 // Remove underline if element has a button class.
-@mixin removeButtonUnderline() {
+@mixin remove-button-underline() {
 	&.button,
 	&.components-button:not( .is-link ),
 	&.wp-block-button__link {

--- a/assets/css/sass/utils/_mixins.scss
+++ b/assets/css/sass/utils/_mixins.scss
@@ -59,7 +59,7 @@
 	box-shadow: inset 0 -1px 0 rgba( #000, 0.3 );
 }
 
-@mixin wrapBreakWord {
+@mixin wrap-break-word {
 	// https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap
 	// https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
 	// This is the current standard, works in most browsers.

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -572,7 +572,7 @@ ul.products,
 
 			table.woocommerce-grouped-product-list {
 				.woocommerce-grouped-product-list-item__label {
-					@include wrapBreakWord();
+					@include wrap-break-word();
 				}
 
 				.woocommerce-grouped-product-list-item__quantity {
@@ -1095,7 +1095,7 @@ table.cart {
 	}
 
 	td.product-name {
-		@include wrapBreakWord();
+		@include wrap-break-word();
 	}
 
 	td,
@@ -1374,7 +1374,7 @@ form.checkout {
 table.woocommerce-checkout-review-order-table {
 	.product-name {
 		width: 45%;
-		@include wrapBreakWord();
+		@include wrap-break-word();
 	}
 }
 

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -631,7 +631,7 @@ ul.products,
 			margin-top: - ms(-1);
 
 			a {
-				@include underlinedLink();
+				@include underlined-link();
 			}
 
 			.star-rating {
@@ -656,7 +656,7 @@ ul.products,
 			}
 
 			a {
-				@include underlinedLink();
+				@include underlined-link();
 			}
 		}
 


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2405 we renamed the `wrap-break-word` mixin in WC Blocks, it makes sense keeping it consistent in Storefront.

I also took the change to update some other mixins to use hyphens instead of camelCase.