### PR TITLE
Fix product grids selector not targeting All Products block

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -343,7 +343,8 @@ ul.products,
 		h2, // @todo Remove when WooCommerce 2.8 is live
 		h3, // @todo Remove when WooCommerce 2.8 is live
 		.woocommerce-loop-product__title,
-		.wc-block-grid__product-title {
+		.wc-block-grid__product-title,
+		.wc-block-grid__product-title > a {
 			font-size: 1rem;
 			font-weight: 400;
 			margin-bottom: ms(-3);


### PR DESCRIPTION
There was a CSS selector targeting product grid blocks that was not having an effect in the _All Products_ block. That's because that block has an anchor element inside `.wc-block-grid__product-title`, but SF has a `h2 a` selector that changes the `font-weight`. So the `font-weight` inherited from the parent was ignored. (Probably that's better explained by the screenshots below :point_down: :sweat_smile: )

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/81280975-8f5dce00-9059-11ea-8b30-ec0ec4ee7662.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/81281005-971d7280-9059-11ea-85e4-63a0fccf6d8d.png)
_(notice the product name font-weight is slightly thicker)_

### How to test the changes in this Pull Request:
1. Create a page with the _Handpicked products_ block and the _All Products_ block.
2. View them in the frontend.
3. Verify they have the same font-weight.

### Changelog

> Updated font-weight of the All Products block so it matches the other product grid blocks.
