### PR TITLE
Add defensive checks for WC Cart instance

### DIFF
--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -5,6 +5,19 @@
  * @package storefront
  */
 
+if ( ! function_exists( 'storefront_woo_cart_available' ) ) {
+	/**
+	 * Validates whether the Woo Cart instance is available in the request
+	 *
+	 * @since 2.6.0
+	 * @return bool
+	 */
+	function storefront_woo_cart_available() {
+		$woo = WC();
+		return $woo instanceof \WooCommerce && $woo->cart instanceof \WC_Cart;
+	}
+}
+
 if ( ! function_exists( 'storefront_before_content' ) ) {
 	/**
 	 * Before Content
@@ -71,6 +84,9 @@ if ( ! function_exists( 'storefront_cart_link' ) ) {
 	 * @since  1.0.0
 	 */
 	function storefront_cart_link() {
+		if ( ! storefront_woo_cart_available() ) {
+			return;
+		}
 		?>
 			<a class="cart-contents" href="<?php echo esc_url( wc_get_cart_url() ); ?>" title="<?php esc_attr_e( 'View your shopping cart', 'storefront' ); ?>">
 				<?php /* translators: %d: number of items in cart */ ?>
@@ -682,6 +698,9 @@ if ( ! function_exists( 'storefront_handheld_footer_bar_cart_link' ) ) {
 	 * @since 2.0.0
 	 */
 	function storefront_handheld_footer_bar_cart_link() {
+		if ( ! storefront_woo_cart_available() ) {
+			return;
+		}
 		?>
 			<a class="footer-cart-contents" href="<?php echo esc_url( wc_get_cart_url() ); ?>" title="<?php esc_attr_e( 'View your shopping cart', 'storefront' ); ?>">
 				<span class="count"><?php echo wp_kses_data( WC()->cart->get_cart_contents_count() ); ?></span>


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #1188 

See #1188 for details. 

This fixes the potential for Fatal errors to occur on various non-shopper facing requests that might get triggered against a site with Storefront active.

## Testing

This impacts the display of the Cart Links in the header (desktop/ large viewport width) and the footer (mobile/ small viewport). 

* [ ] verify the header and footer links for the cart appear in storefront given the view being tested.

Follow the testing steps in [this comment](https://github.com/woocommerce/storefront/issues/1188#issuecomment-665928301):

Likely reproduce steps:

* Set up a new site with Storefront (from this branch) and WooCommerce.
* Browse to {domain}/new//wp-json/wp/v2/users/ .
* Should see fatal error in logs.

**Note:** I was unable to reproduce this fatal on a site with WooCommerce Beta 1 and WordPress 5.5 RC1 without this branch. It's possible there was something changed in WooCommerce core and/or WP 5.5 that impacted the conditions where the fatal could occur. Still, this additional defensive check is worthwhile.

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – Add defensive checks in template functions around calls to `WC()->cart` to only invoke calls when there is an instance of `WooCommerce` and `WC_Cart` available in the request. #1440 

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
