### PR TITLE
add hints to explain the issue and fix in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,9 @@
 <!-- Reference any related issues or PRs here -->
 Fixes #
 
-<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
+<!-- Briefly describe the issue or problem that this PR solves. -->
+
+<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->
 
 <!-- Don't forget to update the title with something descriptive. -->
 
@@ -9,7 +11,7 @@ Fixes #
 <!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
 
 ### How to test the changes in this Pull Request:
-<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->
+<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->
 
 1.
 2.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,11 @@ Fixes #
 2.
 3.
 
+<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->
+
+-
+- 
+
 ### Changelog
 
 Add suggested changelog entry here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,4 +19,10 @@ Fixes #
 
 ### Changelog
 
-> Add suggested changelog entry here.
+Add suggested changelog entry here.
+
+For example:
+
+> Fix – Edit, reply and author icons are now displayed in comment list form. #1319
+
+See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples.


### PR DESCRIPTION
Fleshed out the PR template a bit more. The goal is to capture the PR submitter's understanding of the issue/problem and explain the fix.

Also includes:

- A prompt to consider and list affected [flows](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features).
- Clearer guidance for release notes / changelog entries.