### PR TITLE
Remove code targeting unsupported versions of WooCommerce

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,6 +4,8 @@ Requires at least: 5.3.4
 Tested up to: 5.6.0
 Stable tag: 2.9.0
 Version: 3.0.0
+WC requires at least: 4.2
+WC tested up to: 4.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Tags: e-commerce, two-columns, left-sidebar, right-sidebar, custom-background, custom-colors, custom-header, custom-menu, featured-images, full-width-template, threaded-comments, accessibility-ready, rtl-language-support, footer-widgets, sticky-post, theme-options, editor-style

--- a/functions.php
+++ b/functions.php
@@ -62,10 +62,7 @@ if ( is_admin() ) {
 if ( version_compare( get_bloginfo( 'version' ), '4.7.3', '>=' ) && ( is_admin() || is_customize_preview() ) ) {
 	require 'inc/nux/class-storefront-nux-admin.php';
 	require 'inc/nux/class-storefront-nux-guided-tour.php';
-
-	if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.0.0', '>=' ) ) {
-		require 'inc/nux/class-storefront-nux-starter-content.php';
-	}
+	require 'inc/nux/class-storefront-nux-starter-content.php';
 }
 
 /**

--- a/inc/nux/class-storefront-nux-starter-content.php
+++ b/inc/nux/class-storefront-nux-starter-content.php
@@ -33,11 +33,7 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 			add_action( 'after_setup_theme', array( $this, 'remove_default_widgets' ) );
 			add_action( 'transition_post_status', array( $this, 'transition_post_status' ), 10, 3 );
 			add_filter( 'the_title', array( $this, 'filter_auto_draft_title' ), 10, 2 );
-
-			if ( version_compare( get_bloginfo( 'version' ), '5.2', '>=' ) &&
-			( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.6.0', '>=' ) ) ) {
-				add_action( 'customize_preview_init', array( $this, 'update_homepage_content' ), 10 );
-			}
+			add_action( 'customize_preview_init', array( $this, 'update_homepage_content' ), 10 );
 
 			if ( ! isset( $_GET['sf_starter_content'] ) || 1 !== absint( $_GET['sf_starter_content'] ) ) { // WPCS: input var ok.
 				add_filter( 'storefront_starter_content', '__return_empty_array' );
@@ -66,6 +62,10 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 		public function starter_content() {
 			$starter_content = array(
 				'posts'       => array(
+					'home'    => array(
+						'post_title' => esc_attr__( 'Homepage', 'storefront' ),
+						'template'   => 'template-fullwidth.php',
+					),
 					'about'   => array(
 						'post_type'    => 'page',
 						'post_title'   => __( 'About', 'storefront' ),
@@ -200,29 +200,6 @@ if ( ! class_exists( 'Storefront_NUX_Starter_Content' ) ) :
 					),
 				),
 			);
-
-			// Add homepage.
-			if ( version_compare( get_bloginfo( 'version' ), '5.2', '>=' ) &&
-				( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.6.0', '>=' ) ) ) {
-				$homepage_content = array(
-					'post_title' => esc_attr__( 'Homepage', 'storefront' ),
-					'template'   => 'template-fullwidth.php',
-				);
-			} else {
-				$homepage_content = array(
-					'post_title'   => esc_attr__( 'Welcome', 'storefront' ),
-					/* translators: %s: 'End Of Line' symbol */
-					'post_content' => sprintf( esc_attr__( 'This is your homepage which is what most visitors will see when they first visit your shop.%sYou can change this text by editing the "Welcome" page via the "Pages" menu in your dashboard.', 'storefront' ), PHP_EOL . PHP_EOL ),
-					'template'     => 'template-homepage.php',
-					'thumbnail'    => '{{hero-image}}',
-				);
-			}
-
-			$homepage = array(
-				'home' => $homepage_content,
-			);
-
-			$starter_content['posts'] = array_merge( $starter_content['posts'], $homepage );
 
 			// Add products.
 			$starter_content_wc_products = $this->starter_content_products();

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -31,14 +31,6 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			add_filter( 'woocommerce_product_thumbnails_columns', array( $this, 'thumbnail_columns' ) );
 			add_filter( 'woocommerce_breadcrumb_defaults', array( $this, 'change_breadcrumb_delimiter' ) );
 
