### PR TITLE
#1347: Remove obsolete CSS statement

### DIFF
--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -111,20 +111,6 @@ input[type='submit'],
 	}
 }
 
-.main-navigtion {
-	ul {
-		li {
-			a {
-				&::before {
-					@include sf-fa-icon;
-					content: fa-content( $fa-var-file-alt );
-					margin-right: ms(-3);
-				}
-			}
-		}
-	}
-}
-
 .handheld-navigation {
 	ul {
 		&.menu {


### PR DESCRIPTION
Fixes #1347

Note: Removed an obsolete CSS statement which served no purpose for the previous three years.

### Changelog

> Dev - Removed unused broken CSS for main navigation icons. #1347 
