### PR TITLE
Add Cart and Checkout block styles

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -911,6 +911,16 @@ input[type='submit'],
 	}
 }
 
+.wc-block-components-button:not( .is-link ).disabled,
+.wc-block-components-button:not( .is-link ):disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+
+	&:hover {
+		opacity: 0.5;
+	}
+}
+
 input[type='checkbox'],
 input[type='radio'] {
 	padding: 0; /* Addresses excess padding in IE8/9 */

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -805,6 +805,32 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				color: ' . $storefront_theme_mods['hero_text_color'] . ';
 			}
 
+			.wc-block-components-button:not(.is-link) {
+				background-color: ' . $storefront_theme_mods['button_background_color'] . ';
+				border-color: ' . $storefront_theme_mods['button_background_color'] . ';
+				color: ' . $storefront_theme_mods['button_text_color'] . ';
+			}
+
+			.wc-block-components-button:not(.is-link):hover {
+				background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_background_color'], $darken_factor ) . ';
+				border-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_background_color'], $darken_factor ) . ';
+			}
+
+			.wc-block-cart__submit-container {
+				background-color: ' . $storefront_theme_mods['background_color'] . ';
+			}
+
+			.wc-block-cart__submit-container::before {
+				color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], is_color_light( $storefront_theme_mods['background_color'] ) ? -35 : 70, 0.5 ) . ';
+			}
+
+			.wc-block-components-order-summary-item__quantity {
+				background-color: ' . $storefront_theme_mods['background_color'] . ';
+				border-color: ' . $storefront_theme_mods['text_color'] . ';
+				box-shadow: 0 0 0 2px ' . $storefront_theme_mods['background_color'] . ';
+				color: ' . $storefront_theme_mods['text_color'] . ';
+			}
+
 			@media screen and ( min-width: 768px ) {
 				.secondary-navigation ul.menu a:hover {
 					color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['header_text_color'], $brighten_factor ) . ';

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -810,8 +810,16 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				color: ' . $storefront_theme_mods['button_alt_text_color'] . ';
 			}
 
