### PR TITLE
Fix focus outline in My Account page with Firefox

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -2832,6 +2832,7 @@ dl.variation {
 
 			a {
 				float: right;
+				overflow: hidden;
 			}
 
 			h3 {


### PR DESCRIPTION
Fixes #1364.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/87934701-d6236780-ca8f-11ea-8e2f-2d052c8aa8e3.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/87934674-ca37a580-ca8f-11ea-8982-32dece79de04.png)

### How to test the changes in this Pull Request:
1. Using Firefox, go to Wocommerce's "My Account" page
2. Click on "Addresses"
3. Click on "Billing Address" or "Shipping Address" (alternatively in web inspector add the "focus" pseudoclass
4. Verify the outline is only around the icon and doesn't overflow the screen.

### Changelog

> Fix – The focus outline of the My Account address icon no longer overflows the viewport in Firefox.