### PR TITLE
reinstate icons in comment list forms - edit, reply, post author

### DIFF
--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -41,7 +41,7 @@
 }
 
 #comments {
-	.commentlist {
+	.comment-list {
 		.bypostauthor {
 			> .comment-body cite {
 				&::after {

--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -43,7 +43,7 @@
 #comments {
 	.comment-list {
 		.bypostauthor {
-			> .comment-body cite {
+			> .comment-body cite a {
 				&::after {
 					@include sf-fa-icon;
 					content: fa-content( $fa-var-file-alt );


### PR DESCRIPTION
Fixes #1319

Storefront has css to show icons in the comment area under posts:

- Document icon for comments by the post author.
- Pencil icon for edit comment button (if available).
- Reply arrow for reply button.

These icons stopped working at some point because the css class changed - presumably from `commentlist` to `comment-list`. 

This PR fixes the css selector so the icons work correctly again 🎉 
### Screenshots
<img width="1712" alt="Screen Shot 2020-05-18 at 11 31 47 AM" src="https://user-images.githubusercontent.com/4167300/82162780-2ac52d80-98fb-11ea-9f4c-e99f73da93d0.png">


### How to test the changes in this Pull Request:
1. Clone this branch, ensure site has a blog post.
2. Comment on a post as post author - confirm comment avatar has document icon.
3. Confirm reply and edit icons are displayed when appropriate.
4. Test with different browsers, screen sizes and user roles and confirm no regressions.

### Changelog

> Fix – Edit, reply and author icons are now displayed in comment list form. #1319
