### PR TITLE
🐛 FIX: Adjust browse products button on mobile (#1328)

### DIFF
--- a/assets/css/sass/utils/_variables.scss
+++ b/assets/css/sass/utils/_variables.scss
@@ -20,6 +20,7 @@ $info:              #3d9cd2;
 
 // layout sizes
 $desktop:           768px;
+$handheld-max:      767px;
 $handheld:          568px;
 $container-width:   ms(18);
 

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1984,6 +1984,31 @@ dl.variation {
 	}
 }
 
+@media (max-width: $handheld-max) {
+	.woocommerce-MyAccount-content {
+		.woocommerce-info {
+			padding: 1em;
+			
+			.button {
+				background: $body-background;
+				border: 1px solid;
+				border-radius: 3px;
+				color: $info;
+				display: block;
+				float: none;
+				margin: 0 0 0.5em;
+				padding: 0.5em;
+				width: 100%;
+			}
+
+			&::before {
+				display: none;
+			}
+
+		}
+	}
+}
+
 /**
  * Homepage
  */


### PR DESCRIPTION
Fixes #1328

Adjust the **No downloads available yet.** label and **Browse products** button within the **Downloads** section on the **My Account** page on a mobile device.

### Screenshots

#### English texts

<table>
<tr>
<td>Before:
<br><br>

![#1328-before-EN](https://user-images.githubusercontent.com/3323310/93623907-a77f2a00-fa09-11ea-997a-6fa2b15c5523.png)
</td>
<td>After:
<br><br>

![#1328-after-EN](https://user-images.githubusercontent.com/3323310/93623911-a817c080-fa09-11ea-828d-997e965d9b43.png)
</td>
</tr>
</table>

#### Spanish texts

<table>
<tr>
<td>Before:
<br><br>

![#1328-before-ES](https://user-images.githubusercontent.com/3323310/93623906-a6e69380-fa09-11ea-8734-e8e82897b37d.png)
</td>
<td>After:
<br><br>

![#1328-after-ES](https://user-images.githubusercontent.com/3323310/93623904-a64dfd00-fa09-11ea-873c-13b7f93383f7.png)
</td>
</tr>
</table>

#### Extra long text

<table>
<tr>
<td>Before:
<br><br>

![#1328-before-extra-long-text](https://user-images.githubusercontent.com/3323310/93623889-a1894900-fa09-11ea-9108-d9e225cd3e31.png)
</td>
<td>After:
<br><br>

![#1328-after-extra-long-text](https://user-images.githubusercontent.com/3323310/93623902-a5b56680-fa09-11ea-8dd8-3d3075195734.png)
</td>
</tr>
</table>

### How to test the changes in this Pull Request:

1. Install and set up the [WooCommerce](https://wordpress.org/plugins/woocommerce/) plugin.
2. Install and set up the [Storefront](https://woocommerce.com/storefront/?aff=10486&cid=1131038) theme.
3. Head over to `/wp-admin/edit.php?post_type=shop_order` and set all your orders on hold (to ensure that there are no downloads available)
4. Head over to `/wp-admin/options-general.php` and set your site language to Spanish (Espagñol)
5. Head over to `/my-account/downloads/` and shrink screen width to 767px max. or look up this page on a smartphone

### Changelog

> Fix - Adjust button in My Account → Downloads section on mobile. #1328