### PR TITLE
Fix editor dynamic width on WP 5.6

### DIFF
--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -300,18 +300,23 @@ table {
 .wp-block {
 	max-width: $container-width;
 
+	&[data-align='wide'] {
+		max-width: ms(19);
+	}
+
+	&[data-align='full'] {
+		max-width: none;
+
+		.storefront-has-sidebar & {
+			margin-left: auto !important;
+			margin-right: auto !important;
+		}
+	}
+
 	.storefront-has-sidebar & {
 		$span-value: span(9) / 100;
 		max-width: calc(#{$container-width} * #{$span-value / ( $span-value * 0 + 1 )}); // Unitless hack.
 	}
-}
-
-.wp-block[data-align='wide'] {
-	max-width: ms(19);
-}
-
-.wp-block[data-align='full'] {
-	max-width: none;
 }
 
 // Tables

--- a/assets/js/src/editor.js
+++ b/assets/js/src/editor.js
@@ -6,10 +6,10 @@
  */
 
 // First class for WP<=5.3 and second class for WP>=5.4.
-const editorWrapperSelector = '.editor-writing-flow, .block-editor-writing-flow';
+const editorWrapperSelector =
+	'.editor-writing-flow, .block-editor-writing-flow';
 
-( function() {
-
+( function () {
 	/**
 	 * Check if the main sidebar is active (has widgets).
 	 *
@@ -21,7 +21,10 @@ const editorWrapperSelector = '.editor-writing-flow, .block-editor-writing-flow'
 	const sidebarIsActive = () => {
 		const settings = wp.data.select( 'core/editor' ).getEditorSettings();
 
-		if ( settings.hasOwnProperty( 'mainSidebarActive' ) && settings.mainSidebarActive ) {
+		if (
+			settings.hasOwnProperty( 'mainSidebarActive' ) &&
+			settings.mainSidebarActive
+		) {
 			return true;
 		}
 
@@ -34,7 +37,9 @@ const editorWrapperSelector = '.editor-writing-flow, .block-editor-writing-flow'
 	 * @return {string} The page template name.
 	 */
 	const getCurrentPageTemplate = () => {
-		return wp.data.select( 'core/editor' ).getEditedPostAttribute( 'template' );
+		return wp.data
+			.select( 'core/editor' )
+			.getEditedPostAttribute( 'template' );
 	};
 
 	/**
@@ -46,7 +51,9 @@ const editorWrapperSelector = '.editor-writing-flow, .block-editor-writing-flow'
 	 * @return {void}
 	 */
 	const updateWideSupport = ( alignWide ) => {
-		wp.data.dispatch( 'core/block-editor' ).updateSettings( { 'alignWide': !! alignWide } );
+		wp.data
+			.dispatch( 'core/block-editor' )
+			.updateSettings( { alignWide: !! alignWide } );
 	};
 
 	/**
@@ -76,7 +83,8 @@ const editorWrapperSelector = '.editor-writing-flow, .block-editor-writing-flow'
 	 * @return {void}
 	 */
 	const maybeUpdateEditor = ( pageTemplate, sidebarActive ) => {
-		const hasSidebar = 'template-fullwidth.php' !== pageTemplate && sidebarActive;
+		const hasSidebar =
+			'template-fullwidth.php' !== pageTemplate && sidebarActive;
 		updateWideSupport( ! hasSidebar );
 		toggleCustomSidebarClass( hasSidebar );
 	};
@@ -94,7 +102,10 @@ const editorWrapperSelector = '.editor-writing-flow, .block-editor-writing-flow'
 			wp.data.subscribe( () => {
 				const newPageTemplate = getCurrentPageTemplate();
 				const newSidebarActive = sidebarIsActive();
-				if ( newPageTemplate !== pageTemplate || newSidebarActive !== sidebarActive ) {
+				if (
+					newPageTemplate !== pageTemplate ||
+					newSidebarActive !== sidebarActive
+				) {
 					pageTemplate = newPageTemplate;
 					sidebarActive = newSidebarActive;
 
@@ -107,6 +118,6 @@ const editorWrapperSelector = '.editor-writing-flow, .block-editor-writing-flow'
 
 		const targetNode = document.querySelector( '.block-editor__container' );
 		const config = { childList: true, subtree: true };
-		observer.observe(targetNode, config);
+		observer.observe( targetNode, config );
 	} );
 } )();


### PR DESCRIPTION
Fixes #1512.

First, I would like to summarize what this feature is about:

* Change the editor width depending on the selected template. If the template is full width, the editor area is wider, mimicking the template in the frontend.
* That needs to happen when the user changes the template in the sidebar + on page load.
* If the template is not full width, blocks shouldn't allow setting a 'wide'  or 'full' alignment.
* According to the code, I think it was planned it would remove the alignment from all 'wide' and 'full' blocks when the template is changed from full width to default/homepage. However, this feature didn't seem to work and I completely removed the code. With this PR, a 'wide' or 'full' aligned block stays that way even in narrow templates, but in those cases they render like a centered block.

While this PR fixes the issue and (I think) cleans up a bit the code, I still fill this feature is very fragile. We are directly interacting with the DOM of the editor, so the code might break every time there is an update in the editor markup in a future WP update. In fact, that same code stopped working some months ago with WP 5.4 (see #1316).

I'm not sure if there is a better way to handle this with proper APIs, if there is, I couldn't find it but I would be happy to be corrected, so we could fix this issue in a robust way. In case there isn't any supported API, we have several options:

* Fix it (with this PR or another one) and keep an eye on this feature for future breakages, keep fixing it every time a WP update breaks this code.
* Fix it for now, but remove this feature next time it breaks.
* Take the chance now and instead of fixing it, remove the feature.

Thoughts @haszari @nerrad?

In addition to that, I opened an issue in Gutenberg repo with our use-case. You can find it here: https://github.com/WordPress/gutenberg/issues/26494. We would also need https://github.com/WordPress/gutenberg/issues/18571 to be fixed in order to be able to completely re-write this feature using supported APIs.

### Screenshots
![Peek 2020-10-27 09-21](https://user-images.githubusercontent.com/3616980/97275158-dfae2f80-1835-11eb-8070-9a2188194aef.gif)

### How to test the changes in this Pull Request:

1. Create a page and switch to the 'Full width' template.
2. Add a paragraph block that spans several lines + a cover block with alignment wide + a cover block width alignment full.
3. Save the page, preview it in the frontend and reload it in the editor. Verify styles are applied correctly in the frontend + editor.
4. Now, switch to the 'Default' template and verify the paragraph block is narrower and the cover blocks look like if they were center-aligned. Click on them and verify the 'wide' and 'full' alignment options can't be selected.
5. Save the page, preview it in the frontend and reload it in the editor. Verify styles are applied correctly in the frontend + editor.

Do the testing steps above with WP 5.5 and WP 5.6.

I also tested it with IE11 to ensure code is compatible with it.

Affected [flows & features](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features):

- Merchant can author pages that use the full page width.
- Block editor shows a realistic preview of the front end styling.

### Changelog

> Compatibility – The code to adapt the editor width to the selected template has been updated so it works with WP 5.6.