### PR TITLE
Fix different font sizes of category and product titles in shop page

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -352,17 +352,16 @@ ul.products,
 			}
 		}
 
-		h2, // @todo Remove when WooCommerce 2.8 is live
-		h3, // @todo Remove when WooCommerce 2.8 is live
 		.woocommerce-loop-product__title,
+		.woocommerce-loop-category__title,
 		.wc-block-grid__product-title,
 		.wc-block-grid__product-title > a {
 			font-weight: 400;
 			margin-bottom: ms(-3);
 		}
-		h2, // @todo Remove when WooCommerce 2.8 is live
-		h3, // @todo Remove when WooCommerce 2.8 is live
+
 		.woocommerce-loop-product__title,
+		.woocommerce-loop-category__title,
 		.wc-block-grid__product-title,
 		.wc-block-grid__product-title > a:not( .has-font-size ) {
 			font-size: 1rem;
@@ -378,8 +377,6 @@ ul.products,
 		}
 
 		&.product-category {
-			h2, // @todo Remove when WooCommerce 2.8 is live
-			h3, // @todo Remove when WooCommerce 2.8 is live
 			.woocommerce-loop-category__title {
 				font-size: 1.1em;
 			}

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -377,10 +377,6 @@ ul.products,
 		}
 
 		&.product-category {
-			.woocommerce-loop-category__title {
-				font-size: 1.1em;
-			}
-
 			img {
 				margin-bottom: ms(3);
 			}


### PR DESCRIPTION
Fixes #1500.

This PR fixes a font size inconsistency in the shop page (#1500), also replaces some tag CSS selectors deprecated in an old WC version with a class selector (see https://github.com/woocommerce/storefront/pull/1424#discussion_r482130967 for reference).

### Screenshots
_Before:_
![products-categories-font-sizes](https://user-images.githubusercontent.com/3616980/96243362-f090b280-0fa4-11eb-86e8-2545613fb405.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/96244549-824cef80-0fa6-11eb-8345-b04cdceda40d.png)

### How to test the changes in this Pull Request:

1. Go to the Customizer > WooCommerce > Product Catalog > Shop page display and select Show categories & products.
2. In the frontend, go to the Shop page.
3. Verify the font size of category titles and product titles are the same.

### Changelog

>  Fix different font sizes of category and product titles in shop page 