-			.wc-block-components-button:not(.is-link):hover {
+			.wc-block-components-button:not(.is-link):hover,
+			.wc-block-components-button:not(.is-link):focus,
+			.wc-block-components-button:not(.is-link):active {
 				background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_alt_background_color'], $darken_factor ) . ';
+				color: ' . $storefront_theme_mods['button_alt_text_color'] . ';
+			}
+
+			.wc-block-components-button:not(.is-link):disabled {
+				background-color: ' . $storefront_theme_mods['button_alt_background_color'] . ';
+				color: ' . $storefront_theme_mods['button_alt_text_color'] . ';
 			}
 
 			.wc-block-cart__submit-container {

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -806,14 +806,12 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			}
 
 			.wc-block-components-button:not(.is-link) {
-				background-color: ' . $storefront_theme_mods['button_background_color'] . ';
-				border-color: ' . $storefront_theme_mods['button_background_color'] . ';
-				color: ' . $storefront_theme_mods['button_text_color'] . ';
+				background-color: ' . $storefront_theme_mods['button_alt_background_color'] . ';
+				color: ' . $storefront_theme_mods['button_alt_text_color'] . ';
 			}
 
 			.wc-block-components-button:not(.is-link):hover {
-				background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_background_color'], $darken_factor ) . ';
-				border-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_background_color'], $darken_factor ) . ';
+				background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_alt_background_color'], $darken_factor ) . ';
 			}
 
 			.wc-block-cart__submit-container {

--- a/inc/storefront-functions.php
+++ b/inc/storefront-functions.php
@@ -119,18 +119,13 @@ function storefront_homepage_content_styles() {
 }
 
 /**
- * Adjust a hex color brightness
- * Allows us to create hover styles for custom link colors
+ * Given an hex colors, returns an array with the colors components.
  *
- * @param  strong  $hex   hex color e.g. #111111.
- * @param  integer $steps factor by which to brighten/darken ranging from -255 (darken) to 255 (brighten).
- * @return string        brightened/darkened hex color
- * @since  1.0.0
+ * @param  strong $hex Hex color e.g. #111111.
+ * @return bool        Array with color components (r, g, b).
+ * @since  2.5.8
  */
-function storefront_adjust_color_brightness( $hex, $steps ) {
-	// Steps should be between -255 and 255. Negative = darker, positive = lighter.
-	$steps = max( -255, min( 255, $steps ) );
-
+function get_rgb_values_from_hex( $hex ) {
 	// Format the hex color string.
 	$hex = str_replace( '#', '', $hex );
 
@@ -143,10 +138,52 @@ function storefront_adjust_color_brightness( $hex, $steps ) {
 	$g = hexdec( substr( $hex, 2, 2 ) );
 	$b = hexdec( substr( $hex, 4, 2 ) );
 
+	return array(
+		'r' => $r,
+		'g' => $g,
+		'b' => $b,
+	);
+}
+
+/**
+ * Returns true for light colors and false for dark colors.
+ *
+ * @param  strong $hex Hex color e.g. #111111.
+ * @return bool        True if the average lightness of the three components of the color is higher or equal than 127.5.
+ * @since  2.5.8
+ */
+function is_color_light( $hex ) {
+	$rgb_values = get_rgb_values_from_hex( $hex );
+	$average_lightness = ( $rgb_values['r'] + $rgb_values['g'] + $rgb_values['b'] ) / 3;
+	return $average_lightness >= 127.5;
+}
+
+/**
+ * Adjust a hex color brightness
+ * Allows us to create hover styles for custom link colors
+ *
+ * @since 2.5.8 Added $opacity argument.
+ *
+ * @param  strong  $hex     Hex color e.g. #111111.
+ * @param  integer $steps   Factor by which to brighten/darken ranging from -255 (darken) to 255 (brighten).
+ * @param  float   $opacity Opacity factor between 0 and 1.
+ * @return string           Brightened/darkened color (hex by default, rgba if opacity is set to a valid value below 1).
+ * @since  1.0.0
+ */
+function storefront_adjust_color_brightness( $hex, $steps, $opacity = 1 ) {
+	// Steps should be between -255 and 255. Negative = darker, positive = lighter.
+	$steps = max( -255, min( 255, $steps ) );
+
+	$rgb_values = get_rgb_values_from_hex( $hex );
+
 	// Adjust number of steps and keep it inside 0 to 255.
-	$r = max( 0, min( 255, $r + $steps ) );
-	$g = max( 0, min( 255, $g + $steps ) );
-	$b = max( 0, min( 255, $b + $steps ) );
+	$r = max( 0, min( 255, $rgb_values['r'] + $steps ) );
+	$g = max( 0, min( 255, $rgb_values['g'] + $steps ) );
+	$b = max( 0, min( 255, $rgb_values['b'] + $steps ) );
+
+	if ( $opacity >= 0 && $opacity < 1 ) {
+		return 'rgba(' . $r . ',' . $g . ',' . $b . ',' . $opacity . ')';
+	}
 
 	$r_hex = str_pad( dechex( $r ), 2, '0', STR_PAD_LEFT );
 	$g_hex = str_pad( dechex( $g ), 2, '0', STR_PAD_LEFT );


### PR DESCRIPTION
### How to test the changes in this Pull Request:

1. Go to the Customizer and change the background color and the button `alt` colors.
2. Go to the Cart block with a narrow viewport (simulating mobile) and verify colors are applied to the buttons and the `Proceed to Checkout` container:

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/86456301-26759800-bd22-11ea-9dbc-3f7eb3023910.png) | ![imatge](https://user-images.githubusercontent.com/3616980/86456238-0fcf4100-bd22-11ea-9e2c-99bfbb912ad8.png) |

3. Now test with a Storefront child theme. Bistro is a good example because its colors are quite different:

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/86457422-ef07eb00-bd23-11ea-9754-bc8372ffaaef.png) | ![imatge](https://user-images.githubusercontent.com/3616980/86456500-6fc5e780-bd22-11ea-9f47-1c797c158a3a.png) |

4. If you test it in combination with https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2814, you should see the box shadow aligns with the background color (testing with a dark background color makes it more noticable):

| Before | After | After (with WC Blocks PR) |
| --- | --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/86456982-42c60480-bd23-11ea-9107-c2f662f4375a.png) | ![imatge](https://user-images.githubusercontent.com/3616980/86456903-22964580-bd23-11ea-953c-3393be0939fd.png) | ![imatge](https://user-images.githubusercontent.com/3616980/86456933-2cb84400-bd23-11ea-90a3-12b6aae38462.png) |

5. In the Checkout block, take a look at the _Order Summary_ quantity badge and verify theme colors are honored:

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/86457221-98021600-bd23-11ea-8f49-22bb0cf0e28c.png) | ![imatge](https://user-images.githubusercontent.com/3616980/86457272-aea86d00-bd23-11ea-8f12-7b14e3768f89.png) |

### Changelog

> Enhancement – Cart and Checkout block buttons honor the alternative button colors and the Checkout block quantity badge inherits the theme background and text color.