### PR TITLE
Install cssnano to minify CSS files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,14 +4,17 @@ module.exports = function( grunt ) {
 
 	var sass = require( 'node-sass' );
 
+	var processors = [ require( 'autoprefixer' )() ];
+	if ( grunt.option('env') === 'production' ) {
+		processors.push( require( 'cssnano' )() );
+	}
+
 	grunt.initConfig({
 
 		// Autoprefixer.
 		postcss: {
 			options: {
-				processors: [
-					require( 'autoprefixer' )()
-				]
+				processors: processors
 			},
 			dist: {
 				src: [

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "url": "https://github.com/woothemes/storefront.git"
   },
   "scripts": {
+    "build": "grunt deploy --env=production",
     "build:dev": "grunt",
-    "build": "grunt deploy",
     "css": "grunt css",
     "start": "grunt watch",
     "wp-env": "wp-env",
@@ -37,6 +37,7 @@
     "@wordpress/env": "1.6.0",
     "autoprefixer": "9.8.6",
     "bourbon": "5.1.0",
+    "cssnano": "^4.1.10",
     "grunt": "1.3.0",
     "grunt-babel": "8.0.0",
     "grunt-checktextdomain": "1.0.1",


### PR DESCRIPTION
While working on #1502, I noticed Storefront CSS files were not minified. This PR installs cssnano (which is also [used in WC Blocks](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/postcss.config.js#L4)) in order to minify CSS files.

Some filesize wins:

| File | `trunk` | This branch |
| :--- | ---: | ---: |
| `icons.css` | 103,2 kB | 83,8 kB |
| `woocommerce.css` | 76,8kB | 60,8 kB |
| `style.css` | 69,5 kB | 40,5 kB |
| `gutenberg-blocks.css` | 47,3 kB | 43,0 kB |
| `gutenberg-editor.css` | 5,9 kB | 4,7 kB |

### How to test the changes in this Pull Request:

Run `npm build` and verify there are no style regressions in the store.

### Changelog

> Performance – Added CSS minification.