### PR TITLE
Fix Product Pagination including draft product

### DIFF
--- a/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
+++ b/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
@@ -80,7 +80,6 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 			global $post;
 
 			$product = false;
-
 			$this->current_product = $post->ID;
 
 			// Try to get a valid product via `get_adjacent_post()`.
@@ -164,6 +163,7 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 				'visibility' => 'catalog',
 				'exclude'    => array( $post->ID ),
 				'orderby'    => 'date',
+				'status'     => 'publish'
 			);
 
 			if ( ! $this->previous ) {


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #1411

Fixes an issue in which draft products would show up in product pagination, this is because we use `WC_Product_Query` which defaults to all core statuses like `draft` `pending` `private` and `publish`.

I could have changed this to accept `private` and `pending` as well, but I went with `publish` for now.

This change might break some stores that relies on private or pending product showing up.

This code path is only executed if we can't find adjasant products.

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Create a new draft product (copy a product). 
2. in master, you can see the the draft visible.
3. in this branch, you will see another product.


### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix issue with draft products showing up in pagination.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->