### PR TITLE
Use is_wc_admin_active function if available

### DIFF
--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -25,9 +25,9 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
 			/*
-			* In case the user has installed the Storefront theme without WooCommerce plugin this will detect this scenario and show the admin notice.
-			*/
-			if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.8.0', '>=' ) ) {
+			 * In case the user has installed the Storefront theme without WooCommerce plugin this will detect this scenario and show the admin notice.
+			 */
+			if ( is_callable( array( 'WooCommerce', 'is_wc_admin_active' ) ) && wc()->is_wc_admin_active() ) {
 				add_action( 'admin_notices', array( $this, 'admin_inbox_messages' ), 99 );
 			} else {
 				add_action( 'admin_notices', array( $this, 'admin_notices' ), 99 );


### PR DESCRIPTION
WooCommerce admin can be disabled via a filter hook. This PR implements the core [is_wc_admin_active function](https://github.com/woocommerce/woocommerce/blob/ba37b7332ade5bf9039ad31034f83c14a9be6ffe/includes/class-woocommerce.php#L909) to see if WC admin is actually available before using it's admin note functionality.

Fixes #1563

### How to test the changes in this Pull Request:

1. Disable WC admin using the filter: `add_filter( 'woocommerce_admin_disabled', '__return_true' );`
2. Edit your DB options table and delete the `storefront_nux_dismissed` option value, or use a clean install.
3. Activate Storefront.
4. You will see the old style admin notice instead of a fatal error.

### Changelog

> Fix – Prevent a fatal error on activation if WooCommerce Admin is intentionally disabled.
