### PR TITLE
👌 IMPROVE: Remove deprecated code (#1373)

### DIFF
--- a/inc/jetpack/class-storefront-jetpack.php
+++ b/inc/jetpack/class-storefront-jetpack.php
@@ -90,10 +90,7 @@ if ( ! class_exists( 'Storefront_Jetpack' ) ) :
 		 *
 		 * @return void
 		 */
-		public function jetpack_infinite_scroll_wrapper_columns() {
-			add_action( 'storefront_jetpack_product_infinite_scroll_before', 'storefront_product_columns_wrapper' );
-			add_action( 'storefront_jetpack_product_infinite_scroll_after', 'storefront_product_columns_wrapper_close' );
-		}
+		public function jetpack_infinite_scroll_wrapper_columns() {}
 
 		/**
 		 * Enqueue jetpack styles.

--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -208,14 +208,6 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 					'post_title' => esc_attr__( 'Homepage', 'storefront' ),
 					'template'   => 'template-fullwidth.php',
 				);
-			} else {
-				$homepage_content = array(
-					'post_title'   => esc_attr__( 'Welcome', 'storefront' ),
-					/* translators: %s: 'End Of Line' symbol */
-					'post_content' => sprintf( esc_attr__( 'This is your homepage which is what most visitors will see when they first visit your shop.%sYou can change this text by editing the "Welcome" page via the "Pages" menu in your dashboard.', 'storefront' ), PHP_EOL . PHP_EOL ),
-					'template'     => 'template-homepage.php',
-					'thumbnail'    => '{{hero-image}}',
-				);
 			}
 
 			$homepage = array(

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -31,14 +31,6 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			add_filter( 'woocommerce_product_thumbnails_columns', array( $this, 'thumbnail_columns' ) );
 			add_filter( 'woocommerce_breadcrumb_defaults', array( $this, 'change_breadcrumb_delimiter' ) );
 
-			if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '2.5', '<' ) ) {
-				add_action( 'wp_footer', array( $this, 'star_rating_script' ) );
-			}
-
-			if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.3', '<' ) ) {
-				add_filter( 'loop_shop_per_page', array( $this, 'products_per_page' ) );
-			}
-
 			// Integrations.
 			add_action( 'storefront_woocommerce_setup', array( $this, 'setup_integrations' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'woocommerce_integrations_scripts' ), 99 );
@@ -151,28 +143,6 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 
 			if ( ! class_exists( 'Storefront_Sticky_Add_to_Cart' ) && is_product() ) {
 				wp_register_script( 'storefront-sticky-add-to-cart', get_template_directory_uri() . '/assets/js/sticky-add-to-cart' . $suffix . '.js', array(), $storefront_version, true );
-			}
-		}
-
-		/**
-		 * Star rating backwards compatibility script (WooCommerce <2.5).
-		 *
-		 * @since 1.6.0
-		 */
-		public function star_rating_script() {
-			if ( is_product() ) {
-				?>
-			<script type="text/javascript">
-				var starsEl = document.querySelector( '#respond p.stars' );
-				if ( starsEl ) {
-					starsEl.addEventListener( 'click', function( event ) {
-						if ( event.target.tagName === 'A' ) {
-							starsEl.classList.add( 'selected' );
-						}
-					} );
-				}
-			</script>
-				<?php
 			}
 		}
 

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -183,19 +183,6 @@ if ( ! function_exists( 'storefront_sorting_wrapper_close' ) ) {
 	}
 }
 
-if ( ! function_exists( 'storefront_product_columns_wrapper' ) ) {
-	/**
-	 * Product columns wrapper
-	 *
-	 * @since   2.2.0
-	 * @return  void
-	 */
-	function storefront_product_columns_wrapper() {
-		$columns = storefront_loop_columns();
-		echo '<div class="columns-' . absint( $columns ) . '">';
-	}
-}
-
 if ( ! function_exists( 'storefront_loop_columns' ) ) {
 	/**
 	 * Default loop columns on product archives
@@ -211,18 +198,6 @@ if ( ! function_exists( 'storefront_loop_columns' ) ) {
 		}
 
 		return apply_filters( 'storefront_loop_columns', $columns );
-	}
-}
-
-if ( ! function_exists( 'storefront_product_columns_wrapper_close' ) ) {
-	/**
-	 * Product columns wrapper close
-	 *
-	 * @since   2.2.0
-	 * @return  void
-	 */
-	function storefront_product_columns_wrapper_close() {
-		echo '</div>';
 	}
 }
 

--- a/inc/woocommerce/storefront-woocommerce-template-hooks.php
+++ b/inc/woocommerce/storefront-woocommerce-template-hooks.php
@@ -56,13 +56,6 @@ add_action( 'woocommerce_before_shop_loop', 'storefront_sorting_wrapper_close', 
 
 add_action( 'storefront_footer', 'storefront_handheld_footer_bar', 999 );
 
-// Legacy WooCommerce columns filter.
-if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.3', '<' ) ) {
-	add_filter( 'loop_shop_columns', 'storefront_loop_columns' );
-	add_action( 'woocommerce_before_shop_loop', 'storefront_product_columns_wrapper', 40 );
-	add_action( 'woocommerce_after_shop_loop', 'storefront_product_columns_wrapper_close', 40 );
-}
-
 /**
  * Products
  *
@@ -98,8 +91,6 @@ add_action( 'storefront_header', 'storefront_header_cart', 60 );
  */
 if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '2.3', '>=' ) ) {
 	add_filter( 'woocommerce_add_to_cart_fragments', 'storefront_cart_link_fragment' );
-} else {
-	add_filter( 'add_to_cart_fragments', 'storefront_cart_link_fragment' );
 }
 
 /**


### PR DESCRIPTION
Fixes #1373

Remove deprecated code.

### How to test the changes in this Pull Request:

1. When running a WooCommerce version < 2.3, the `add_to_cart_fragments` filter will no longer work.
2. When running a WooCommerce version < 2.5, the `star_rating` script will no longer work.
3. When running a WooCommerce version < 3.3, the `products_per_page` script will no longer work.
4. When running a WooCommerce version < 3.3, the `loop_shop_columns` filter and
the `woocommerce_before_shop_loop` and `woocommerce_after_shop_loop` actions will no longer work.

### Changelog

> Dev – Removed code for unsupported versions of WooCommerce (3.3 and earlier) #1373