### PR TITLE
Add more specificity to wp-block-cover

### DIFF
--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -999,12 +999,12 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -2 ) . ';
 				}
 
-				.wp-block-cover .wp-block-cover__inner-container h1,
-				.wp-block-cover .wp-block-cover__inner-container h2,
-				.wp-block-cover .wp-block-cover__inner-container h3,
-				.wp-block-cover .wp-block-cover__inner-container h4,
-				.wp-block-cover .wp-block-cover__inner-container h5,
-				.wp-block-cover .wp-block-cover__inner-container h6 {
+				.wp-block-cover:not(.has-text-color) .wp-block-cover__inner-container h1,
+				.wp-block-cover:not(.has-text-color) .wp-block-cover__inner-container h2,
+				.wp-block-cover:not(.has-text-color) .wp-block-cover__inner-container h3,
+				.wp-block-cover:not(.has-text-color) .wp-block-cover__inner-container h4,
+				.wp-block-cover:not(.has-text-color) .wp-block-cover__inner-container h5,
+				.wp-block-cover:not(.has-text-color) .wp-block-cover__inner-container h6 {
 					color: ' . $storefront_theme_mods['hero_heading_color'] . ';
 				}
 			';

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -999,12 +999,12 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['background_color'], -2 ) . ';
 				}
 
-				.wp-block-cover:not(.has-text-color) .wp-block-cover__inner-container h1,
-				.wp-block-cover:not(.has-text-color) .wp-block-cover__inner-container h2,
-				.wp-block-cover:not(.has-text-color) .wp-block-cover__inner-container h3,
-				.wp-block-cover:not(.has-text-color) .wp-block-cover__inner-container h4,
-				.wp-block-cover:not(.has-text-color) .wp-block-cover__inner-container h5,
-				.wp-block-cover:not(.has-text-color) .wp-block-cover__inner-container h6 {
+				.wp-block-cover .wp-block-cover__inner-container h1:not(.has-text-color),
+				.wp-block-cover .wp-block-cover__inner-container h2:not(.has-text-color),
+				.wp-block-cover .wp-block-cover__inner-container h3:not(.has-text-color),
+				.wp-block-cover .wp-block-cover__inner-container h4:not(.has-text-color),
+				.wp-block-cover .wp-block-cover__inner-container h5:not(.has-text-color),
+				.wp-block-cover .wp-block-cover__inner-container h6:not(.has-text-color) {
 					color: ' . $storefront_theme_mods['hero_heading_color'] . ';
 				}
 			';


### PR DESCRIPTION
#### Fixes
#1487 

#### The problem
The CSS for assigning the hero-heading-cover color to `wp-block-cover` heading colors is superseding the code from the block editor to set the colors. This only happens when using one of the default colors that use the predefined color such as `has-white-color`

```
.wp-block-cover .wp-block-cover__inner-container h1,
.wp-block-cover .wp-block-cover__inner-container h2,
.wp-block-cover .wp-block-cover__inner-container h3,
.wp-block-cover .wp-block-cover__inner-container h4,
.wp-block-cover .wp-block-cover__inner-container h5,
.wp-block-cover .wp-block-cover__inner-container h6 {
    color: ' . $storefront_theme_mods['hero_heading_color'] . ';
}
```

#### The solution
By adding the additional selector of `:not(.has-text-color)` this can avoid applying to blocks that have a color set

```
.wp-block-cover .wp-block-cover__inner-container h1:not(.has-text-color),
.wp-block-cover .wp-block-cover__inner-container h2:not(.has-text-color),
.wp-block-cover .wp-block-cover__inner-container h3:not(.has-text-color),
.wp-block-cover .wp-block-cover__inner-container h4:not(.has-text-color),
.wp-block-cover .wp-block-cover__inner-container h5:not(.has-text-color),
.wp-block-cover .wp-block-cover__inner-container h6:not(.has-text-color) {
    color: ' . $storefront_theme_mods['hero_heading_color'] . ';
}
```
### Screenshots

*Before*
[![Screenshot](https://d.pr/i/xtLzr4+)](https://d.pr/i/xtLzr4)

*After*
[![Screenshot](https://d.pr/i/coQD1F+)](https://d.pr/i/coQD1F)

#### Testing
My test site ⇢ https://woocommerce-shipping.mystagingwebsite.com/test/

1. Create a page with a Cover Block and a Heading Block on top
2. Change the color settings of the Heading Block
3. View the page