### PR TITLE
Set storefront-style and storefront-icons as dependencies of storefront-woocommerce-style

### DIFF
--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -139,7 +139,7 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 
 			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
-			wp_enqueue_style( 'storefront-woocommerce-style', get_template_directory_uri() . '/assets/css/woocommerce/woocommerce.css', array(), $storefront_version );
+			wp_enqueue_style( 'storefront-woocommerce-style', get_template_directory_uri() . '/assets/css/woocommerce/woocommerce.css', array( 'storefront-style', 'storefront-icons' ), $storefront_version );
 			wp_style_add_data( 'storefront-woocommerce-style', 'rtl', 'replace' );
 
 			wp_register_script( 'storefront-header-cart', get_template_directory_uri() . '/assets/js/woocommerce/header-cart' . $suffix . '.js', array(), $storefront_version, true );


### PR DESCRIPTION
Fixes #1299.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/83748644-ccba7900-a662-11ea-9c9c-bdca246113f7.png)
_(notice the breadcrumbs are broken)_

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/83747880-99c3b580-a661-11ea-869a-b9321755aae1.png)

### How to test the changes in this Pull Request:

In order to test this PR, you will need to create a dummy Storefront child theme as follows:

`functions.php`:
```PHP
<?php
add_action( 'wp_enqueue_scripts', 'enqueue_styles' );

function enqueue_styles() {
	wp_enqueue_style( 'storefront-child-style-2', get_stylesheet_directory_uri() . '/style-2.css', ['storefront-child-style', 'storefront-woocommerce-style'] );
}
?>
```

`style.css`:
```CSS
/*
 Theme Name:   Storefront Child
 Template:     storefront
*/
body {
	border: 5px solid pink;
}
```
`style-2.css`:
```CSS
body {
	border-top-color: blue;
}
```

1. Select that theme in WP-Admin.
2. Verify styles are correctly loaded and breadcrumbs don't break.

### Explanation

Notice, before this PR, there was a work-around to achieve the same result as the `After` screenshot above that consisted on increasing the priority value of `wp_enqueue_scripts` in `functions.php`:
```PHP
<?php
add_action( 'wp_enqueue_scripts', 'enqueue_styles', 40 );

function enqueue_styles() {
	wp_enqueue_style( 'storefront-child-style-2', get_stylesheet_directory_uri() . '/style-2.css' );
}
?>
```

So what this PR does is that instead of needed the work-around, child themes can define `storefront-woocommerce-style` as a style dependency and doing that won't change the order the styles are loaded so the layout doesn't break.

### Changelog

> Fix – Stylesheet `storefront-woocommerce-style` has `storefront-style` and `storefront-icons` as explicit dependencies, so child themes can define `storefront-woocommerce-style` as a dependency without the risk of breaking the stylesheets order.