### PR TITLE
👌 IMPROVE: Adjust pagination thumbnail size (#1429)

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -71,6 +71,11 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 */
 			add_theme_support( 'post-thumbnails' );
 
+			/*
+			 * Enable support for pagination thumbnails.
+			 */
+			add_image_size( 'pagination-thumbnails', 180, 180, true );
+
 			/**
 			 * Enable support for site logo.
 			 */

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -774,14 +774,14 @@ if ( ! function_exists( 'storefront_single_product_pagination' ) ) {
 		<nav class="storefront-product-pagination" aria-label="<?php esc_attr_e( 'More products', 'storefront' ); ?>">
 			<?php if ( $previous_product ) : ?>
 				<a href="<?php echo esc_url( $previous_product->get_permalink() ); ?>" rel="prev">
-					<?php echo wp_kses_post( $previous_product->get_image() ); ?>
+					<?php echo wp_kses_post( $previous_product->get_image( 'pagination-thumbnails' ) ); ?>
 					<span class="storefront-product-pagination__title"><?php echo wp_kses_post( $previous_product->get_name() ); ?></span>
 				</a>
 			<?php endif; ?>
 
 			<?php if ( $next_product ) : ?>
 				<a href="<?php echo esc_url( $next_product->get_permalink() ); ?>" rel="next">
-					<?php echo wp_kses_post( $next_product->get_image() ); ?>
+					<?php echo wp_kses_post( $next_product->get_image( 'pagination-thumbnails' ) ); ?>
 					<span class="storefront-product-pagination__title"><?php echo wp_kses_post( $next_product->get_name() ); ?></span>
 				</a>
 			<?php endif; ?>


### PR DESCRIPTION
Fixes #1429

Adjust the pagination thumbnail size. Initially, the pagination thumbnails were using the image size 324px by 324px. As the pagination thumbnails are displayed with an image size of 90px by 90px. I introduced the image size `pagination_thumbnails` with an image size of 180px by 180px. I doubled the expected size so that the image looks [sharp on retina screens](https://developer.apple.com/design/human-interface-guidelines/macos/icons-and-images/image-size-and-resolution/).

### How to test the changes in this Pull Request:

1. Install and set up the [WooCommerce](https://wordpress.org/plugins/woocommerce/) plugin.
2. Install and set up the [Storefront](https://woocommerce.com/storefront/?aff=10486&cid=1131038) theme.
3. Head over to a product page and check the image size of the pagination thumbnails within the inspector.

⚠️  If you have an existing WooCommerce test site, you need to regenerate the thumbnails to see this effect. You can achieve this via:

- [WP-CLI command `wp media regenerate`](https://developer.wordpress.org/cli/commands/media/regenerate/)
- [Regenerate Thumbnails plugin](https://wordpress.org/plugins/regenerate-thumbnails/)
- [reGenerate Thumbnails Advanced plugin](https://wordpress.org/plugins/regenerate-thumbnails-advanced/)

### Changelog

> Tweak - Adjust the pagination thumbnail size. #1429