### PR TITLE
document Storefront's version numbering scheme/policy (semver) in releases doc

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,6 +2,8 @@
 
 This document outlines the process for releasing new versions of the Storefront theme.
 
+Note that Storefront uses [semantic versioning](https://semver.org). Please keep this in mind when preparing releases. 
+
 ## Steps
 
 The release process has three main phases:


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #1370

This PR adds a sentence to the release process/doc about how we choose version numbers. We have been using semver since v2.3.0; this is useful info for anyone using the theme on a site, and for anyone preparing or planning a release.

### Discussion
Semver is designed primarily for services with APIs. We're using it in a looser way; any change that could "break" a site - e.g. a surprising change in layout or removal of behaviour could trigger a major version bump. I'm interested in feedback or examples to flesh out what major/minor/patch mean in a Storefront context.

Since 2.3.0 there have not been any major version bumps - so the next time we make a breaking change (if that happens) we'll be trying this for the first time. 

Note - in general we aim to follow the WooCommerce policy/scheme for version numbering.

Note that [WordPress core does not use semver](https://make.wordpress.org/core/handbook/about/release-cycle/version-numbering/) - the first and second field both signify the same "kind" of release (major) and the third field is for minor releases. Also WordPress core only uses single digits - there can never be a 3.11 release of WordPress. 

As a nod to WordPress core, Storefront reserves the right to skip minor releases to avoid unsightly or confusing multi-digit numbers for minor or patch version :)

**An important consideration is** [**WordPress's support for automatically updating themes**](https://wordpress.org/support/article/configuring-automatic-background-updates/). Ignoring security updates, sites can opt-in (or out) to general auto updates for themes. The release number doesn't affect this at all - all kinds of release will be updated if site is opted in. 

In any case, whenever we release, we endeavour to preserve backwards compatibility, and if there are breaking changes, provide upgrade routines and guidance to ensure a happy and successful upgrade for all sites.


### Changelog

> Dev – Document switch to semantic versioning (as of v2.3.0). #1370

