### PR TITLE
👌 IMPROVE: Fix PHP linting warnings (#1473)

### DIFF
--- a/inc/admin/class-storefront-admin.php
+++ b/inc/admin/class-storefront-admin.php
@@ -175,8 +175,8 @@ if ( ! class_exists( 'Storefront_Admin' ) ) :
 						'url'     => '#',
 						'classes' => 'disabled',
 					);
-				} elseif ( $this->_is_plugin_installed( $plugin_slug ) ) {
-					$url = $this->_is_plugin_installed( $plugin_slug );
+				} elseif ( $this->is_plugin_installed( $plugin_slug ) ) {
+					$url = $this->is_plugin_installed( $plugin_slug );
 
 					// The plugin exists but isn't activated yet.
 					$button = array(
@@ -214,7 +214,7 @@ if ( ! class_exists( 'Storefront_Admin' ) ) :
 		 *
 		 * @param string $plugin_slug The plugin slug.
 		 */
-		public function _is_plugin_installed( $plugin_slug ) {
+		public function is_plugin_installed( $plugin_slug ) {
 			if ( file_exists( WP_PLUGIN_DIR . '/' . $plugin_slug ) ) {
 				$plugins = get_plugins( '/' . $plugin_slug );
 				if ( ! empty( $plugins ) ) {

--- a/inc/admin/class-storefront-plugin-install.php
+++ b/inc/admin/class-storefront-plugin-install.php
@@ -67,8 +67,8 @@ if ( ! class_exists( 'Storefront_Plugin_Install' ) ) :
 					if ( '' !== $activated ) {
 						$button['message'] = esc_attr( $activated );
 					}
-				} elseif ( self::_is_plugin_installed( $plugin_slug ) ) {
-					$url = self::_is_plugin_installed( $plugin_slug );
+				} elseif ( self::is_plugin_installed( $plugin_slug ) ) {
+					$url = self::is_plugin_installed( $plugin_slug );
 
 					// The plugin exists but isn't activated yet.
 					$button = array(
@@ -123,7 +123,7 @@ if ( ! class_exists( 'Storefront_Plugin_Install' ) ) :
 		 *
 		 * @param string $plugin_slug The plugin slug.
 		 */
-		private static function _is_plugin_installed( $plugin_slug ) {
+		private static function is_plugin_installed( $plugin_slug ) {
 			if ( file_exists( WP_PLUGIN_DIR . '/' . $plugin_slug ) ) {
 				$plugins = get_plugins( '/' . $plugin_slug );
 				if ( ! empty( $plugins ) ) {

--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -105,7 +105,7 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 								<input type="hidden" name="homepage" value="on">
 							<?php endif; ?>
 
-							<?php if ( true === (bool) get_option( 'storefront_nux_fresh_site' ) && true === $this->_is_woocommerce_empty() ) : ?>
+							<?php if ( true === (bool) get_option( 'storefront_nux_fresh_site' ) && true === $this->is_woocommerce_empty() ) : ?>
 								<input type="hidden" name="products" value="on">
 							<?php endif; ?>
 
@@ -121,7 +121,7 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 									?>
 								</label>
 
-								<?php if ( true === $this->_is_woocommerce_empty() ) : ?>
+								<?php if ( true === $this->is_woocommerce_empty() ) : ?>
 									<label>
 										<input type="checkbox" name="products" checked>
 										<?php esc_html_e( 'Add example products', 'storefront' ); ?>
@@ -170,7 +170,7 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 
 			if ( ! empty( $_REQUEST['homepage'] ) && 'on' === sanitize_text_field( wp_unslash( $_REQUEST['homepage'] ) ) ) { // WPCS: input var ok.
 				if ( current_user_can( 'edit_pages' ) && 'page' === get_option( 'show_on_front' ) ) {
-					$this->_assign_page_template( get_option( 'page_on_front' ), 'template-homepage.php' );
+					$this->assign_page_template( get_option( 'page_on_front' ), 'template-homepage.php' );
 				} else {
 					$tasks[] = 'homepage';
 				}
@@ -189,7 +189,7 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 					update_option( 'fresh_site', true );
 
 					if ( current_user_can( 'edit_pages' ) && true === (bool) get_option( 'storefront_nux_fresh_site' ) ) {
-						$this->_set_woocommerce_pages_full_width();
+						$this->set_woocommerce_pages_full_width();
 					}
 				}
 			}
@@ -269,11 +269,11 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 		 *
 		 * @since 2.2.0
 		 */
-		private function _set_woocommerce_pages_full_width() {
+		private function set_woocommerce_pages_full_width() {
 			$wc_pages = $this->get_woocommerce_pages();
 
 			foreach ( $wc_pages as $option => $page_id ) {
-				$this->_assign_page_template( $page_id, 'template-fullwidth.php' );
+				$this->assign_page_template( $page_id, 'template-fullwidth.php' );
 			}
 		}
 
@@ -285,7 +285,7 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 		 * @param string $template Template file name.
 		 * @return void|bool Returns false if $page_id or $template is empty.
 		 */
-		private function _assign_page_template( $page_id, $template ) {
+		private function assign_page_template( $page_id, $template ) {
 			if ( empty( $page_id ) || empty( $template ) || '' === locate_template( $template ) ) {
 				return false;
 			}
@@ -299,7 +299,7 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 		 * @since 2.2.0
 		 * @return bool
 		 */
-		private function _is_woocommerce_empty() {
+		private function is_woocommerce_empty() {
 			$products = wp_count_posts( 'product' );
 
 			if ( 0 < $products->publish ) {

--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -39,7 +39,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				add_action( 'customize_preview_init', array( $this, 'update_homepage_content' ), 10 );
 			}
 
-			if ( ! isset( $_GET['sf_starter_content'] ) || 1 !== absint( $_GET['sf_starter_content'] ) ) { // WPCS: input var ok.
+			if ( ! isset( $_GET['sf_starter_content'] ) || 1 !== absint( $_GET['sf_starter_content'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				add_filter( 'storefront_starter_content', '__return_empty_array' );
 			}
 		}
@@ -202,8 +202,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			);
 
 			// Add homepage.
-			if ( version_compare( get_bloginfo( 'version' ), '5.2', '>=' ) &&
-			   ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.6.0', '>=' ) ) ) {
+			if ( version_compare( get_bloginfo( 'version' ), '5.2', '>=' ) && ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.6.0', '>=' ) ) ) {
 				$homepage_content = array(
 					'post_title' => esc_attr__( 'Homepage', 'storefront' ),
 					'template'   => 'template-fullwidth.php',
@@ -225,7 +224,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			$starter_content['posts'] = array_merge( $starter_content['posts'], $homepage );
 
 			// Add products.
-			$starter_content_wc_products = $this->_starter_content_products();
+			$starter_content_wc_products = $this->starter_content_products();
 
 			if ( ! empty( $starter_content_wc_products ) ) {
 				$starter_content['posts'] = array_merge( $starter_content['posts'], $starter_content_wc_products );
@@ -269,7 +268,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 * @return array $content
 		 */
 		public function filter_start_content( $content, $config ) {
-			if ( ! isset( $_GET['sf_starter_content'] ) || 1 !== absint( $_GET['sf_starter_content'] ) ) { // WPCS: input var ok.
+			if ( ! isset( $_GET['sf_starter_content'] ) || 1 !== absint( $_GET['sf_starter_content'] ) ) {  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				return $content;
 			}
 
@@ -283,11 +282,11 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			// Remove some of the content if necessary.
 			$tasks = array();
 
-			if ( isset( $_GET['sf_tasks'] ) && '' !== sanitize_text_field( wp_unslash( $_GET['sf_tasks'] ) ) ) { // WPCS: input var ok.
-				$tasks = explode( ',', sanitize_text_field( wp_unslash( $_GET['sf_tasks'] ) ) ); // WPCS: input var ok.
+			if ( isset( $_GET['sf_tasks'] ) && '' !== sanitize_text_field( wp_unslash( $_GET['sf_tasks'] ) ) ) {  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$tasks = explode( ',', sanitize_text_field( wp_unslash( $_GET['sf_tasks'] ) ) );  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			}
 
-			$tasks = $this->_validate_tasks( $tasks );
+			$tasks = $this->validate_tasks( $tasks );
 
 			foreach ( $tasks as $task ) {
 				switch ( $task ) {
@@ -354,14 +353,14 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			$post__in = array();
 
 			// Add existing products.
-			$existing_products = $this->_get_existing_wc_products();
+			$existing_products = $this->get_existing_wc_products();
 
 			if ( ! empty( $existing_products ) ) {
 				$post__in = array_merge( $post__in, $existing_products );
 			}
 
 			// Add starter content.
-			$created_products = $this->_get_created_starter_content_products();
+			$created_products = $this->get_createdstarter_content_products();
 
 			if ( false !== $created_products ) {
 
@@ -399,14 +398,14 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			$query_args['post__in'] = array();
 
 			// Add existing products to query.
-			$existing_products = $this->_get_existing_wc_products();
+			$existing_products = $this->get_existing_wc_products();
 
 			if ( ! empty( $existing_products ) ) {
 				$query_args['post__in'] = array_merge( $query_args['post__in'], $existing_products );
 			}
 
 			// Add starter content to query.
-			$created_products = $this->_get_created_starter_content_products();
+			$created_products = $this->get_createdstarter_content_products();
 
 			if ( false !== $created_products ) {
 
@@ -442,7 +441,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 					'hoodie-with-pocket',
 				);
 
-				$products = $this->_query_starter_content( 'product', $onsale, true );
+				$products = $this->query_starter_content( 'product', $onsale, true );
 
 				if ( ! empty( $products ) ) {
 					$query_args['post__in'] = $products;
@@ -491,13 +490,13 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				return;
 			}
 
-			$created_products = $this->_get_created_starter_content_products();
+			$created_products = $this->get_createdstarter_content_products();
 
 			if ( false === $created_products ) {
 				return;
 			}
 
-			$starter_products = $this->_starter_content_products();
+			$starter_products = $this->starter_content_products();
 
 			if ( is_array( $created_products ) ) {
 				foreach ( $created_products as $product ) {
@@ -545,7 +544,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 									if ( ! is_wp_error( $created_category ) ) {
 										$category_ids[] = $created_category['term_id'];
 
-										$category_image = $this->_get_category_image_attachment_id( $category['slug'] );
+										$category_image = $this->get_category_image_attachment_id( $category['slug'] );
 
 										if ( $category_image ) {
 											update_term_meta( (int) $created_category['term_id'], 'thumbnail_id', $category_image );
@@ -574,13 +573,13 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				return;
 			}
 
-			$created_products = $this->_get_created_starter_content_products();
+			$created_products = $this->get_createdstarter_content_products();
 
 			if ( false === $created_products ) {
 				return;
 			}
 
-			$starter_products = $this->_starter_content_products();
+			$starter_products = $this->starter_content_products();
 
 			if ( is_array( $created_products ) ) {
 				foreach ( $created_products as $product ) {
@@ -656,7 +655,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				$args['hide_empty'] = false;
 
 				// List of categories to display.
-				$args['ids'] = implode( $product_cats, ',' );
+				$args['ids'] = implode( ',', $product_cats );
 			}
 
 			return $args;
@@ -675,7 +674,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			if ( 'publish' === $new_status && 'auto-draft' === $old_status && in_array( $post->post_type, array( 'product' ), true ) ) {
 				$post_name = get_post_meta( $post->ID, '_customize_draft_post_name', true );
 
-				$starter_products = $this->_starter_content_products();
+				$starter_products = $this->starter_content_products();
 
 				if ( $post_name && array_key_exists( $post_name, $starter_products ) ) {
 					$update_product = array(
@@ -706,7 +705,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			if ( $post && 'auto-draft' === $post->post_status && in_array( $post->post_type, array( 'product' ), true ) && 'AUTO-DRAFT' === $post->post_title ) {
 				$post_name = get_post_meta( $post->ID, '_customize_draft_post_name', true );
 
-				$starter_products = $this->_starter_content_products();
+				$starter_products = $this->starter_content_products();
 
 				if ( $post_name && array_key_exists( $post_name, $starter_products ) ) {
 					return $starter_products[ $post_name ]['post_title'];
@@ -721,7 +720,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 *
 		 * @since 2.2.0
 		 */
-		private function _starter_content_products() {
+		private function starter_content_products() {
 			$accessories_name        = esc_attr__( 'Accessories', 'storefront' );
 			$accessories_description = esc_attr__( 'A short category description', 'storefront' );
 
@@ -997,7 +996,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				$products[ $symbol ]['post_name'] = $symbol;
 			}
 
-			return apply_filters( 'storefront_starter_content_products', $products );
+			return apply_filters( 'storefrontstarter_content_products', $products );
 		}
 
 		/**
@@ -1006,7 +1005,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 * @since 2.5.0
 		 */
 		public function update_homepage_content() {
-			$homepage = $this->_query_starter_content( 'page', 'homepage', true );
+			$homepage = $this->query_starter_content( 'page', 'homepage', true );
 
 			if ( empty( $homepage ) ) {
 				return;
@@ -1014,7 +1013,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 
 			$homepage = $homepage[0];
 
-			$content = $this->_replace_homepage_blocks_symbols();
+			$content = $this->replace_homepage_blocks_symbols();
 
 			if ( ! empty( $content ) ) {
 
@@ -1034,7 +1033,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 * @since 2.5.0
 		 * @return string $content Homepage content.
 		 */
-		private function _homepage_blocks_content() {
+		private function homepage_blocks_content() {
 			$content = '
 				{{cover}}
 
@@ -1082,11 +1081,11 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 * @since 2.5.0
 		 * @return string $content Homepage content.
 		 */
-		private function _replace_homepage_blocks_symbols() {
-			$content = $this->_homepage_blocks_content();
+		private function replace_homepage_blocks_symbols() {
+			$content = $this->homepage_blocks_content();
 
 			// Replace hero placeholders.
-			$hero = $this->_query_starter_content( 'attachment', 'hero-image', true );
+			$hero = $this->query_starter_content( 'attachment', 'hero-image', true );
 
 			if ( ! empty( $hero ) ) {
 				$cover = '
@@ -1121,7 +1120,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				'hoodie',
 			);
 
-			$products = $this->_query_starter_content( 'product', $featured, true );
+			$products = $this->query_starter_content( 'product', $featured, true );
 
 			if ( ! empty( $products ) ) {
 				$handpicked = '
@@ -1147,7 +1146,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 * @since 2.2.1
 		 * @return mixed false|array $query Array of post ids.
 		 */
-		private function _get_created_starter_content_products() {
+		private function get_createdstarter_content_products() {
 			global $wp_customize;
 
 			$setting = $wp_customize->get_setting( 'nav_menus_created_posts' );
@@ -1169,7 +1168,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 * @since 2.2.0
 		 * @return array $query Array of product ids.
 		 */
-		private function _get_existing_wc_products() {
+		private function get_existing_wc_products() {
 			$query_args = array(
 				'post_type'      => 'product',
 				'post_status'    => 'publish',
@@ -1195,12 +1194,12 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 * @param bool               $ids Whether to return just the ids or the whole post object.
 		 * @return mixed false|int $query Query results.
 		 */
-		private function _query_starter_content( $post_type, $draft_slugs, $ids = false ) {
+		private function query_starter_content( $post_type, $draft_slugs, $ids = false ) {
 			$query_args = array(
 				'post_type'      => $post_type,
 				'post_status'    => 'auto-draft',
 				'posts_per_page' => -1,
-				'meta_query'     => array(
+				'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					array(
 						'key'     => '_customize_draft_post_name',
 						'value'   => $draft_slugs,
@@ -1209,7 +1208,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				),
 			);
 
-			$created_products = $this->_get_created_starter_content_products();
+			$created_products = $this->get_createdstarter_content_products();
 
 			if ( false !== $created_products ) {
 				$query_args['post__in'] = $created_products;
@@ -1235,8 +1234,8 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 * @param string $category Category.
 		 * @return mixed false|int $query first attachment found.
 		 */
-		private function _get_category_image_attachment_id( $category ) {
-			$attachment = $this->_query_starter_content( 'attachment', $category . '-image', true );
+		private function get_category_image_attachment_id( $category ) {
+			$attachment = $this->query_starter_content( 'attachment', $category . '-image', true );
 
 			if ( ! empty( $attachment ) ) {
 				return $attachment[0];
@@ -1252,7 +1251,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		 * @param string $tasks The tasks.
 		 * @return mixed false|array $validated_tasks if tasks list is not empty.
 		 */
-		private function _validate_tasks( $tasks ) {
+		private function validate_tasks( $tasks ) {
 			$valid_tasks = apply_filters( 'storefront_valid_tour_tasks', array( 'homepage', 'products' ) );
 
 			$validated_tasks = array();

--- a/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
+++ b/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
@@ -83,7 +83,7 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 			$this->current_product = $post->ID;
 
 			// Try to get a valid product via `get_adjacent_post()`.
-			while ( $adjacent = $this->get_adjacent() ) {
+			while ( $adjacent = $this->get_adjacent() ) { // phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 				$product = wc_get_product( $adjacent->ID );
 
 				if ( $product && $product->is_visible() ) {

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -411,9 +411,9 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			global $storefront;
 
 			if ( ! is_object( $storefront ) ||
-				 ! property_exists( $storefront, 'customizer' ) ||
-				 ! is_a( $storefront->customizer, 'Storefront_Customizer' ) ||
-				 ! method_exists( $storefront->customizer, 'get_storefront_theme_mods' ) ) {
+				! property_exists( $storefront, 'customizer' ) ||
+				! is_a( $storefront->customizer, 'Storefront_Customizer' ) ||
+				! method_exists( $storefront->customizer, 'get_storefront_theme_mods' ) ) {
 				return apply_filters( 'storefront_customizer_woocommerce_extension_css', '' );
 			}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11736,14 +11736,15 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-      "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+      "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
         "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "uniq": "^1.0.1",
+        "util-deprecate": "^1.0.2"
       }
     },
     "postcss-syntax": {
@@ -13592,9 +13593,9 @@
       "dev": true
     },
     "stylelint": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.1.tgz",
-      "integrity": "sha512-qzqazcyRxrSRdmFuO0/SZOJ+LyCxYy0pwcvaOBBnl8/2VfHSMrtNIE+AnyJoyq6uKb+mt+hlgmVrvVi6G6XHfQ==",
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.2.tgz",
+      "integrity": "sha512-mmieorkfmO+ZA6CNDu1ic9qpt4tFvH2QUB7vqXgrMVHe5ENU69q7YDq0YUg/UHLuCsZOWhUAvcMcLzLDIERzSg==",
       "dev": true,
       "requires": {
         "@stylelint/postcss-css-in-js": "^0.37.2",
@@ -13706,12 +13707,12 @@
           "dev": true
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "emoji-regex": {
@@ -14013,9 +14014,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+          "version": "6.12.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jest-puppeteer": "4.4.0",
     "node-sass": "4.14.1",
     "puppeteer": "4.0.1",
-    "stylelint": "13.7.1",
+    "stylelint": "13.7.2",
     "susy": "2.2.14"
   },
   "engines": {


### PR DESCRIPTION
Fixes #1473

Fix PHP linting warnings

### Changes

Before fixing the warnings, running the command `npm run lint:php` resulted in https://github.com/woocommerce/storefront/issues/1473#issue-704847752. After addresses the warnings, the command results in

```
> storefront@2.6.0 lint:php /Users/nielslange/Development/themes/storefront
> composer run-script phpcs ./

> phpcs --extensions=php -s -p './'
........................................ 40 / 40 (100%)


Time: 11.19 secs; Memory: 32MB
```

### Changelog

Tweak - Fix PHP linting warnings. #1473