### PR TITLE
Remove sidebar from default page layout template

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -457,9 +457,9 @@ if ( ! class_exists( 'Storefront' ) ) :
 				$classes[] = 'storefront-cute';
 			}
 
-			// Add the full width class unless the current page template is sidebar
+			// On pages, add the full width class unless the current page template is sidebar
 			// AND the sidebar has widgets.
-			if ( ! is_active_sidebar( 'sidebar-1' ) || ! is_page_template( 'template-sidebar.php' ) ) {
+			if ( is_page() && ( ! is_active_sidebar( 'sidebar-1' ) || ! is_page_template( 'template-sidebar.php' ) ) ) {
 				$classes[] = 'storefront-full-width-content';
 			}
 

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -457,8 +457,9 @@ if ( ! class_exists( 'Storefront' ) ) :
 				$classes[] = 'storefront-cute';
 			}
 
-			// If our main sidebar doesn't contain widgets, adjust the layout to be full-width.
-			if ( ! is_active_sidebar( 'sidebar-1' ) ) {
+			// Add the full width class unless the current page template is sidebar
+			// AND the sidebar has widgets.
+			if ( ! is_active_sidebar( 'sidebar-1' ) || ! is_page_template( 'template-sidebar.php' ) ) {
 				$classes[] = 'storefront-full-width-content';
 			}
 

--- a/page.php
+++ b/page.php
@@ -7,6 +7,8 @@
  * and that other 'pages' on your WordPress site will use a
  * different template.
  *
+ * 2.5.8 - Sidebar removed; default page template is now full width
+ *
  * @package storefront
  */
 
@@ -37,5 +39,4 @@ get_header(); ?>
 	</div><!-- #primary -->
 
 <?php
-do_action( 'storefront_sidebar' );
 get_footer();

--- a/template-sidebar.php
+++ b/template-sidebar.php
@@ -7,7 +7,7 @@
  * This template was added so stores can opt-in to sidebar layout on a
  * per-page basis.
  *
- * Template Name: Sidebar
+ * Template Name: Page with sidebar
  *
  * @since 2.5.8
  * @package storefront

--- a/template-sidebar.php
+++ b/template-sidebar.php
@@ -1,9 +1,15 @@
 <?php
 /**
- * The template for displaying full width pages.
+ * Template for displaying pages with a sidebar.
  *
- * Template Name: Full width
+ * In Storefront 2.5.7 and earlier, the default page template included a
+ * sidebar. In 2.5.8 the sidebar was removed from the default template.
+ * This template was added so stores can opt-in to sidebar layout on a
+ * per-page basis.
  *
+ * Template Name: Sidebar
+ *
+ * @since 2.5.8
  * @package storefront
  */
 
@@ -34,4 +40,5 @@ get_header(); ?>
 	</div><!-- #primary -->
 
 <?php
+do_action( 'storefront_sidebar' );
 get_footer();


### PR DESCRIPTION
Fixes #1349

As Gutenberg develops, it's becoming more popular to manage the page layout directly in the block editor, and reduce the amount of layout elements managed by PHP templates or widget areas.

In WooCommerce and Storerfront, many of the key pages are designed to work best in a full-width layout; for example, cart and checkout. 

The default page template includes a sidebar widget area. This PR removes this and adds a new page template (not the default) that can be used to opt-in to sidebar layout on a per-page basis. The previous full width template is removed, as it's now redundant.

Note this layout change only affects pages – blog posts and the blog archive view all still show a sidebar.

#### Considerations

It's not clear how sites are using the sidebar layout. The Storefront starter content and onboarding/nux disables it in some cases and uses a full width template for generated cart and checkout pages. Also the sidebar doesn't show if there are no widgets added to it.

Some sites may have many pages that currently show the sidebar layout. If the traditional sidebar layout is desired, there are a few ways for admins/merchants/developers to switch to the sidebar template:

- Edit pages individually, in Block Editor or classic, select a page template, publish.
- Select pages in wp-admin pages view, [bulk-edit](https://wordpress.org/support/article/pages-screen/#actions), select desired page template, update.
- Use [wp-cli to change page template](https://developer.wordpress.org/cli/commands/post/meta/) programmatically or from a script.
- Write a custom PHP plugin to update page templates programmatically.

### Screenshots
<img width="366" alt="Screen Shot 2020-05-25 at 3 14 22 PM" src="https://user-images.githubusercontent.com/4167300/82774978-6c754b80-9e9a-11ea-9a80-f0ce20b1c7ca.png">

### How to test the changes in this Pull Request:
0. Set up some pages in your test Storefront site, using default and full width templates. Add some blocks with full or wide alignment (e.g. `Cover` or `Image` blocks).
2. Optional: add or remove widgets from the sidebar widget area.
1. Switch to this branch, simulating an upgrade of Storefront to 2.5.8.
2. Confirm pages render correctly on front end. Pages using default template should no longer display a sidebar. Pages using `Full width` template should render the same as before.
3. Edit page(s) and select the `Sidebar` template (and publish). Ensure there are some widgets added to sidebar. On front end, those pages should show sidebar.
6. Bonus points: Test various with various store state scenarios/flows:
   - Clean site with no products/pages – Storefront NUX should set up appropriate content.
   - Site with existing pages, posts, config – pages with default or `full width` template should use full width, can opt-in to sidebar by changing template.

Related flows:

- Storefront customizer - can change sidebar position (left/right)
- WordPress core - Merchant can customise page layout using core widgets and shortcodes.
- Storefront features: 
  - Storefront shows an onboarding / welcome notice which guides user to set up Storefront and create a homepage.
  - Merchant can author pages that use the full page width.

#### Summary of expected behaviour
##### New behaviour
- Posts with default template should be full width, and never show sidebar (similar to previous `Full width` template)
- Posts with new `Sidebar` template should show a sidebar, if widgets have been added to the sidebar (customizer/widgets screens); otherwise should behave the same as full width

##### Existing behaviour, unchanged
- If there are no widgets added to the sidebar, sidebar should be hidden from all pages/posts
- If the sidebar is not displayed, Gutenberg `full` and `wide` alignment options should work correctly
- Blog posts and blog archive should show sidebar
- Legacy PHP homepage template does not show sidebar

### Follow ups

While working on this, I noticed some other areas we might want to look at. I'll (@haszari) ensure we have issues for all relevant follow up work when this PR is merged.

- Finalise how we want to release this - e.g. 2.5.8 or 2.6.0 or 3.0.0. (Could clarify our version numbering policy while there – I don't know what it is!)
- Check in with happiness / support about this change and recommended solutions / workarounds if merchants have issues.
- The `Homepage` template is somewhat legacy; new homepages are based on WooCommerce Blocks and don't use a special PHP home page template. We might want to indicate this in a code comment or the template name (ui), and clarify testing expectations (homepage template vs. generated blocks homepage content).
- Review the starter content/nux onboarding - what's useful & worth maintaining? Does some of this cross over with other Woo onboarding? Related, is there some setup that's useful outside an onboarding context, for example "regenerate cart & checkout pages"?
- Any support/mitigation for stores that want to retain legacy sidebar layout. For example, an automatic (silent/background) upgrade routine which selects `Sidebar` for all pages currently using `Default`. Or an admin notice that allows admin to manually trigger a similar bulk change.
- Storefront includes a custom block editor integration which uses a tweaks editor width and enables/disables some alignment options, based on the page template. This may no longer be needed, if full width is the default. (Related issue: #1270)
- Update documentation to clarify how sidebar works, how to enable it, how to disable it.
- Update [testing flows doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features).

I'll take care of adding issues for these if needed, and/or documenting any decisions in this PR.

### Changelog
> Change – Default page template is now full width; new Sidebar template available if needed. #1349
