### PR TITLE
🐛 FIX: Adjust gallery block layout (#1235)

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -458,9 +458,7 @@
 
 		.blocks-gallery-image,
 		.blocks-gallery-item {
-			width: span(6);
-			margin: 0 gutter(12) gutter(12) 0;
-			flex-grow: 0;
+			width: calc( (100% - 16px) / 2);
 
 			&:nth-of-type( even ) {
 				margin-right: 0;


### PR DESCRIPTION
Fixes #1235 

<table>
<tr>
<td>Before:
<br><br>

![#1235-before](https://user-images.githubusercontent.com/3323310/81847789-47b9d380-957e-11ea-9175-df378c20ec02.png)
</td>
<td>After:
<br><br>

![#1235-after](https://user-images.githubusercontent.com/3323310/81847803-4b4d5a80-957e-11ea-8bf5-72d03a659b99.png)
</td>
</tr>
</table>