### PR TITLE
Fix incorrect starter content for HomePage.

### DIFF
--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -1048,9 +1048,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				<h2 style="text-align:center">' . __( 'New In', 'storefront' ) . '</h2>
 				<!-- /wp:heading -->
 
-				<!-- wp:woocommerce/product-new {"columns":4} -->
-				<div class="wp-block-woocommerce-product-new">[products limit="4" columns="4" orderby="date" order="DESC"]</div>
-				<!-- /wp:woocommerce/product-new -->
+				<!-- wp:woocommerce/product-new {"columns":4} /-->
 
 				{{handpicked-products}}
 
@@ -1058,25 +1056,19 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				<h2 style="text-align:center">' . __( 'Fan Favorites', 'storefront' ) . '</h2>
 				<!-- /wp:heading -->
 
-				<!-- wp:woocommerce/product-top-rated {"columns":4} -->
-				<div class="wp-block-woocommerce-product-top-rated">[products limit="4" columns="4" orderby="rating"]</div>
-				<!-- /wp:woocommerce/product-top-rated -->
+				<!-- wp:woocommerce/product-top-rated {"columns":4} /-->
 
 				<!-- wp:heading {"align":"center"} -->
 				<h2 style="text-align:center">' . __( 'On Sale', 'storefront' ) . '</h2>
 				<!-- /wp:heading -->
 
-				<!-- wp:woocommerce/product-on-sale {"columns":4} -->
-				<div class="wp-block-woocommerce-product-on-sale">[products limit="4" columns="4" orderby="date" order="DESC" on_sale="1"]</div>
-				<!-- /wp:woocommerce/product-on-sale -->
+				<!-- wp:woocommerce/product-on-sale {"columns":4} /-->
 
 				<!-- wp:heading {"align":"center"} -->
 				<h2 style="text-align:center">' . __( 'Best Sellers', 'storefront' ) . '</h2>
 				<!-- /wp:heading -->
 
-				<!-- wp:woocommerce/product-best-sellers {"columns":4} -->
-				<div class="wp-block-woocommerce-product-best-sellers">[products limit="4" columns="4" best_selling="1"]</div>
-				<!-- /wp:woocommerce/product-best-sellers -->
+				<!-- wp:woocommerce/product-best-sellers {"columns":4} /-->
 			';
 
 			return trim( $content );
@@ -1135,9 +1127,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 					<h2 style="text-align:center">' . __( 'We Recommend', 'storefront' ) . '</h2>
 					<!-- /wp:heading -->
 
-					<!-- wp:woocommerce/handpicked-products {"columns":4,"editMode":false,"products":[{{handpicked-products}}]} -->
-					<div class = "wp-block-woocommerce-handpicked-products">[products limit="4" columns="4" orderby="date" order="DESC" ids="{{handpicked-products}}"]</div>
-					<!-- /wp:woocommerce/handpicked-products -->
+					<!-- wp:woocommerce/handpicked-products {"columns":4,"editMode":false,"products":[{{handpicked-products}}]} /-->
 				';
 
 				$handpicked = str_replace( '{{handpicked-products}}', implode( ',', $products ), $handpicked );


### PR DESCRIPTION
Fixes #1423

In testing, some folks surfaced a problem where the created Homepage via the starting notice for Storefront included invalid blocks. This surfaces when trying to edit the homepage. The blocks themselves render on the frontend, but the block structure invalidates when run through the block editor validation.

The blocks are recoverable, but this is a poor experience for users wanting to edit their homepage.

It looks like the starter content originally included shortcodes as a fallback when blocks were not present in the environment the theme is installed in. However it's been a while since that was the case and we can remove that extraneous fallback.

## To Reproduce
While on master:

Create a home page using this wizard:

<img width="1730" alt="Image 2020-07-14 at 2 34 07 PM" src="https://user-images.githubusercontent.com/1429108/87463461-6b7db200-c5df-11ea-9063-acd979dd12ac.png">

(You can trigger this via a fresh install of Storefront, or by manipulating the `storefront_nux_dismissed` and storefront_nux_fresh_site` options in your database).

When editing the home page you'll see this:

<img width="517" alt="Image 2020-07-14 at 2 38 05 PM" src="https://user-images.githubusercontent.com/1429108/87463601-b13a7a80-c5df-11ea-83f9-d1f02a5bcdc0.png">

## To Test

- Try creating a homepage using this branch.
- The homepage blocks should render as expected and when editing the homepage there should be no block validation errors.



