### PR TITLE
Add icons to notices and messages

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -23,6 +23,18 @@
 	font-style: normal;
 }
 
+@font-face {
+	font-family: 'WooCommerce';
+	src: url('../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot');
+	src:
+		url('../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot?#iefix') format('embedded-opentype'),
+		url('../../../../../plugins/woocommerce/assets/fonts/WooCommerce.woff') format('woff'),
+		url('../../../../../plugins/woocommerce/assets/fonts/WooCommerce.ttf') format('truetype'),
+		url('../../../../../plugins/woocommerce/assets/fonts/WooCommerce.svg#WooCommerce') format('svg');
+	font-weight: normal;
+	font-style: normal;
+}
+
 // Animations
 @keyframes slideInDown {
 	from {
@@ -1829,7 +1841,6 @@ p.stars {
 .woocommerce-error,
 .woocommerce-noreviews,
 p.no-comments {
-	padding: 1em ms(3);
 	@include clearfix;
 	margin-bottom: ms(5);
 	background-color: $success;
@@ -1838,6 +1849,9 @@ p.no-comments {
 	color: #fff;
 	clear: both;
 	border-left: ms(-2) solid rgba( 0, 0, 0, 0.15 );
+	padding: 1em 2em 1em 3.5em;
+	position: relative;
+	list-style: none outside;
 
 	a {
 		color: #fff;
@@ -1850,6 +1864,16 @@ p.no-comments {
 		&.button:hover {
 			opacity: 1;
 		}
+	}
+
+	&::before {
+		font-family: 'WooCommerce';
+		content: '\e028';
+		display: inline-block;
+		position: absolute;
+		top: 1em;
+		left: 1.5em;
+		color: #fff;
 	}
 
 	.button {
@@ -1876,6 +1900,21 @@ p.no-comments {
 
 	pre {
 		background-color: rgba( 0, 0, 0, 0.1 );
+	}
+}
+
+.woocommerce-message {
+
+	&::before {
+		content: '\e015';
+	}
+}
+
+
+.woocommerce-error {
+
+	&::before {
+		content: '\e016';
 	}
 }
 


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #1444 

This PR adds icons to storefront notices while trying to maintain the same styles.



### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
<img width="1068" alt="Screen Shot 2020-08-25 at 4 22 49 PM" src="https://user-images.githubusercontent.com/6165348/91194708-51f87b80-e6f0-11ea-97ad-35c6f3cedc06.png">
<img width="1083" alt="Screen Shot 2020-08-25 at 4 28 03 PM" src="https://user-images.githubusercontent.com/6165348/91195778-3b065900-e6f1-11ea-86d7-8d95c01ff046.png">
<img width="1083" alt="Screen Shot 2020-08-25 at 4 28 03 PM" src="https://user-images.githubusercontent.com/6165348/91195910-65581680-e6f1-11ea-85cf-6a72161dea68.png">




### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Go to a product page and add a product to your cart, this should trigger a success message.
2. Change a product to be sold individuality sold
![image](https://user-images.githubusercontent.com/6165348/91195048-96841700-e6f0-11ea-8175-497b0369a167.png)

3. Add more than one, you should see the error.

4. Visit cart or checkout to see a normal notice.

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

-
-

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Add icons to notices.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
