### PR TITLE
reinstate phpcs php linting

### DIFF
--- a/404.php
+++ b/404.php
@@ -69,7 +69,7 @@ get_header(); ?>
 								)
 							);
 
-							echo $shortcode_content; // WPCS: XSS ok.
+							echo $shortcode_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 						echo '</section>';
 					}

--- a/404.php
+++ b/404.php
@@ -47,7 +47,8 @@ get_header(); ?>
 								echo '<h2>' . esc_html__( 'Product Categories', 'storefront' ) . '</h2>';
 
 								the_widget(
-									'WC_Widget_Product_Categories', array(
+									'WC_Widget_Product_Categories',
+									array(
 										'count' => 1,
 									)
 								);
@@ -61,7 +62,8 @@ get_header(); ?>
 							echo '<h2>' . esc_html__( 'Popular Products', 'storefront' ) . '</h2>';
 
 							$shortcode_content = storefront_do_shortcode(
-								'best_selling_products', array(
+								'best_selling_products',
+								array(
 									'per_page' => 4,
 									'columns'  => 4,
 								)

--- a/comments.php
+++ b/comments.php
@@ -25,12 +25,14 @@ if ( post_password_required() ) {
 		?>
 		<h2 class="comments-title">
 			<?php
-				printf( // WPCS: XSS OK.
+				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+				printf(
 					/* translators: 1: number of comments, 2: post title */
 					esc_html( _nx( '%1$s thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'storefront' ) ),
 					number_format_i18n( get_comments_number() ),
 					'<span>' . get_the_title() . '</span>'
 				);
+				// phpcs:enable
 			?>
 		</h2>
 

--- a/comments.php
+++ b/comments.php
@@ -72,7 +72,8 @@ if ( post_password_required() ) {
 	endif;
 
 	$args = apply_filters(
-		'storefront_comment_form_args', array(
+		'storefront_comment_form_args',
+		array(
 			'title_reply_before' => '<span id="reply-title" class="gamma comment-reply-title">',
 			'title_reply_after'  => '</span>',
 		)

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "composer/installers": "1.9.0"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": "*",
-    "wp-coding-standards/wpcs": "0.14.1",
+    "squizlabs/php_codesniffer": "3.5.6",
+    "wp-coding-standards/wpcs": "2.3.0",
     "phpunit/phpunit": "6.5.14",
     "woocommerce/woocommerce-git-hooks": "*",
     "woocommerce/woocommerce-sniffs": "*",

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
   "require-dev": {
     "squizlabs/php_codesniffer": "3.5.6",
     "wp-coding-standards/wpcs": "2.3.0",
+    "woocommerce/woocommerce-sniffs": "0.1.0",
+    "phpcompatibility/php-compatibility": "9.3.5",
     "phpunit/phpunit": "6.5.14",
     "woocommerce/woocommerce-git-hooks": "*",
-    "woocommerce/woocommerce-sniffs": "*",
-    "wimg/php-compatibility": "8.2.0",
     "dealerdirect/phpcodesniffer-composer-installer": "0.7.0"
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
       "phpunit"
     ],
     "phpcs": [
-      "phpcs -s -p"
+      "phpcs --extensions=php -s -p"
     ],
     "phpcbf": [
-      "phpcbf -p"
+      "phpcbf --extensions=php -p"
     ]
   },
   "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f10b5d194649da461c7b22c4773ff7ba",
+    "content-hash": "45deef94ef94701e8e40e359f4205f4e",
     "packages": [
         {
             "name": "composer/installers",
@@ -889,6 +889,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2017-11-27T05:48:46+00:00"
         },
         {
@@ -1596,16 +1597,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.0",
+            "version": "3.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d86873af43b4aa9d1f39a3601cc0cfcf02b25266"
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d86873af43b4aa9d1f39a3601cc0cfcf02b25266",
-                "reference": "d86873af43b4aa9d1f39a3601cc0cfcf02b25266",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
                 "shasum": ""
             },
             "require": {
@@ -1638,12 +1639,12 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-06-06T23:58:19+00:00"
+            "time": "2020-08-10T04:50:15+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1935,24 +1936,30 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.14.1",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "cf6b310caad735816caef7573295f8a534374706"
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
-                "reference": "cf6b310caad735816caef7573295f8a534374706",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1962,7 +1969,7 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
@@ -1971,7 +1978,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-02-16T01:57:48+00:00"
+            "time": "2020-05-13T23:57:56+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "45deef94ef94701e8e40e359f4205f4e",
+    "content-hash": "7ff3a2e7da502ccf34364163b41c05cd",
     "packages": [
         {
             "name": "composer/installers",
@@ -283,20 +283,20 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.5",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
+                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.1 || ^8.0"
             },
             "replace": {
                 "myclabs/deep-copy": "self.version"
@@ -327,7 +327,13 @@
                 "object",
                 "object graph"
             ],
-            "time": "2020-01-17T21:11:47+00:00"
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-29T13:22:24+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -432,26 +438,186 @@
             "time": "2017-03-05T17:38:23+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.1.0",
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
-                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "time": "2019-11-04T15:17:54+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/41bef18ba688af638b7310666db28e1ea9158b2f",
+                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2019-08-28T14:22:28+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
@@ -478,32 +644,31 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2020-04-27T09:25:28+00:00"
+            "time": "2020-06-27T09:03:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.1.0",
+            "version": "5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
+                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
-                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d870572532cd70bc3fab58f2e23ad423c8404c44",
+                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44",
                 "shasum": ""
             },
             "require": {
-                "ext-filter": "^7.1",
-                "php": "^7.2",
-                "phpdocumentor/reflection-common": "^2.0",
-                "phpdocumentor/type-resolver": "^1.0",
-                "webmozart/assert": "^1"
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1",
-                "mockery/mockery": "^1"
+                "mockery/mockery": "~1.3.2"
             },
             "type": "library",
             "extra": {
@@ -531,34 +696,33 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2020-02-22T12:28:44+00:00"
+            "time": "2020-08-15T11:14:08+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
+                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
-                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e878a14a65245fbe78f8080eba03b47c3b705651",
+                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2",
+                "php": "^7.2 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "^7.2",
-                "mockery/mockery": "~1"
+                "ext-tokenizer": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-1.x": "1.x-dev"
                 }
             },
             "autoload": {
@@ -577,7 +741,7 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2020-02-18T18:59:58+00:00"
+            "time": "2020-06-27T10:12:23+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1648,16 +1812,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.17.0",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9"
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
-                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
                 "shasum": ""
             },
             "require": {
@@ -1669,7 +1833,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -1716,27 +1884,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-12T16:14:59+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.3",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1756,27 +1924,34 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2019-06-13T22:48:21+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-12T23:59:07+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.8.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
-                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0",
+                "php": "^5.3.3 || ^7.0 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
+                "phpstan/phpstan": "<0.12.20",
                 "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
@@ -1804,61 +1979,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-04-18T12:12:48+00:00"
-        },
-        {
-            "name": "wimg/php-compatibility",
-            "version": "8.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
-            },
-            "conflict": {
-                "squizlabs/php_codesniffer": "2.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
-                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-            },
-            "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "PHPCompatibility\\": "PHPCompatibility/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Godden",
-                    "role": "lead"
-                }
-            ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
-            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
-            "keywords": [
-                "compatibility",
-                "phpcs",
-                "standards"
-            ],
-            "abandoned": "phpcompatibility/php-compatibility",
-            "time": "2018-07-17T13:42:26+00:00"
+            "time": "2020-07-08T17:02:28+00:00"
         },
         {
             "name": "woocommerce/woocommerce-git-hooks",
@@ -1895,24 +2016,23 @@
         },
         {
             "name": "woocommerce/woocommerce-sniffs",
-            "version": "0.0.2",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-sniffs.git",
-                "reference": "2890fd5d98b318f62acb42f2b5cd6d02627cfd82"
+                "reference": "b72b7dd2e70aa6aed16f80cdae5b1e6cce2e4c79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-sniffs/zipball/2890fd5d98b318f62acb42f2b5cd6d02627cfd82",
-                "reference": "2890fd5d98b318f62acb42f2b5cd6d02627cfd82",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-sniffs/zipball/b72b7dd2e70aa6aed16f80cdae5b1e6cce2e4c79",
+                "reference": "b72b7dd2e70aa6aed16f80cdae5b1e6cce2e4c79",
                 "shasum": ""
             },
             "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
                 "php": ">=7.0",
-                "squizlabs/php_codesniffer": "^3.0.2"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "phpcompatibility/phpcompatibility-wp": "2.1.0",
+                "wp-coding-standards/wpcs": "2.3.0"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1932,7 +2052,7 @@
                 "woocommerce",
                 "wordpress"
             ],
-            "time": "2018-03-22T18:39:19+00:00"
+            "time": "2020-08-06T18:23:45+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ff3a2e7da502ccf34364163b41c05cd",
+    "content-hash": "cd47bed164fdbbbc580f4f4fcd7a3007",
     "packages": [
         {
             "name": "composer/installers",

--- a/inc/admin/class-storefront-admin.php
+++ b/inc/admin/class-storefront-admin.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'Storefront_Admin' ) ) :
 			global $storefront_version;
 
 			if ( 'appearance_page_storefront-welcome' === $hook_suffix ) {
-				wp_enqueue_style( 'storefront-welcome-screen', get_template_directory_uri() . '/assets/css/admin/welcome-screen/welcome.css', $storefront_version );
+				wp_enqueue_style( 'storefront-welcome-screen', get_template_directory_uri() . '/assets/css/admin/welcome-screen/welcome.css', array(), $storefront_version );
 				wp_style_add_data( 'storefront-welcome-screen', 'rtl', 'replace' );
 			}
 		}
@@ -191,8 +191,10 @@ if ( ! class_exists( 'Storefront_Admin' ) ) :
 							array(
 								'action' => 'install-plugin',
 								'plugin' => $plugin_slug,
-							), self_admin_url( 'update.php' )
-						), 'install-plugin_' . $plugin_slug
+							),
+							self_admin_url( 'update.php' )
+						),
+						'install-plugin_' . $plugin_slug
 					);
 					$button = array(
 						'message' => esc_attr__( 'Install now', 'storefront' ),
@@ -223,8 +225,10 @@ if ( ! class_exists( 'Storefront_Admin' ) ) :
 							array(
 								'action' => 'activate',
 								'plugin' => $plugin_file,
-							), admin_url( 'plugins.php' )
-						), 'activate-plugin_' . $plugin_file
+							),
+							admin_url( 'plugins.php' )
+						),
+						'activate-plugin_' . $plugin_file
 					);
 					return $url;
 				}

