### PR TITLE
Add accent color to WC Blocks price slider

### DIFF
--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -870,6 +870,11 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				color: ' . $storefront_theme_mods['hero_text_color'] . ';
 			}
 
+			.wc-block-components-price-slider__range-input-progress,
+			.rtl .wc-block-components-price-slider__range-input-progress {
+				--range-color: ' . $storefront_theme_mods['accent_color'] . ';
+			}
+
 			.wc-block-components-button:not(.is-link) {
 				background-color: ' . $storefront_theme_mods['button_alt_background_color'] . ';
 				color: ' . $storefront_theme_mods['button_alt_text_color'] . ';

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -875,6 +875,13 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				--range-color: ' . $storefront_theme_mods['accent_color'] . ';
 			}
 
+			/* Target only IE11 */
+			@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+				.wc-block-components-price-slider__range-input-progress {
+					background: ' . $storefront_theme_mods['accent_color'] . ';
+				}
+			}
+
 			.wc-block-components-button:not(.is-link) {
 				background-color: ' . $storefront_theme_mods['button_alt_background_color'] . ';
 				color: ' . $storefront_theme_mods['button_alt_text_color'] . ';

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -870,50 +870,6 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				color: ' . $storefront_theme_mods['hero_text_color'] . ';
 			}
 
-			.wc-block-components-price-slider__range-input-progress,
-			.rtl .wc-block-components-price-slider__range-input-progress {
-				--range-color: ' . $storefront_theme_mods['accent_color'] . ';
-			}
-
-			/* Target only IE11 */
-			@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-				.wc-block-components-price-slider__range-input-progress {
-					background: ' . $storefront_theme_mods['accent_color'] . ';
-				}
-			}
-
-			.wc-block-components-button:not(.is-link) {
-				background-color: ' . $storefront_theme_mods['button_alt_background_color'] . ';
-				color: ' . $storefront_theme_mods['button_alt_text_color'] . ';
-			}
-
-			.wc-block-components-button:not(.is-link):hover,
-			.wc-block-components-button:not(.is-link):focus,
-			.wc-block-components-button:not(.is-link):active {
-				background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_alt_background_color'], $darken_factor ) . ';
-				color: ' . $storefront_theme_mods['button_alt_text_color'] . ';
-			}
-
-			.wc-block-components-button:not(.is-link):disabled {
-				background-color: ' . $storefront_theme_mods['button_alt_background_color'] . ';
-				color: ' . $storefront_theme_mods['button_alt_text_color'] . ';
-			}
-
-			.wc-block-cart__submit-container {
-				background-color: ' . $storefront_theme_mods['background_color'] . ';
-			}
-
-			.wc-block-cart__submit-container::before {
-				color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], is_color_light( $storefront_theme_mods['background_color'] ) ? -35 : 70, 0.5 ) . ';
-			}
-
-			.wc-block-components-order-summary-item__quantity {
-				background-color: ' . $storefront_theme_mods['background_color'] . ';
-				border-color: ' . $storefront_theme_mods['text_color'] . ';
-				box-shadow: 0 0 0 2px ' . $storefront_theme_mods['background_color'] . ';
-				color: ' . $storefront_theme_mods['text_color'] . ';
-			}
-
 			@media screen and ( min-width: 768px ) {
 				.secondary-navigation ul.menu a:hover {
 					color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['header_text_color'], $brighten_factor ) . ';
@@ -1018,6 +974,50 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				.wp-block-cover .wp-block-cover__inner-container h5:not(.has-text-color),
 				.wp-block-cover .wp-block-cover__inner-container h6:not(.has-text-color) {
 					color: ' . $storefront_theme_mods['hero_heading_color'] . ';
+				}
+
+				.wc-block-components-price-slider__range-input-progress,
+				.rtl .wc-block-components-price-slider__range-input-progress {
+					--range-color: ' . $storefront_theme_mods['accent_color'] . ';
+				}
+
+				/* Target only IE11 */
+				@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+					.wc-block-components-price-slider__range-input-progress {
+						background: ' . $storefront_theme_mods['accent_color'] . ';
+					}
+				}
+
+				.wc-block-components-button:not(.is-link) {
+					background-color: ' . $storefront_theme_mods['button_alt_background_color'] . ';
+					color: ' . $storefront_theme_mods['button_alt_text_color'] . ';
+				}
+
+				.wc-block-components-button:not(.is-link):hover,
+				.wc-block-components-button:not(.is-link):focus,
+				.wc-block-components-button:not(.is-link):active {
+					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_alt_background_color'], $darken_factor ) . ';
+					color: ' . $storefront_theme_mods['button_alt_text_color'] . ';
+				}
+
+				.wc-block-components-button:not(.is-link):disabled {
+					background-color: ' . $storefront_theme_mods['button_alt_background_color'] . ';
+					color: ' . $storefront_theme_mods['button_alt_text_color'] . ';
+				}
+
+				.wc-block-cart__submit-container {
+					background-color: ' . $storefront_theme_mods['background_color'] . ';
+				}
+
+				.wc-block-cart__submit-container::before {
+					color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], is_color_light( $storefront_theme_mods['background_color'] ) ? -35 : 70, 0.5 ) . ';
+				}
+
+				.wc-block-components-order-summary-item__quantity {
+					background-color: ' . $storefront_theme_mods['background_color'] . ';
+					border-color: ' . $storefront_theme_mods['text_color'] . ';
+					box-shadow: 0 0 0 2px ' . $storefront_theme_mods['background_color'] . ';
+					color: ' . $storefront_theme_mods['text_color'] . ';
 				}
 			';
 


### PR DESCRIPTION
This PR adds styles to the price slider of the Filter Products by Price block. It requires the changes in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3300, which decrease the selector specificity of the default styles.

### Screenshots
#### Customizer
![Peek 2020-10-20 18-25](https://user-images.githubusercontent.com/3616980/96615478-99bb0e00-1301-11eb-90ad-bcf7af565730.gif)

#### Child theme
(Screenshots with [Bistro](https://woocommerce.com/products/bistro/))

_Before:_
<img src="https://user-images.githubusercontent.com/3616980/96570001-2053f900-12ca-11eb-8a75-8a54f243bda3.png" alt="Price filter screenshot" width="286" />

_After:_
<img src="https://user-images.githubusercontent.com/3616980/96569858-f0a4f100-12c9-11eb-8011-05227bb60277.png" alt="Price filter screenshot with custom styles" width="286" />

### How to test the changes in this Pull Request:

1. Create a page with the price filter and the All Products block.
2. In the customizer, change the accent color to something different from purple.
3. Verify the price slider has the new accent color.
4. Test a Storefront child theme too to ensure the accent color of the child theme is honored as well.

### Changelog

> Enhancement – Added styles to the Filter Products by Price block, so the accent color is used in the slider.