### PR TITLE
Add e2e test for initial onboarding and demo content

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,4 @@
+# Minified js
+*.min.js
+/assets/js/vendor/*.min.js
+/assets/js/editor.js

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	presets: [
+		[
+			'@babel/preset-env',
+			{
+				targets: {
+					node: 'current',
+				},
+			},
+		],
+	],
+};

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,12 +1,7 @@
 module.exports = {
 	presets: [
 		[
-			'@babel/preset-env',
-			{
-				targets: {
-					node: 'current',
-				},
-			},
+			'@wordpress/default',
 		],
 	],
 };

--- a/e2e/specs/admin.test.js
+++ b/e2e/specs/admin.test.js
@@ -14,7 +14,7 @@ beforeAll( async () => {
 } );
 
 describe( 'Storefront onboarding', () => {
-	// Work in progress - testing!
+	// Work in progress!
 	it( 'should launch customizer', async () => {
 		await expect( page ).toMatch( 'You are customizing' );
 	} );

--- a/e2e/specs/admin.test.js
+++ b/e2e/specs/admin.test.js
@@ -12,7 +12,10 @@ describe( 'Storefront onboarding', () => {
 		await visitAdminPage( '' );
 
 		// Click the onboarding notice "Let's go" link, wait for customizer.
-		await page.click( '.sf-notice-nux .sf-nux-button' );
+		await Promise.all([
+			page.click( '.sf-notice-nux .sf-nux-button' ),
+			page.waitForNavigation(),
+		]);
 		await page.waitForSelector( '#customize-header-actions input#save' );
 	} );
 

--- a/e2e/specs/admin.test.js
+++ b/e2e/specs/admin.test.js
@@ -3,17 +3,17 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
+beforeAll( async () => {
+	// Log in as admin, switch to dashboard.
+	await switchUserToAdmin();
+	await visitAdminPage( '' );
+
+	// Click the onboarding notice "Let's go" link, wait for customizer.
+	await page.click( '.sf-notice-nux .sf-nux-button' );
+	await page.waitForSelector( '#customize-header-actions input#save' );
+} );
+
 describe( 'Storefront onboarding', () => {
-	beforeAll( async () => {
-		// Log in as admin, switch to dashboard.
-		await switchUserToAdmin();
-		await visitAdminPage( '' );
-
-		// Click the onboarding notice "Let's go" link, wait for customizer.
-		await page.click( '.sf-notice-nux #sf-nux-button' );
-		await page.waitForSelector( '#customize-header-actions button#save' );
-	} );
-
 	// Work in progress!
 	it( 'should launch customizer', async () => {
 		await expect( page ).toMatch( 'You are customizing' );

--- a/e2e/specs/admin.test.js
+++ b/e2e/specs/admin.test.js
@@ -1,0 +1,21 @@
+import {
+	switchUserToAdmin,
+	visitAdminPage,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Storefront onboarding', () => {
+	beforeAll( async () => {
+		// Log in as admin, switch to dashboard.
+		await switchUserToAdmin();
+		await visitAdminPage( '' );
+
+		// Click the onboarding notice "Let's go" link, wait for customizer.
+		await page.click( '.sf-notice-nux #sf-nux-button' );
+		await page.waitForSelector( '#customize-header-actions button#save' );
+	} );
+
+	// Work in progress!
+	it( 'should launch customizer', async () => {
+		await expect( page ).toMatch( 'You are customizing' );
+	} );
+});

--- a/e2e/specs/admin.test.js
+++ b/e2e/specs/admin.test.js
@@ -4,23 +4,41 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Storefront onboarding', () => {
-	// Enter the customizer via the "Let's go" onboarding link.
-	// Note this assumes that the nux notice is displayed - this may be fragile.
 	beforeAll( async () => {
 		// Log in as admin, switch to dashboard.
 		await switchUserToAdmin();
 		await visitAdminPage( '' );
+	} );
 
+	// Work in progress!
+	// These tests assume that the nux notice is not dismissed.
+	// This test suite is slow – presumably because all the sample products are
+	// being imported. If this test ends up being a problem we can remove or
+	// improve it :)
+
+	it( 'nux notice should launch customizer', async () => {
 		// Click the onboarding notice "Let's go" link, wait for customizer.
 		await Promise.all([
 			page.click( '.sf-notice-nux .sf-nux-button' ),
 			page.waitForNavigation(),
 		]);
 		await page.waitForSelector( '#customize-header-actions input#save' );
-	} );
 
-	// Work in progress!
-	it( 'should launch customizer', async () => {
 		await expect( page ).toMatch( 'You are customizing' );
 	} );
+
+	it( 'publishing customizer changes should succeed', async () => {
+		// Click customizer `Publish`, wait for success.
+		await page.click( '#customize-header-actions input#save' );
+		await expect( page ).toMatch( 'Published' );
+	} );
+
+	// This test isn't working yet - the products aren't finished importing;
+	// need to figure out how to wait for them.
+	// Testing the onboarding + product import might not be a good fit for e2e tests.
+	// it( 'sample products should exist after nux customizer', async () => {
+	// 	await visitAdminPage( 'edit.php', 'post_type=product' );
+	// 	await page.waitForNavigation();
+	// 	await expect( page ).toMatch( 'WordPress Pennant' );
+	// } );
 });

--- a/e2e/specs/admin.test.js
+++ b/e2e/specs/admin.test.js
@@ -3,17 +3,19 @@ import {
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
-beforeAll( async () => {
-	// Log in as admin, switch to dashboard.
-	await switchUserToAdmin();
-	await visitAdminPage( '' );
-
-	// Click the onboarding notice "Let's go" link, wait for customizer.
-	await page.click( '.sf-notice-nux .sf-nux-button' );
-	await page.waitForSelector( '#customize-header-actions input#save' );
-} );
-
 describe( 'Storefront onboarding', () => {
+	// Enter the customizer via the "Let's go" onboarding link.
+	// Note this assumes that the nux notice is displayed - this may be fragile.
+	beforeAll( async () => {
+		// Log in as admin, switch to dashboard.
+		await switchUserToAdmin();
+		await visitAdminPage( '' );
+
+		// Click the onboarding notice "Let's go" link, wait for customizer.
+		await page.click( '.sf-notice-nux .sf-nux-button' );
+		await page.waitForSelector( '#customize-header-actions input#save' );
+	} );
+
 	// Work in progress!
 	it( 'should launch customizer', async () => {
 		await expect( page ).toMatch( 'You are customizing' );

--- a/e2e/specs/admin.test.js
+++ b/e2e/specs/admin.test.js
@@ -14,7 +14,7 @@ beforeAll( async () => {
 } );
 
 describe( 'Storefront onboarding', () => {
-	// Work in progress!
+	// Work in progress - testing!
 	it( 'should launch customizer', async () => {
 		await expect( page ).toMatch( 'You are customizing' );
 	} );

--- a/e2e/specs/shopper.test.js
+++ b/e2e/specs/shopper.test.js
@@ -1,4 +1,4 @@
-describe( 'Storefront', () => {
+describe( 'Storefront front end', () => {
 	beforeAll( async () => {
 		await page.goto( STORE_URL );
 	} );

--- a/e2e/specs/shopper.test.js
+++ b/e2e/specs/shopper.test.js
@@ -1,6 +1,6 @@
 describe( 'Storefront front end', () => {
 	beforeAll( async () => {
-		await page.goto( STORE_URL );
+		await page.goto( process.env.WP_BASE_URL );
 	} );
 
 	it( 'should have "built with Storefront" footer', async () => {

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	// Work in progress.
+	// Launch chromium and run tests at slow speed so can see where things go wrong.
+	// Will configure this as an option or remove before merge.
+	launch: {
+		slowMo: 1200,
+		headless: false,
+	}
+}

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,7 +1,7 @@
 
 // Launch chromium and run tests at slow speed so can see where things go wrong.
 const launch = process.env.STOREFRONT_E2E_DEV ? {
-	slowMo: 250,
+	slowMo: 50,
 	headless: false,
 	devtools: true,
 } : undefined;

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,9 +1,11 @@
+
+// Launch chromium and run tests at slow speed so can see where things go wrong.
+const launch = process.env.STOREFRONT_E2E_DEV ? {
+	slowMo: 250,
+	headless: false,
+	devtools: true,
+} : undefined;
+
 module.exports = {
-	// Work in progress.
-	// Launch chromium and run tests at slow speed so can see where things go wrong.
-	// Will configure this as an option or remove before merge.
-	launch: {
-		slowMo: 1200,
-		headless: false,
-	}
+	launch: launch,
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,8 +3,5 @@ module.exports = {
 	setupFilesAfterEnv: [
 		"expect-puppeteer"
 	],
-	globals: {
-		STORE_URL: "http://localhost:8802"
-	},
 	testTimeout: 25000,
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,5 @@ module.exports = {
 	globals: {
 		STORE_URL: "http://localhost:8802"
 	},
-	testTimeout: process.env.STOREFRONT_E2E_DEV ? 100000 : undefined,
+	testTimeout: 25000,
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+	"preset": "jest-puppeteer",
+	"setupFilesAfterEnv": [
+		"expect-puppeteer"
+	],
+	"globals": {
+		"STORE_URL": "http://localhost:8802"
+	},
+	// "users": {
+	// 	"admin": {
+	// 		"username": "admin",
+	// 		"password": "password"
+	// 	},
+	// 	"customer": {
+	// 		"username": "customer",
+	// 		"password": "password"
+	// 	}
+	// }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,19 +1,10 @@
 module.exports = {
-	"preset": "jest-puppeteer",
-	"setupFilesAfterEnv": [
+	preset: "jest-puppeteer",
+	setupFilesAfterEnv: [
 		"expect-puppeteer"
 	],
-	"globals": {
-		"STORE_URL": "http://localhost:8802"
+	globals: {
+		STORE_URL: "http://localhost:8802"
 	},
-	// "users": {
-	// 	"admin": {
-	// 		"username": "admin",
-	// 		"password": "password"
-	// 	},
-	// 	"customer": {
-	// 		"username": "customer",
-	// 		"password": "password"
-	// 	}
-	// }
+	testTimeout: process.env.STOREFRONT_E2E_DEV ? 100000 : undefined,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3233,6 +3233,37 @@
         "defer-to-connect": "^2.0.0"
       }
     },
+    "@tannin/compile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+      "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
+      "dev": true,
+      "requires": {
+        "@tannin/evaluate": "^1.2.0",
+        "@tannin/postfix": "^1.1.0"
+      }
+    },
+    "@tannin/evaluate": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+      "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
+      "dev": true
+    },
+    "@tannin/plural-forms": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+      "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
+      "dev": true,
+      "requires": {
+        "@tannin/compile": "^1.1.0"
+      }
+    },
+    "@tannin/postfix": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+      "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.9",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
@@ -3446,6 +3477,27 @@
       "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.7.0.tgz",
       "integrity": "sha512-pB45JlfmHuEigNFZ1X+CTgIsOT3/TTb9iZxw1DHXge/7ytY8FNhtcNwTfF9IgnS6/xaFRZBqzw4DyH4sP1Lyxg==",
       "dev": true
+    },
+    "@wordpress/e2e-test-utils": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-4.10.0.tgz",
+      "integrity": "sha512-qZaFKUStp/cZuuLQ+gtj1f8kGBjj5cGBhXhh7ixS6weN5YZn6sYVT5a/6GyShQ38okex3mbkrWNSQakM4jTLHQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/keycodes": "^2.14.0",
+        "@wordpress/url": "^2.17.0",
+        "lodash": "^4.17.15",
+        "node-fetch": "^1.7.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
     },
     "@wordpress/element": {
       "version": "2.15.0",
@@ -3715,6 +3767,83 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "@wordpress/i18n": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.14.0.tgz",
+      "integrity": "sha512-FQbSggdvkdS+IWMNhTl3n1nThqfzAPxORvoFpjDma7DOwuRKOA8iPyomwacfeG/krAeaurj1DIDzDvZh9Ex79w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "gettext-parser": "^1.3.1",
+        "lodash": "^4.17.15",
+        "memize": "^1.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "dependencies": {
+        "gettext-parser": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+          "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.12",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
+    "@wordpress/keycodes": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.14.0.tgz",
+      "integrity": "sha512-R/0orMutajuQ1d1kFFIvksXKR5C5TtszEkbnxSfdNlKaOW7p9Srv8+8m2QqM+AKNvEGMaq6cn7BfDtTbZ33Dbw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/i18n": "^3.14.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
+    "@wordpress/url": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.17.0.tgz",
+      "integrity": "sha512-4OBUy8IKZlobXe41GASw+p5xP/Nvh+HSzfhTN+BU0OggnIsXvZpf0iBYRYGp6M60ne8MkeEoQg9rMM22Osh9Cg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "lodash": "^4.17.15",
+        "qs": "^6.5.2",
+        "react-native-url-polyfill": "^1.1.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+          "dev": true
+        }
       }
     },
     "@wordpress/warning": {
@@ -9959,6 +10088,12 @@
         "unist-util-visit": "^2.0.0"
       }
     },
+    "memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "dev": true
+    },
     "meow": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -10287,6 +10422,16 @@
       "optional": true,
       "requires": {
         "semver": "^5.4.1"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-gyp": {
@@ -11869,6 +12014,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "react-native-url-polyfill": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.1.2.tgz",
+      "integrity": "sha512-RPYwjW+4udnAf26xUCQP2dn4t2tnRFo3Ii4s/hy7Ivpe7xYtXp7CMVX505CR8X3p0f8NKmOJ4MQEFMMnbd/Y/Q==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.4.3",
+        "whatwg-url-without-unicode": "8.0.0-1"
+      }
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -13839,6 +13994,15 @@
         }
       }
     },
+    "tannin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+      "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
+      "dev": true,
+      "requires": {
+        "@tannin/plural-forms": "^1.1.0"
+      }
+    },
     "tar": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
@@ -14719,6 +14883,23 @@
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^2.0.2",
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+          "dev": true
+        }
+      }
+    },
+    "whatwg-url-without-unicode": {
+      "version": "8.0.0-1",
+      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-1.tgz",
+      "integrity": "sha512-0Uy8mjsG5O8Y53327XL+ZqsrMdxO1CL/6m840SmW5iyRWFvU2zlxS2RzpD3pFFVKYOKCmsKn5JKzWxQ+bImnWA==",
+      "dev": true,
+      "requires": {
         "webidl-conversions": "^5.0.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,15 +18,6 @@
     "e2e": "jest",
     "e2e:ci": "npm run e2e:start && npm run e2e"
   },
-  "jest": {
-    "preset": "jest-puppeteer",
-    "setupFilesAfterEnv": [
-      "expect-puppeteer"
-    ],
-    "globals": {
-      "STORE_URL": "http://localhost:8802"
-    }
-  },
   "license": "GPL-2.0+",
   "main": "Gruntfile.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "deploy": "grunt deploy",
     "e2e:start": "wp-env start",
     "e2e:stop": "wp-env stop",
+    "e2e:clean": "wp-env clean",
     "e2e:destroy": "wp-env destroy",
-    "e2e": "jest",
+    "e2e": "WP_BASE_URL=http://localhost:8802 jest",
+    "e2e:dev": "STOREFRONT_E2E_DEV=true WP_BASE_URL=http://localhost:8802 jest",
     "e2e:ci": "npm run e2e:start && npm run e2e"
   },
   "license": "GPL-2.0+",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@babel/core": "7.10.4",
     "@wordpress/babel-preset-default": "4.16.0",
+    "@wordpress/e2e-test-utils": "4.10.0",
     "@wordpress/env": "1.6.0",
     "autoprefixer": "9.8.4",
     "bourbon": "5.1.0",


### PR DESCRIPTION
_In progress_

Fixes #1330

The goal of this PR is to add a meaningful and useful e2e test. To do this we'll need to add more jest/puppeteer config and pull in utils ([e.g. `@wordpress/e2e-test-utils`](https://developer.wordpress.org/block-editor/packages/packages-e2e-test-utils/)) so we can navigate around admin dashboard.

As part of this I'm aiming to add config so tests can be run interactively (watch them live) when developing, as well as the usual headless.

Also this PR will be used to confirm that Travis is running on PRs in a useful way - may be some follow up if this isn't working as expected. 

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1.
2.
3.

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

-
-