--- a/inc/admin/class-storefront-plugin-install.php
+++ b/inc/admin/class-storefront-plugin-install.php
@@ -87,8 +87,10 @@ if ( ! class_exists( 'Storefront_Plugin_Install' ) ) :
 							array(
 								'action' => 'install-plugin',
 								'plugin' => $plugin_slug,
-							), self_admin_url( 'update.php' )
-						), 'install-plugin_' . $plugin_slug
+							),
+							self_admin_url( 'update.php' )
+						),
+						'install-plugin_' . $plugin_slug
 					);
 					$button = array(
 						'message' => esc_attr__( 'Install now', 'storefront' ),
@@ -132,8 +134,10 @@ if ( ! class_exists( 'Storefront_Plugin_Install' ) ) :
 							array(
 								'action' => 'activate',
 								'plugin' => $plugin_file,
-							), admin_url( 'plugins.php' )
-						), 'activate-plugin_' . $plugin_file
+							),
+							admin_url( 'plugins.php' )
+						),
+						'activate-plugin_' . $plugin_file
 					);
 					return $url;
 				}

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -75,8 +75,10 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 * Enable support for site logo.
 			 */
 			add_theme_support(
-				'custom-logo', apply_filters(
-					'storefront_custom_logo_args', array(
+				'custom-logo',
+				apply_filters(
+					'storefront_custom_logo_args',
+					array(
 						'height'      => 110,
 						'width'       => 470,
 						'flex-width'  => true,
@@ -90,7 +92,8 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 */
 			register_nav_menus(
 				apply_filters(
-					'storefront_register_nav_menus', array(
+					'storefront_register_nav_menus',
+					array(
 						'primary'   => __( 'Primary Menu', 'storefront' ),
 						'secondary' => __( 'Secondary Menu', 'storefront' ),
 						'handheld'  => __( 'Handheld Menu', 'storefront' ),
@@ -103,8 +106,10 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 * to output valid HTML5.
 			 */
 			add_theme_support(
-				'html5', apply_filters(
-					'storefront_html5_args', array(
+				'html5',
+				apply_filters(
+					'storefront_html5_args',
+					array(
 						'search-form',
 						'comment-form',
 						'comment-list',
@@ -121,8 +126,10 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 * Setup the WordPress core custom background feature.
 			 */
 			add_theme_support(
-				'custom-background', apply_filters(
-					'storefront_custom_background_args', array(
+				'custom-background',
+				apply_filters(
+					'storefront_custom_background_args',
+					array(
 						'default-color' => apply_filters( 'storefront_default_background_color', 'ffffff' ),
 						'default-image' => '',
 					)
@@ -133,8 +140,10 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 * Setup the WordPress core custom header feature.
 			 */
 			add_theme_support(
-				'custom-header', apply_filters(
-					'storefront_custom_header_args', array(
+				'custom-header',
+				apply_filters(
+					'storefront_custom_header_args',
+					array(
 						'default-image' => '',
 						'header-text'   => false,
 						'width'         => 1950,
@@ -151,8 +160,10 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 *  http://jetpack.me/
 			 */
 			add_theme_support(
-				'site-logo', apply_filters(
-					'storefront_site_logo_args', array(
+				'site-logo',
+				apply_filters(
+					'storefront_site_logo_args',
+					array(
 						'size' => 'full',
 					)
 				)
@@ -186,33 +197,36 @@ if ( ! class_exists( 'Storefront' ) ) :
 			/**
 			 * Add support for editor font sizes.
 			 */
-			add_theme_support( 'editor-font-sizes', array(
+			add_theme_support(
+				'editor-font-sizes',
 				array(
-					'name' => __( 'Small', 'storefront' ),
-					'size' => 14,
-					'slug' => 'small',
-				),
-				array(
-					'name' => __( 'Normal', 'storefront' ),
-					'size' => 16,
-					'slug' => 'normal',
-				),
-				array(
-					'name' => __( 'Medium', 'storefront' ),
-					'size' => 23,
-					'slug' => 'medium',
-				),
-				array(
-					'name' => __( 'Large', 'storefront' ),
-					'size' => 26,
-					'slug' => 'large',
-				),
-				array(
-					'name' => __( 'Huge', 'storefront' ),
-					'size' => 37,
-					'slug' => 'huge',
-				),
-			) );
+					array(
+						'name' => __( 'Small', 'storefront' ),
+						'size' => 14,
+						'slug' => 'small',
+					),
+					array(
+						'name' => __( 'Normal', 'storefront' ),
+						'size' => 16,
+						'slug' => 'normal',
+					),
+					array(
+						'name' => __( 'Medium', 'storefront' ),
+						'size' => 23,
+						'slug' => 'medium',
+					),
+					array(
+						'name' => __( 'Large', 'storefront' ),
+						'size' => 26,
+						'slug' => 'large',
+					),
+					array(
+						'name' => __( 'Huge', 'storefront' ),
+						'size' => 37,
+						'slug' => 'huge',
+					),
+				)
+			);
 
 			/**
 			 * Enqueue editor styles.
@@ -323,7 +337,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 			/**
 			 * Fonts
 			 */
-			wp_enqueue_style( 'storefront-fonts', $this->google_fonts(), array(), null );
+			wp_enqueue_style( 'storefront-fonts', $this->google_fonts(), array(), $storefront_version );
 
 			/**
 			 * Scripts
@@ -361,7 +375,8 @@ if ( ! class_exists( 'Storefront' ) ) :
 		 */
 		public function google_fonts() {
 			$google_fonts = apply_filters(
-				'storefront_google_font_families', array(
+				'storefront_google_font_families',
+				array(
 					'source-sans-pro' => 'Source+Sans+Pro:400,300,300italic,400italic,600,700,900',
 				)
 			);
@@ -516,7 +531,9 @@ if ( ! class_exists( 'Storefront' ) ) :
 		 * Add styles for embeds
 		 */
 		public function print_embed_styles() {
-			wp_enqueue_style( 'source-sans-pro', '//fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,300italic,400italic,700,900' );
+			global $storefront_version;
+
+			wp_enqueue_style( 'source-sans-pro', '//fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,300italic,400italic,700,900', array(), $storefront_version );
 			$accent_color     = get_theme_mod( 'storefront_accent_color' );
 			$background_color = storefront_get_content_background_color();
 			?>

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -39,7 +39,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 		 */
 		public function get_storefront_default_setting_values() {
 			return apply_filters(
-				'storefront_setting_default_values', $args = array(
+				'storefront_setting_default_values',
+				$args = array(
 					'storefront_heading_color'           => '#333333',
 					'storefront_text_color'              => '#6d6d6d',
 					'storefront_accent_color'            => '#96588a',
@@ -132,21 +133,24 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				$wp_customize->get_setting( 'blogdescription' )->transport = 'postMessage';
 
 				$wp_customize->selective_refresh->add_partial(
-					'custom_logo', array(
+					'custom_logo',
+					array(
 						'selector'        => '.site-branding',
 						'render_callback' => array( $this, 'get_site_logo' ),
 					)
 				);
 
 				$wp_customize->selective_refresh->add_partial(
-					'blogname', array(
+					'blogname',
+					array(
 						'selector'        => '.site-title.beta a',
 						'render_callback' => array( $this, 'get_site_name' ),
 					)
 				);
 
 				$wp_customize->selective_refresh->add_partial(
-					'blogdescription', array(
+					'blogdescription',
+					array(
 						'selector'        => '.site-description',
 						'render_callback' => array( $this, 'get_site_description' ),
 					)
@@ -167,7 +171,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Add the typography section
 			 */
 			$wp_customize->add_section(
-				'storefront_typography', array(
+				'storefront_typography',
+				array(
 					'title'    => __( 'Typography', 'storefront' ),
 					'priority' => 45,
 				)
@@ -177,7 +182,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Heading color
 			 */
 			$wp_customize->add_setting(
-				'storefront_heading_color', array(
+				'storefront_heading_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_heading_color', '#484c51' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -185,7 +191,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_heading_color', array(
+					$wp_customize,
+					'storefront_heading_color',
+					array(
 						'label'    => __( 'Heading color', 'storefront' ),
 						'section'  => 'storefront_typography',
 						'settings' => 'storefront_heading_color',
@@ -198,7 +206,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Text Color
 			 */
 			$wp_customize->add_setting(
-				'storefront_text_color', array(
+				'storefront_text_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_text_color', '#43454b' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -206,7 +215,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_text_color', array(
+					$wp_customize,
+					'storefront_text_color',
+					array(
 						'label'    => __( 'Text color', 'storefront' ),
 						'section'  => 'storefront_typography',
 						'settings' => 'storefront_text_color',
@@ -219,7 +230,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Accent Color
 			 */
 			$wp_customize->add_setting(
-				'storefront_accent_color', array(
+				'storefront_accent_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_accent_color', '#96588a' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -227,7 +239,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_accent_color', array(
+					$wp_customize,
+					'storefront_accent_color',
+					array(
 						'label'    => __( 'Link / accent color', 'storefront' ),
 						'section'  => 'storefront_typography',
 						'settings' => 'storefront_accent_color',
@@ -240,7 +254,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Hero Heading Color
 			 */
 			$wp_customize->add_setting(
-				'storefront_hero_heading_color', array(
+				'storefront_hero_heading_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_hero_heading_color', '#000000' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -248,11 +263,13 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_hero_heading_color', array(
-						'label'           => __( 'Hero heading color', 'storefront' ),
-						'section'         => 'storefront_typography',
-						'settings'        => 'storefront_hero_heading_color',
-						'priority'        => 50,
+					$wp_customize,
+					'storefront_hero_heading_color',
+					array(
+						'label'    => __( 'Hero heading color', 'storefront' ),
+						'section'  => 'storefront_typography',
+						'settings' => 'storefront_hero_heading_color',
+						'priority' => 50,
 					)
 				)
 			);
@@ -261,7 +278,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Hero Text Color
 			 */
 			$wp_customize->add_setting(
-				'storefront_hero_text_color', array(
+				'storefront_hero_text_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_hero_text_color', '#000000' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -269,18 +287,22 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_hero_text_color', array(
-						'label'           => __( 'Hero text color', 'storefront' ),
-						'section'         => 'storefront_typography',
-						'settings'        => 'storefront_hero_text_color',
-						'priority'        => 60,
+					$wp_customize,
+					'storefront_hero_text_color',
+					array(
+						'label'    => __( 'Hero text color', 'storefront' ),
+						'section'  => 'storefront_typography',
+						'settings' => 'storefront_hero_text_color',
+						'priority' => 60,
 					)
 				)
 			);
 
 			$wp_customize->add_control(
 				new Arbitrary_Storefront_Control(
-					$wp_customize, 'storefront_header_image_heading', array(
+					$wp_customize,
+					'storefront_header_image_heading',
+					array(
 						'section'  => 'header_image',
 						'type'     => 'heading',
 						'label'    => __( 'Header background image', 'storefront' ),
@@ -293,7 +315,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Header Background
 			 */
 			$wp_customize->add_setting(
-				'storefront_header_background_color', array(
+				'storefront_header_background_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_header_background_color', '#2c2d33' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -301,7 +324,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_header_background_color', array(
+					$wp_customize,
+					'storefront_header_background_color',
+					array(
 						'label'    => __( 'Background color', 'storefront' ),
 						'section'  => 'header_image',
 						'settings' => 'storefront_header_background_color',
@@ -314,7 +339,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Header text color
 			 */
 			$wp_customize->add_setting(
-				'storefront_header_text_color', array(
+				'storefront_header_text_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_header_text_color', '#9aa0a7' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -322,7 +348,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_header_text_color', array(
+					$wp_customize,
+					'storefront_header_text_color',
+					array(
 						'label'    => __( 'Text color', 'storefront' ),
 						'section'  => 'header_image',
 						'settings' => 'storefront_header_text_color',
@@ -335,7 +363,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Header link color
 			 */
 			$wp_customize->add_setting(
-				'storefront_header_link_color', array(
+				'storefront_header_link_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_header_link_color', '#d5d9db' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -343,7 +372,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_header_link_color', array(
+					$wp_customize,
+					'storefront_header_link_color',
+					array(
 						'label'    => __( 'Link color', 'storefront' ),
 						'section'  => 'header_image',
 						'settings' => 'storefront_header_link_color',
@@ -356,7 +387,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Footer section
 			 */
 			$wp_customize->add_section(
-				'storefront_footer', array(
+				'storefront_footer',
+				array(
 					'title'       => __( 'Footer', 'storefront' ),
 					'priority'    => 28,
 					'description' => __( 'Customize the look & feel of your website footer.', 'storefront' ),
@@ -367,7 +399,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Footer Background
 			 */
 			$wp_customize->add_setting(
-				'storefront_footer_background_color', array(
+				'storefront_footer_background_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_footer_background_color', '#f0f0f0' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -375,7 +408,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_footer_background_color', array(
+					$wp_customize,
+					'storefront_footer_background_color',
+					array(
 						'label'    => __( 'Background color', 'storefront' ),
 						'section'  => 'storefront_footer',
 						'settings' => 'storefront_footer_background_color',
@@ -388,7 +423,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Footer heading color
 			 */
 			$wp_customize->add_setting(
-				'storefront_footer_heading_color', array(
+				'storefront_footer_heading_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_footer_heading_color', '#494c50' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -396,7 +432,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_footer_heading_color', array(
+					$wp_customize,
+					'storefront_footer_heading_color',
+					array(
 						'label'    => __( 'Heading color', 'storefront' ),
 						'section'  => 'storefront_footer',
 						'settings' => 'storefront_footer_heading_color',
@@ -409,7 +447,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Footer text color
 			 */
 			$wp_customize->add_setting(
-				'storefront_footer_text_color', array(
+				'storefront_footer_text_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_footer_text_color', '#61656b' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -417,7 +456,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_footer_text_color', array(
+					$wp_customize,
+					'storefront_footer_text_color',
+					array(
 						'label'    => __( 'Text color', 'storefront' ),
 						'section'  => 'storefront_footer',
 						'settings' => 'storefront_footer_text_color',
@@ -430,7 +471,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Footer link color
 			 */
 			$wp_customize->add_setting(
-				'storefront_footer_link_color', array(
+				'storefront_footer_link_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_footer_link_color', '#2c2d33' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -438,7 +480,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_footer_link_color', array(
+					$wp_customize,
+					'storefront_footer_link_color',
+					array(
 						'label'    => __( 'Link color', 'storefront' ),
 						'section'  => 'storefront_footer',
 						'settings' => 'storefront_footer_link_color',
@@ -451,7 +495,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Buttons section
 			 */
 			$wp_customize->add_section(
-				'storefront_buttons', array(
+				'storefront_buttons',
+				array(
 					'title'       => __( 'Buttons', 'storefront' ),
 					'priority'    => 45,
 					'description' => __( 'Customize the look & feel of your website buttons.', 'storefront' ),
@@ -462,7 +507,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Button background color
 			 */
 			$wp_customize->add_setting(
-				'storefront_button_background_color', array(
+				'storefront_button_background_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_button_background_color', '#96588a' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -470,7 +516,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_button_background_color', array(
+					$wp_customize,
+					'storefront_button_background_color',
+					array(
 						'label'    => __( 'Background color', 'storefront' ),
 						'section'  => 'storefront_buttons',
 						'settings' => 'storefront_button_background_color',
@@ -483,7 +531,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Button text color
 			 */
 			$wp_customize->add_setting(
-				'storefront_button_text_color', array(
+				'storefront_button_text_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_button_text_color', '#ffffff' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -491,7 +540,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_button_text_color', array(
+					$wp_customize,
+					'storefront_button_text_color',
+					array(
 						'label'    => __( 'Text color', 'storefront' ),
 						'section'  => 'storefront_buttons',
 						'settings' => 'storefront_button_text_color',
@@ -504,7 +555,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Button alt background color
 			 */
 			$wp_customize->add_setting(
-				'storefront_button_alt_background_color', array(
+				'storefront_button_alt_background_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_button_alt_background_color', '#2c2d33' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -512,7 +564,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_button_alt_background_color', array(
+					$wp_customize,
+					'storefront_button_alt_background_color',
+					array(
 						'label'    => __( 'Alternate button background color', 'storefront' ),
 						'section'  => 'storefront_buttons',
 						'settings' => 'storefront_button_alt_background_color',
@@ -525,7 +579,8 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Button alt text color
 			 */
 			$wp_customize->add_setting(
-				'storefront_button_alt_text_color', array(
+				'storefront_button_alt_text_color',
+				array(
 					'default'           => apply_filters( 'storefront_default_button_alt_text_color', '#ffffff' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
@@ -533,7 +588,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new WP_Customize_Color_Control(
-					$wp_customize, 'storefront_button_alt_text_color', array(
+					$wp_customize,
+					'storefront_button_alt_text_color',
+					array(
 						'label'    => __( 'Alternate button text color', 'storefront' ),
 						'section'  => 'storefront_buttons',
 						'settings' => 'storefront_button_alt_text_color',
@@ -546,14 +603,16 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * Layout
 			 */
 			$wp_customize->add_section(
-				'storefront_layout', array(
+				'storefront_layout',
+				array(
 					'title'    => __( 'Layout', 'storefront' ),
 					'priority' => 50,
 				)
 			);
 
 			$wp_customize->add_setting(
-				'storefront_layout', array(
+				'storefront_layout',
+				array(
 					'default'           => apply_filters( 'storefront_default_layout', $layout = is_rtl() ? 'left' : 'right' ),
 					'sanitize_callback' => 'storefront_sanitize_choices',
 				)
@@ -561,7 +620,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 			$wp_customize->add_control(
 				new Storefront_Custom_Radio_Image_Control(
-					$wp_customize, 'storefront_layout', array(
+					$wp_customize,
+					'storefront_layout',
+					array(
 						'settings' => 'storefront_layout',
 						'section'  => 'storefront_layout',
 						'label'    => __( 'General Layout', 'storefront' ),
@@ -579,14 +640,16 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 */
 			if ( apply_filters( 'storefront_customizer_more', true ) ) {
 				$wp_customize->add_section(
-					'storefront_more', array(
+					'storefront_more',
+					array(
 						'title'    => __( 'More', 'storefront' ),
 						'priority' => 999,
 					)
 				);
 
 				$wp_customize->add_setting(
-					'storefront_more', array(
+					'storefront_more',
+					array(
 						'default'           => null,
 						'sanitize_callback' => 'sanitize_text_field',
 					)
@@ -594,7 +657,9 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 
 				$wp_customize->add_control(
 					new More_Storefront_Control(
-						$wp_customize, 'storefront_more', array(
+						$wp_customize,
+						'storefront_more',
+						array(
 							'label'    => __( 'Looking for more options?', 'storefront' ),
 							'section'  => 'storefront_more',
 							'settings' => 'storefront_more',

--- a/inc/jetpack/class-storefront-jetpack.php
+++ b/inc/jetpack/class-storefront-jetpack.php
@@ -37,8 +37,10 @@ if ( ! class_exists( 'Storefront_Jetpack' ) ) :
 		 */
 		public function jetpack_setup() {
 			add_theme_support(
-				'infinite-scroll', apply_filters(
-					'storefront_jetpack_infinite_scroll_args', array(
+				'infinite-scroll',
+				apply_filters(
+					'storefront_jetpack_infinite_scroll_args',
+					array(
 						'container'      => 'main',
 						'footer'         => 'page',
 						'render'         => array( $this, 'jetpack_infinite_scroll_loop' ),

--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -211,7 +211,8 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 			$woocommerce_pages = array();
 
 			$wc_pages_options = apply_filters(
-				'storefront_page_option_names', array(
+				'storefront_page_option_names',
+				array(
 					'woocommerce_cart_page_id',
 					'woocommerce_checkout_page_id',
 					'woocommerce_myaccount_page_id',

--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -466,7 +466,8 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 
 			// Get empty categories.
 			$categories = get_terms(
-				'product_cat', array(
+				'product_cat',
+				array(
 					'hide_empty' => false,
 				)
 			);
@@ -642,7 +643,8 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		public function filter_sf_categories( $args ) {
 			// Get Categories.
 			$product_cats = get_terms(
-				'product_cat', array(
+				'product_cat',
+				array(
 					'fields'     => 'ids',
 					'hide_empty' => false,
 				)

--- a/inc/storefront-functions.php
+++ b/inc/storefront-functions.php
@@ -153,7 +153,7 @@ function get_rgb_values_from_hex( $hex ) {
  * @since  2.5.8
  */
 function is_color_light( $hex ) {
-	$rgb_values = get_rgb_values_from_hex( $hex );
+	$rgb_values        = get_rgb_values_from_hex( $hex );
 	$average_lightness = ( $rgb_values['r'] + $rgb_values['g'] + $rgb_values['b'] ) / 3;
 	return $average_lightness >= 127.5;
 }

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -50,7 +50,7 @@ if ( ! function_exists( 'storefront_comment' ) ) {
 			<?php endif; ?>
 
 			<a href="<?php echo esc_url( htmlspecialchars( get_comment_link( $comment->comment_ID ) ) ); ?>" class="comment-date">
-				<?php echo '<time datetime="' . get_comment_date( 'c' ) . '">' . get_comment_date() . '</time>'; ?>
+				<?php echo '<time datetime="' . esc_html( get_comment_date( 'c' ) ) . '">' . esc_html( get_comment_date() ) . '</time>'; ?>
 			</a>
 		</div>
 		<?php if ( 'div' !== $args['style'] ) : ?>
@@ -63,7 +63,8 @@ if ( ! function_exists( 'storefront_comment' ) ) {
 		<?php
 		comment_reply_link(
 			array_merge(
-				$args, array(
+				$args,
+				array(
 					'add_below' => $add_below,
 					'depth'     => $depth,
 					'max_depth' => $args['max_depth'],
@@ -145,14 +146,14 @@ if ( ! function_exists( 'storefront_credit' ) ) {
 		}
 
 		if ( apply_filters( 'storefront_privacy_policy_link', true ) && function_exists( 'the_privacy_policy_link' ) ) {
-			$separator = '<span role="separator" aria-hidden="true"></span>';
+			$separator    = '<span role="separator" aria-hidden="true"></span>';
 			$links_output = get_the_privacy_policy_link( '', ( ! empty( $links_output ) ? $separator : '' ) ) . $links_output;
 		}
-		
+
 		$links_output = apply_filters( 'storefront_credit_links_output', $links_output );
 		?>
 		<div class="site-info">
-			<?php echo esc_html( apply_filters( 'storefront_copyright_text', $content = '&copy; ' . get_bloginfo( 'name' ) . ' ' . date( 'Y' ) ) ); ?>
+			<?php echo esc_html( apply_filters( 'storefront_copyright_text', $content = '&copy; ' . get_bloginfo( 'name' ) . ' ' . gmdate( 'Y' ) ) ); ?>
 
 			<?php if ( ! empty( $links_output ) ) { ?>
 				<br />
@@ -489,7 +490,8 @@ if ( ! function_exists( 'storefront_post_meta' ) ) {
 		}
 
 		echo wp_kses(
-			sprintf( '%1$s %2$s %3$s', $posted_on, $author, $comments ), array(
+			sprintf( '%1$s %2$s %3$s', $posted_on, $author, $comments ),
+			array(
 				'span' => array(
 					'class' => array(),
 				),

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -225,7 +225,7 @@ if ( ! function_exists( 'storefront_site_title_or_logo' ) ) {
 			return $html;
 		}
 
-		echo $html; // WPCS: XSS ok.
+		echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
 

--- a/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
+++ b/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
@@ -79,7 +79,7 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 		public function get_product() {
 			global $post;
 
-			$product = false;
+			$product               = false;
 			$this->current_product = $post->ID;
 
 			// Try to get a valid product via `get_adjacent_post()`.
@@ -163,7 +163,7 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 				'visibility' => 'catalog',
 				'exclude'    => array( $post->ID ),
 				'orderby'    => 'date',
-				'status'     => 'publish'
+				'status'     => 'publish',
 			);
 
 			if ( ! $this->previous ) {

--- a/inc/woocommerce/class-storefront-woocommerce-customizer.php
+++ b/inc/woocommerce/class-storefront-woocommerce-customizer.php
@@ -55,7 +55,8 @@ if ( ! class_exists( 'Storefront_WooCommerce_Customizer' ) ) :
 			 * Product Page
 			 */
 			$wp_customize->add_section(
-				'storefront_single_product_page', array(
+				'storefront_single_product_page',
+				array(
 					'title'    => __( 'Product Page', 'storefront' ),
 					'priority' => 10,
 					'panel'    => 'woocommerce',
@@ -63,21 +64,24 @@ if ( ! class_exists( 'Storefront_WooCommerce_Customizer' ) ) :
 			);
 
 			$wp_customize->add_setting(
-				'storefront_product_pagination', array(
+				'storefront_product_pagination',
+				array(
 					'default'           => apply_filters( 'storefront_default_product_pagination', true ),
 					'sanitize_callback' => 'wp_validate_boolean',
 				)
 			);
 
 			$wp_customize->add_setting(
-				'storefront_sticky_add_to_cart', array(
+				'storefront_sticky_add_to_cart',
+				array(
 					'default'           => apply_filters( 'storefront_default_sticky_add_to_cart', true ),
 					'sanitize_callback' => 'wp_validate_boolean',
 				)
 			);
 
 			$wp_customize->add_control(
-				'storefront_sticky_add_to_cart', array(
+				'storefront_sticky_add_to_cart',
+				array(
 					'type'        => 'checkbox',
 					'section'     => 'storefront_single_product_page',
 					'label'       => __( 'Sticky Add-To-Cart', 'storefront' ),
@@ -87,7 +91,8 @@ if ( ! class_exists( 'Storefront_WooCommerce_Customizer' ) ) :
 			);
 
 			$wp_customize->add_control(
-				'storefront_product_pagination', array(
+				'storefront_product_pagination',
+				array(
 					'type'        => 'checkbox',
 					'section'     => 'storefront_single_product_page',
 					'label'       => __( 'Product Pagination', 'storefront' ),

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -57,8 +57,10 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 		 */
 		public function setup() {
 			add_theme_support(
-				'woocommerce', apply_filters(
-					'storefront_woocommerce_args', array(
+				'woocommerce',
+				apply_filters(
+					'storefront_woocommerce_args',
+					array(
 						'single_image_width'    => 416,
 						'thumbnail_image_width' => 324,
 						'product_grid'          => array(
@@ -183,7 +185,8 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 		 */
 		public function related_products_args( $args ) {
 			$args = apply_filters(
-				'storefront_related_products_args', array(
+				'storefront_related_products_args',
+				array(
 					'posts_per_page' => 3,
 					'columns'        => 3,
 				)

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -302,7 +302,7 @@ if ( ! function_exists( 'storefront_product_categories' ) ) {
 
 			do_action( 'storefront_homepage_after_product_categories_title' );
 
-			echo $shortcode_content; // WPCS: XSS ok.
+			echo $shortcode_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 			do_action( 'storefront_homepage_after_product_categories' );
 
@@ -357,7 +357,7 @@ if ( ! function_exists( 'storefront_recent_products' ) ) {
 
 			do_action( 'storefront_homepage_after_recent_products_title' );
 
-			echo $shortcode_content; // WPCS: XSS ok.
+			echo $shortcode_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 			do_action( 'storefront_homepage_after_recent_products' );
 
@@ -414,7 +414,7 @@ if ( ! function_exists( 'storefront_featured_products' ) ) {
 
 			do_action( 'storefront_homepage_after_featured_products_title' );
 
-			echo $shortcode_content; // WPCS: XSS ok.
+			echo $shortcode_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 			do_action( 'storefront_homepage_after_featured_products' );
 
@@ -469,7 +469,7 @@ if ( ! function_exists( 'storefront_popular_products' ) ) {
 
 			do_action( 'storefront_homepage_after_popular_products_title' );
 
-			echo $shortcode_content; // WPCS: XSS ok.
+			echo $shortcode_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 			do_action( 'storefront_homepage_after_popular_products' );
 
@@ -526,7 +526,7 @@ if ( ! function_exists( 'storefront_on_sale_products' ) ) {
 
 			do_action( 'storefront_homepage_after_on_sale_products_title' );
 
-			echo $shortcode_content; // WPCS: XSS ok.
+			echo $shortcode_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 			do_action( 'storefront_homepage_after_on_sale_products' );
 
@@ -581,7 +581,7 @@ if ( ! function_exists( 'storefront_best_selling_products' ) ) {
 
 			do_action( 'storefront_homepage_after_best_selling_products_title' );
 
-			echo $shortcode_content; // WPCS: XSS ok.
+			echo $shortcode_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 			do_action( 'storefront_homepage_after_best_selling_products' );
 
@@ -613,35 +613,41 @@ if ( ! function_exists( 'storefront_promoted_products' ) ) {
 
 				echo '<h2>' . esc_html__( 'Featured Products', 'storefront' ) . '</h2>';
 
+				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo storefront_do_shortcode(
 					'featured_products',
 					array(
 						'per_page' => $per_page,
 						'columns'  => $columns,
 					)
-				); // WPCS: XSS ok.
+				);
+				// phpcs:enable
 			} elseif ( wc_get_product_ids_on_sale() ) {
 
 				echo '<h2>' . esc_html__( 'On Sale Now', 'storefront' ) . '</h2>';
 
+				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo storefront_do_shortcode(
 					'sale_products',
 					array(
 						'per_page' => $per_page,
 						'columns'  => $columns,
 					)
-				); // WPCS: XSS ok.
+				);
+				// phpcs:enable
 			} elseif ( $recent_fallback ) {
 
 				echo '<h2>' . esc_html__( 'New In Store', 'storefront' ) . '</h2>';
 
+				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo storefront_do_shortcode(
 					'recent_products',
 					array(
 						'per_page' => $per_page,
 						'columns'  => $columns,
 					)
-				); // WPCS: XSS ok.
+				);
+				// phpcs:enable
 			}
 		}
 	}
@@ -890,7 +896,7 @@ if ( ! function_exists( 'storefront_woocommerce_brands_homepage_section' ) ) {
 
 		do_action( 'storefront_homepage_after_woocommerce_brands_title' );
 
-		echo $shortcode_content; // WPCS: XSS ok.
+		echo $shortcode_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		do_action( 'storefront_homepage_after_woocommerce_brands' );
 

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -267,7 +267,8 @@ if ( ! function_exists( 'storefront_product_categories' ) ) {
 	 */
 	function storefront_product_categories( $args ) {
 		$args = apply_filters(
-			'storefront_product_categories_args', array(
+			'storefront_product_categories_args',
+			array(
 				'limit'            => 3,
 				'columns'          => 3,
 				'child_categories' => 0,
@@ -277,8 +278,10 @@ if ( ! function_exists( 'storefront_product_categories' ) ) {
 		);
 
 		$shortcode_content = storefront_do_shortcode(
-			'product_categories', apply_filters(
-				'storefront_product_categories_shortcode_args', array(
+			'product_categories',
+			apply_filters(
+				'storefront_product_categories_shortcode_args',
+				array(
 					'number'  => intval( $args['limit'] ),
 					'columns' => intval( $args['columns'] ),
 					'orderby' => esc_attr( $args['orderby'] ),
@@ -319,7 +322,8 @@ if ( ! function_exists( 'storefront_recent_products' ) ) {
 	 */
 	function storefront_recent_products( $args ) {
 		$args = apply_filters(
-			'storefront_recent_products_args', array(
+			'storefront_recent_products_args',
+			array(
 				'limit'   => 4,
 				'columns' => 4,
 				'orderby' => 'date',
@@ -329,8 +333,10 @@ if ( ! function_exists( 'storefront_recent_products' ) ) {
 		);
 
 		$shortcode_content = storefront_do_shortcode(
-			'products', apply_filters(
-				'storefront_recent_products_shortcode_args', array(
+			'products',
+			apply_filters(
+				'storefront_recent_products_shortcode_args',
+				array(
 					'orderby'  => esc_attr( $args['orderby'] ),
 					'order'    => esc_attr( $args['order'] ),
 					'per_page' => intval( $args['limit'] ),
@@ -371,7 +377,8 @@ if ( ! function_exists( 'storefront_featured_products' ) ) {
 	 */
 	function storefront_featured_products( $args ) {
 		$args = apply_filters(
-			'storefront_featured_products_args', array(
+			'storefront_featured_products_args',
+			array(
 				'limit'      => 4,
 				'columns'    => 4,
 				'orderby'    => 'date',
@@ -382,8 +389,10 @@ if ( ! function_exists( 'storefront_featured_products' ) ) {
 		);
 
 		$shortcode_content = storefront_do_shortcode(
-			'products', apply_filters(
-				'storefront_featured_products_shortcode_args', array(
+			'products',
+			apply_filters(
+				'storefront_featured_products_shortcode_args',
+				array(
 					'per_page'   => intval( $args['limit'] ),
 					'columns'    => intval( $args['columns'] ),
 					'orderby'    => esc_attr( $args['orderby'] ),
@@ -425,7 +434,8 @@ if ( ! function_exists( 'storefront_popular_products' ) ) {
 	 */
 	function storefront_popular_products( $args ) {
 		$args = apply_filters(
-			'storefront_popular_products_args', array(
+			'storefront_popular_products_args',
+			array(
 				'limit'   => 4,
 				'columns' => 4,
 				'orderby' => 'rating',
@@ -435,8 +445,10 @@ if ( ! function_exists( 'storefront_popular_products' ) ) {
 		);
 
 		$shortcode_content = storefront_do_shortcode(
-			'products', apply_filters(
-				'storefront_popular_products_shortcode_args', array(
+			'products',
+			apply_filters(
+				'storefront_popular_products_shortcode_args',
+				array(
 					'per_page' => intval( $args['limit'] ),
 					'columns'  => intval( $args['columns'] ),
 					'orderby'  => esc_attr( $args['orderby'] ),
@@ -477,7 +489,8 @@ if ( ! function_exists( 'storefront_on_sale_products' ) ) {
 	 */
 	function storefront_on_sale_products( $args ) {
 		$args = apply_filters(
-			'storefront_on_sale_products_args', array(
+			'storefront_on_sale_products_args',
+			array(
 				'limit'   => 4,
 				'columns' => 4,
 				'orderby' => 'date',
@@ -488,8 +501,10 @@ if ( ! function_exists( 'storefront_on_sale_products' ) ) {
 		);
 
 		$shortcode_content = storefront_do_shortcode(
-			'products', apply_filters(
-				'storefront_on_sale_products_shortcode_args', array(
+			'products',
+			apply_filters(
+				'storefront_on_sale_products_shortcode_args',
+				array(
 					'per_page' => intval( $args['limit'] ),
 					'columns'  => intval( $args['columns'] ),
 					'orderby'  => esc_attr( $args['orderby'] ),
@@ -531,7 +546,8 @@ if ( ! function_exists( 'storefront_best_selling_products' ) ) {
 	 */
 	function storefront_best_selling_products( $args ) {
 		$args = apply_filters(
-			'storefront_best_selling_products_args', array(
+			'storefront_best_selling_products_args',
+			array(
 				'limit'   => 4,
 				'columns' => 4,
 				'orderby' => 'popularity',
@@ -541,8 +557,10 @@ if ( ! function_exists( 'storefront_best_selling_products' ) ) {
 		);
 
 		$shortcode_content = storefront_do_shortcode(
-			'products', apply_filters(
-				'storefront_best_selling_products_shortcode_args', array(
+			'products',
+			apply_filters(
+				'storefront_best_selling_products_shortcode_args',
+				array(
 					'per_page' => intval( $args['limit'] ),
 					'columns'  => intval( $args['columns'] ),
 					'orderby'  => esc_attr( $args['orderby'] ),
@@ -596,7 +614,8 @@ if ( ! function_exists( 'storefront_promoted_products' ) ) {
 				echo '<h2>' . esc_html__( 'Featured Products', 'storefront' ) . '</h2>';
 
 				echo storefront_do_shortcode(
-					'featured_products', array(
+					'featured_products',
+					array(
 						'per_page' => $per_page,
 						'columns'  => $columns,
 					)
@@ -606,7 +625,8 @@ if ( ! function_exists( 'storefront_promoted_products' ) ) {
 				echo '<h2>' . esc_html__( 'On Sale Now', 'storefront' ) . '</h2>';
 
 				echo storefront_do_shortcode(
-					'sale_products', array(
+					'sale_products',
+					array(
 						'per_page' => $per_page,
 						'columns'  => $columns,
 					)
@@ -616,7 +636,8 @@ if ( ! function_exists( 'storefront_promoted_products' ) ) {
 				echo '<h2>' . esc_html__( 'New In Store', 'storefront' ) . '</h2>';
 
 				echo storefront_do_shortcode(
-					'recent_products', array(
+					'recent_products',
+					array(
 						'per_page' => $per_page,
 						'columns'  => $columns,
 					)
@@ -784,7 +805,7 @@ if ( ! function_exists( 'storefront_sticky_single_add_to_cart' ) ) {
 
 		if ( $product->is_purchasable() && $product->is_in_stock() ) {
 			$show = true;
-		} else if ( $product->is_type( 'external' ) ) {
+		} elseif ( $product->is_type( 'external' ) ) {
 			$show = true;
 		}
 
@@ -793,7 +814,8 @@ if ( ! function_exists( 'storefront_sticky_single_add_to_cart' ) ) {
 		}
 
 		$params = apply_filters(
-			'storefront_sticky_add_to_cart_params', array(
+			'storefront_sticky_add_to_cart_params',
+			array(
 				'trigger_class' => 'entry-summary',
 			)
 		);
@@ -837,7 +859,8 @@ if ( ! function_exists( 'storefront_woocommerce_brands_homepage_section' ) ) {
 	 */
 	function storefront_woocommerce_brands_homepage_section() {
 		$args = apply_filters(
-			'storefront_woocommerce_brands_args', array(
+			'storefront_woocommerce_brands_args',
+			array(
 				'number'     => 6,
 				'columns'    => 4,
 				'orderby'    => 'name',
@@ -847,8 +870,10 @@ if ( ! function_exists( 'storefront_woocommerce_brands_homepage_section' ) ) {
 		);
 
 		$shortcode_content = storefront_do_shortcode(
-			'product_brand_thumbnails', apply_filters(
-				'storefront_woocommerce_brands_shortcode_args', array(
+			'product_brand_thumbnails',
+			apply_filters(
+				'storefront_woocommerce_brands_shortcode_args',
+				array(
 					'number'     => absint( $args['number'] ),
 					'columns'    => absint( $args['columns'] ),
 					'orderby'    => esc_attr( $args['orderby'] ),
@@ -906,7 +931,8 @@ if ( ! function_exists( 'storefront_woocommerce_brands_single' ) ) {
 	 */
 	function storefront_woocommerce_brands_single() {
 		$brand = storefront_do_shortcode(
-			'product_brand', array(
+			'product_brand',
+			array(
 				'class' => '',
 			)
 		);

--- a/inc/wordpress-shims.php
+++ b/inc/wordpress-shims.php
@@ -6,14 +6,14 @@
  */
 
 if ( ! function_exists( 'wp_body_open' ) ) {
-    /**
-     * Adds backwards compatibility for wp_body_open() introduced with WordPress 5.2
-     *
-     * @since 2.5.4
-     * @see https://developer.wordpress.org/reference/functions/wp_body_open/
-     * @return void
-     */
-    function wp_body_open() {
-        do_action( 'wp_body_open' );
-    }
+	/**
+	 * Adds backwards compatibility for wp_body_open() introduced with WordPress 5.2
+	 *
+	 * @since 2.5.4
+	 * @see https://developer.wordpress.org/reference/functions/wp_body_open/
+	 * @return void
+	 */
+	function wp_body_open() {
+		do_action( 'wp_body_open' );
+	}
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "css": "grunt css",
     "watch": "grunt watch",
     "deploy": "grunt deploy",
+    "lint:php": "composer run-script phpcs ./",
+    "lint:php:fix": "composer run-script phpcbf ./",
     "e2e:start": "wp-env start",
     "e2e:stop": "wp-env stop",
     "e2e:destroy": "wp-env destroy",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,7 +10,7 @@
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="4.7" />
+	<config name="minimum_supported_wp_version" value="5.3" />
 	<config name="testVersion" value="5.2-"/>
 
 	<!-- Rules -->
@@ -21,27 +21,6 @@
 		<exclude name="PHPCompatibility.PHP.NewKeywords.t_namespaceFound" />
 	</rule>
 
-	<rule ref="WordPress">
-		<exclude name="WordPress.VIP.DirectDatabaseQuery.NoCaching" />
-		<exclude name="WordPress.VIP.DirectDatabaseQuery.DirectQuery" />
-		<exclude name="WordPress.VIP.DirectDatabaseQuery.SchemaChange" />
-		<exclude name="WordPress.VIP.FileSystemWritesDisallow.file_ops_fwrite" />
-		<exclude name="WordPress.VIP.OrderByRand" />
-		<exclude name="WordPress.VIP.RestrictedFunctions" />
-		<exclude name="WordPress.VIP.RestrictedVariables.user_meta__wpdb__usermeta" />
-		<exclude name="WordPress.VIP.PostsPerPage.posts_per_page_posts_per_page" />
-		<exclude name="WordPress.VIP.RestrictedVariables.cache_constraints___COOKIE" />
-	</rule>
-	<rule ref="WordPress.VIP.ValidatedSanitizedInput">
-		<properties>
-			<property name="customSanitizingFunctions" type="array" value="wc_clean,wc_sanitize_tooltip,wc_format_decimal,wc_stock_amount,wc_sanitize_permalink,wc_sanitize_textarea" />
-		</properties>
-	</rule>
-	<rule ref="WordPress.XSS.EscapeOutput">
-		<properties>
-			<property name="customEscapingFunctions" type="array" value="wc_help_tip,wc_sanitize_tooltip" />
-		</properties>
-	</rule>
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array" value="storefront" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,8 +6,9 @@
 	<description>WooCommerce dev PHP_CodeSniffer ruleset.</description>
 
 	<!-- Exclude paths -->
-	<exclude-pattern>*/node_modules/*</exclude-pattern>
-	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/storefront/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/storefront/vendor/*</exclude-pattern>
+	<exclude-pattern>*/storefront/storefront/*</exclude-pattern>
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="5.3" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,7 +11,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="5.3" />
-	<config name="testVersion" value="5.2-"/>
+	<config name="testVersion" value="5.6-"/>
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,7 +20,7 @@
 		<exclude name="PHPCompatibility.PHP.NewInterfaces.jsonserializableFound" />
 		<exclude name="PHPCompatibility.PHP.NewKeywords.t_namespaceFound" />
 	</rule>
-
+	<rule ref="WordPress" />
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array" value="storefront" />


### PR DESCRIPTION
Prompted by #1393
Fixes #1356

Update: woah cool there is an issue for this! #1356 🎩 @nielslange 

The original goal of this PR was to update the WordPress coding standards PHPcs ruleset, and anything necessary related to it.

I discovered that our phpcs setup wasn't in working order, so have upgraded and replaced various packages. 

~~Work in progress - need to ensure we have enough rules in place that match the existing code. Currently have lots of violations.~~ All violations now fixed and pre-commit should catch issues in new code.

Summary of what's included in this PR:

- Updated and set versions for various phpcs related packages. Key outcome here is getting on the latest WordPress standards. fac37e55bfb523c07e37299edf46946839290d5f
- Added/tweaked commands in composer.json and package.json for visibility and to encourage use/familiarity.
- Set min PHP version of sniffer config to match plugin min PHP version.
- Mega commit fixing all formatting issues automatically using `phpcbf`. 7c90d2311b0433ee9cb0f9d896704c64db3ae0e5
- Manual fixing of a few more interesting violations (~10 issues). One commit per file for visibility. Note this included:
  - Adding/fixing version param in all uses of `wp_enqueue_style`. This means that various third-party assets will be cached less aggressively (now tied to `$storefront_version`).
  - Missing escaping of comment dates in `storefront_comment()` (🧤)
  - Use `gmdate()` instead of ambiguous `date()`.
- Fixed one rule ignore comment to latest format. (Still ignoring, didn't investigate why)

##### We still have some warnings throughout code
> Also notice that when I run that command I get several warnings. I assume that's expected? – @Aljullu 

I've fixed all errors but have not touched any warnings. Warnings should be _carefully_ handled as follow up - linter warnings can be very subtle/tricky/risky  🐲 to fix, so I'm not rushing to fix them all in this PR!

**Update** I have bulk-fixed an older style of ignore comment to reduce the amount of open warnings. These comments opt-out of XSS checks, and we have a lot of them. c2b82fac62038925df1db0bf0fb6f7ed555808c9

- Old comment `// WPCS: XSS ok.`
- Current comment, using `phpcs:ignore` `// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped`


##### Travis / CI is _not_ included (yet)
Note there's nothing in this PR to trigger linter check as a CI step (e.g. on PRs). We should do that next! #1395 

### How to test the changes
#### Test linter tooling
1. Get on this branch, `composer install`, `npm install`.
   - Note: `composer install` is what sets up the `pre-commit` hook (TIL).
2. Run linter `npm run lint:php`. Should pass with flying colours (* and plenty of warnings 😿).
3. Write some [bad PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/).
4. Run linter again - should tell you what's wrong.
5. Try to commit the bad changes - commit hook should catch it. 
5. Write some PHP with auto-fixable changes (e.g. spaces/tabs, dangling commas, long lines, multi-line func calls).
6. Run auto fix to `npm run lint:php:fix`. Should fix the errors so you can commit.

#### Broad smoke testing of a cross-section of Storefront functionality
As this is a big change, any testing of Storefront features would be appreciated. 

cc @woocommerce/rubik I've tagged you all for review – first in first served. I don't expect everyone to review – grateful for any reviews or testing.

If you could run this PR (or master after merge) in your dev environment and keep an eye out for issues I would really appreciate it 🙌 🙇 

#### Affected flows
- Everything (in theory). 
- Comment dates now escaped. 

### Changelog

> Dev – Reinstate phpcs PHP linting. #1463