-			if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '2.5', '<' ) ) {
-				add_action( 'wp_footer', array( $this, 'star_rating_script' ) );
-			}
-
-			if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.3', '<' ) ) {
-				add_filter( 'loop_shop_per_page', array( $this, 'products_per_page' ) );
-			}
-
 			// Integrations.
 			add_action( 'storefront_woocommerce_setup', array( $this, 'setup_integrations' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'woocommerce_integrations_scripts' ), 99 );
@@ -155,28 +147,6 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 		}
 
 		/**
-		 * Star rating backwards compatibility script (WooCommerce <2.5).
-		 *
-		 * @since 1.6.0
-		 */
-		public function star_rating_script() {
-			if ( is_product() ) {
-				?>
-			<script type="text/javascript">
-				var starsEl = document.querySelector( '#respond p.stars' );
-				if ( starsEl ) {
-					starsEl.addEventListener( 'click', function( event ) {
-						if ( event.target.tagName === 'A' ) {
-							starsEl.classList.add( 'selected' );
-						}
-					} );
-				}
-			</script>
-				<?php
-			}
-		}
-
-		/**
 		 * Related Products Args
 		 *
 		 * @param  array $args related products args.
@@ -209,16 +179,6 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			}
 
 			return intval( apply_filters( 'storefront_product_thumbnail_columns', $columns ) );
-		}
-
-		/**
-		 * Products per page
-		 *
-		 * @return integer number of products
-		 * @since  1.0.0
-		 */
-		public function products_per_page() {
-			return intval( apply_filters( 'storefront_products_per_page', 12 ) );
 		}
 
 		/**

--- a/inc/woocommerce/storefront-woocommerce-template-hooks.php
+++ b/inc/woocommerce/storefront-woocommerce-template-hooks.php
@@ -56,13 +56,6 @@ add_action( 'woocommerce_before_shop_loop', 'storefront_sorting_wrapper_close', 
 
 add_action( 'storefront_footer', 'storefront_handheld_footer_bar', 999 );
 
-// Legacy WooCommerce columns filter.
-if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.3', '<' ) ) {
-	add_filter( 'loop_shop_columns', 'storefront_loop_columns' );
-	add_action( 'woocommerce_before_shop_loop', 'storefront_product_columns_wrapper', 40 );
-	add_action( 'woocommerce_after_shop_loop', 'storefront_product_columns_wrapper_close', 40 );
-}
-
 /**
  * Products
  *
@@ -96,11 +89,7 @@ add_action( 'storefront_header', 'storefront_header_cart', 60 );
  *
  * @see storefront_cart_link_fragment()
  */
-if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '2.3', '>=' ) ) {
-	add_filter( 'woocommerce_add_to_cart_fragments', 'storefront_cart_link_fragment' );
-} else {
-	add_filter( 'add_to_cart_fragments', 'storefront_cart_link_fragment' );
-}
+add_filter( 'woocommerce_add_to_cart_fragments', 'storefront_cart_link_fragment' );
 
 /**
  * Integrations


### PR DESCRIPTION
This PR implements some of the changes from #1471 (not all of them since some of the removed methods are still being used, such as the infinite scroll ones).

I've included WC Version support headers in the readme.txt so this is easier to keep track of. I've set the min supported version to 4.2 which was the [min when this issue was logged](https://github.com/woocommerce/storefront/issues/1373). We could increase further but I didn't want to set it to a much later version in a fix release. 

Closes #1471
Fixes #1373 

### How to test the changes in this Pull Request:

Smoke test under supported versions of WC (4.2+).

### Changelog

> Fix – Removed legacy code targeting unsupported versions of WooCommerce. Storefront currently supports 4.2+.
