### PR TITLE
Create STOREFRONT_STATUS.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,9 @@ GitHub is for *bug reports and contributions only* - if you have a support quest
 - [Woo Experts](https://woocommerce.com/experts/)
 - [Codeable](https://codeable.io/)
 
+## Storefront Status
+Please read [this document](./STOREFRONT_STATUS.md) explaining the current status of Storefront development.
+
 ## Contributing To The Core
 
 ### Reporting Issues

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </h1>
 
 <p align="center">
-  <a href="https://packagist.org/packages/woocommerce/woocommerce"><img src="https://poser.pugx.org/woocommerce/woocommerce/license" alt="license"></a> 
+  <a href="https://packagist.org/packages/woocommerce/woocommerce"><img src="https://poser.pugx.org/woocommerce/woocommerce/license" alt="license"></a>
   <a href="https://woocommerce.com/"><img src="http://img.shields.io/badge/Designed%20for-WooCommerce-a46497.svg" alt="Designed for WooCommerce"></a>
   <img src="https://img.shields.io/wordpress/theme/dt/storefront.svg" alt="WordPress.org downloads">
   <img src="https://img.shields.io/wordpress/theme/r/storefront.svg" alt="WordPress.org rating">
@@ -20,6 +20,9 @@ It features deep integration with WooCommerce core plus several of the most popu
 * [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/)
 
 For developers, Storefront is the perfect starting point for your project. It's lean and extensible codebase will allow you to easily add functionality to your site via child theme and/or custom plugin(s).
+
+## Storefront Status
+Please read [this document](./STOREFRONT_STATUS.md) explaining the current status of Storefront development.
 
 ## Storefront extensions
 Looking to take your storefront powered store to the next level? Be sure to checkout the premium [Storefront extensions](https://woocommerce.com/product-category/storefront-extensions/).

--- a/STOREFRONT_STATUS.md
+++ b/STOREFRONT_STATUS.md
@@ -1,0 +1,16 @@
+# Status of Storefront
+
+> **tl;dr:** Storefront is in active development and we’ll continue to improve it alongside priorities like the new optimised checkout.
+
+Storefront continues to be a theme that powers a significant number of WooCommerce stores in the ecosystem and we continue to invest active development time that ensures Storefront remains a valuable resource for the ecosystem. On the horizon there are a number of transitions happening in the WordPress theme industry and in order to be prepared as a team we are also prioritizing and investing in experimenting with and building new features to support this direction that ultimately benefits WooCommerce stores, merchants and shoppers.
+
+To that end, to bring clarity to what we are prioritizing for active Storefront development, we’ve created this criteria list. Our engineers are using this list to help us effectively triage issues. Going forward, we will only be actively addressing issues that fall in one of these criteria “buckets”:
+
+Contribute to improving our release processes or documentation.
+Critical bugs that break expected functionality for important flows in a store (eg. Checkout flow). This also includes security related issues that require immediate release after fixing.
+Non critical  bugs that are still affecting a significant number of merchants or stores but don’t break critical flows (including those related to accessibility or internationalisation). 
+Address significant compatibility issues with any one of: WordPress core updates, WooCommerce core updates, or signature products important to be compatible with (such as WooCommerce Blocks).
+
+At this time, most enhancements and features will not be worked on and in order to be clear about expectations we will be generally closing issues unless they fall into one of the above buckets.
+
+While we also welcome contributions (pull requests) from the community. There is still an investment of time needed by our team to review the prs and consider the impact of merging to Storefront. So at this time, unless a pull request falls into one of the above buckets, we will be closing it. 

--- a/STOREFRONT_STATUS.md
+++ b/STOREFRONT_STATUS.md
@@ -6,10 +6,10 @@ Storefront continues to be a theme that powers a significant number of WooCommer
 
 To that end, to bring clarity to what we are prioritizing for active Storefront development, we’ve created this criteria list. Our engineers are using this list to help us effectively triage issues. Going forward, we will only be actively addressing issues that fall in one of these criteria “buckets”:
 
-Contribute to improving our release processes or documentation.
-Critical bugs that break expected functionality for important flows in a store (eg. Checkout flow). This also includes security related issues that require immediate release after fixing.
-Non critical  bugs that are still affecting a significant number of merchants or stores but don’t break critical flows (including those related to accessibility or internationalisation). 
-Address significant compatibility issues with any one of: WordPress core updates, WooCommerce core updates, or signature products important to be compatible with (such as WooCommerce Blocks).
+- Contribute to improving our release processes or documentation.
+- Critical bugs that break expected functionality for important flows in a store (eg. Checkout flow). This also includes security related issues that require immediate release after fixing.
+- Non critical  bugs that are still affecting a significant number of merchants or stores but don’t break critical flows (including those related to accessibility or internationalisation). 
+- Address significant compatibility issues with any one of: WordPress core updates, WooCommerce core updates, or signature products important to be compatible with (such as WooCommerce Blocks).
 
 At this time, most enhancements and features will not be worked on and in order to be clear about expectations we will be generally closing issues unless they fall into one of the above buckets.
 


### PR DESCRIPTION
In order to help communicate how we prioritize and triage incoming issues and pulls for Storefront, a new document has been prepared that articulates the status of Storefront development. The intent here is to set appropriate expectations for folks who currently contribute (or plan to contribute) in the future.

This has already been reviewed by product leads in Woo and has received the 👍 so I'm going to go ahead and merge this. I created the pull as a reference.

cc @haszari and @jconroy 