### PR TITLE
Exclude susy from updates.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,6 @@
       "automerge": true,
       "requiredStatusChecks": null
     }
-  ]
+  ],
+  "ignoreDeps": ["susy"]
 }


### PR DESCRIPTION
This PR adds susy to renovate bot `ignoreDeps` list. This means that this package will no longer be considered for updating.

Rationale:
https://github.com/woocommerce/storefront/issues/1545
