### PR TITLE
Skip styling All Products Product Title if we have a font size or a color from the editor

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -345,9 +345,15 @@ ul.products,
 		.woocommerce-loop-product__title,
 		.wc-block-grid__product-title,
 		.wc-block-grid__product-title > a {
-			font-size: 1rem;
 			font-weight: 400;
 			margin-bottom: ms(-3);
+		}
+		h2, // @todo Remove when WooCommerce 2.8 is live
+		h3, // @todo Remove when WooCommerce 2.8 is live
+		.woocommerce-loop-product__title,
+		.wc-block-grid__product-title,
+		.wc-block-grid__product-title > a:not(.has-font-size) {
+			font-size: 1rem;
 		}
 
 		.star-rating {

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -352,7 +352,7 @@ ul.products,
 		h3, // @todo Remove when WooCommerce 2.8 is live
 		.woocommerce-loop-product__title,
 		.wc-block-grid__product-title,
-		.wc-block-grid__product-title > a:not(.has-font-size) {
+		.wc-block-grid__product-title > a:not( .has-font-size ) {
 			font-size: 1rem;
 		}
 


### PR DESCRIPTION
In the newest version of  WooCommerce Blocks, users can customize All Product's Product Title block, this customization is via color or font size, but those changes can contradict with any style provided by a theme, such as Storefront.
This PR skips styling for that block if a user has already selected some styling, this is done via `has-text-color` and `has-font-size` classname.

See https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2860 for more details about this behavior.

## Testing

In order to test this, you will need to have WooCommerce Blocks 3.0.0 enabled in your website.

- Create a page.
- Insert `All Products` Block in it.
- Click the "Edit" button of that block.
![image](https://user-images.githubusercontent.com/6165348/89325790-382fbf80-d681-11ea-8c21-ebdfb2b506fc.png)
- Now select the Product Title block.
- In the sidebar, you can change the font size for that block, select a predefined font size for the list, not a custom font size value, as this issue is only present with predefined sizes.
- After changing the color, click "Done"
![image](https://user-images.githubusercontent.com/6165348/89325895-5dbcc900-d681-11ea-99a9-e41e98470b72.png)
- Save the page and view it.
- Check if Storefront honors the font size you selected.

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Respect user-selected Color and Font size values for All Products' Product Title Block.
