### PR TITLE
Fix implode parameters order.

### DIFF
--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -656,7 +656,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 				$args['hide_empty'] = false;
 
 				// List of categories to display.
-				$args['ids'] = implode( $product_cats, ',' );
+				$args['ids'] = implode( ',', $product_cats );
 			}
 
 			return $args;


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #1551

Since PHP8 the alternative parameters order is not supported inside `implode`

### Testing

1. Install storefront
2. Install the starter content
3. Starter content taxonomies should still work.

@haszari I am targeting this directly to the release branch. When the release will be over this will get merged back to the trunk. Such a simple change so I did not want to go the cherry-picking road.

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

