### PR TITLE
Implement stylelint and WordPress CSS coding standards

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -8,6 +8,11 @@
         "block-no-empty": null,
         "no-duplicate-selectors": null,
         "font-family-no-duplicate-names": null,
-        "selector-class-pattern": null
+        "selector-class-pattern": null,
+        "value-keyword-case": null,
+        "scss/selector-no-redundant-nesting-selector": null,
+        "selector-id-pattern": null,
+        "font-weight-notation": null,
+		"declaration-property-unit-whitelist": null
     }
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -11,7 +11,6 @@
         "value-keyword-case": null,
         "scss/selector-no-redundant-nesting-selector": null,
         "selector-id-pattern": null,
-        "font-weight-notation": null,
 		"declaration-property-unit-whitelist": null
     }
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -6,7 +6,6 @@
         "font-family-no-missing-generic-family-keyword": null,
         "no-descending-specificity": null,
         "no-duplicate-selectors": null,
-        "font-family-no-duplicate-names": null,
         "selector-class-pattern": null,
         "value-keyword-case": null,
         "scss/selector-no-redundant-nesting-selector": null,

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -10,7 +10,6 @@
         "selector-class-pattern": null,
         "value-keyword-case": null,
         "scss/selector-no-redundant-nesting-selector": null,
-        "selector-id-pattern": null,
-		"declaration-property-unit-whitelist": null
+        "selector-id-pattern": null
     }
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -5,7 +5,6 @@
     "rules": {
         "font-family-no-missing-generic-family-keyword": null,
         "no-descending-specificity": null,
-        "block-no-empty": null,
         "no-duplicate-selectors": null,
         "font-family-no-duplicate-names": null,
         "selector-class-pattern": null,

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,58 +1,13 @@
 {
-  "rules": {
-	"indentation": "tab",
-	"color-hex-case": "lower",
-	"color-no-invalid-hex": true,
-
-	"function-calc-no-unspaced-operator": true,
-	"function-comma-space-after": "always-single-line",
-	"function-comma-space-before": "never",
-	"function-name-case": "lower",
-	"function-url-quotes": "always",
-	"function-whitespace-after": "always",
-
-	"number-leading-zero": "always",
-	"number-no-trailing-zeros": true,
-	"length-zero-no-unit": true,
-
-	"string-no-newline": true,
-	"string-quotes": "single",
-
-	"unit-case": "lower",
-	"unit-no-unknown": true,
-	"unit-whitelist": ["px", "%", "deg", "ms", "em", "vh", "vw", "rem", "s", "ex", "pt", "cm"],
-
-	"value-list-comma-space-after": "always-single-line",
-	"value-list-comma-space-before": "never",
-
-	"shorthand-property-no-redundant-values": true,
-
-	"property-case": "lower",
-
-	"declaration-block-no-duplicate-properties": [true, { "severity": "warning" } ],
-	"declaration-block-trailing-semicolon": "always",
-	"declaration-block-single-line-max-declarations": 0,
-	"declaration-block-semicolon-space-before": "never",
-	"declaration-block-semicolon-space-after": "always-single-line",
-	"declaration-block-semicolon-newline-before": "never-multi-line",
-	"declaration-block-semicolon-newline-after": "always-multi-line",
-
-	"block-closing-brace-newline-after": "always",
-	"block-closing-brace-newline-before": "always-multi-line",
-	"block-no-empty": true,
-	"block-opening-brace-newline-after": "always-multi-line",
-	"block-opening-brace-space-before": "always",
-
-	"selector-attribute-brackets-space-inside": "never",
-	"selector-attribute-operator-space-after": "never",
-	"selector-attribute-operator-space-before": "never",
-	"selector-combinator-space-after": "always",
-	"selector-combinator-space-before": "always",
-	"selector-pseudo-class-case": "lower",
-	"selector-pseudo-class-parentheses-space-inside": "always",
-	"selector-pseudo-element-case": "lower",
-	"selector-pseudo-element-colon-notation": "double",
-	"selector-pseudo-element-no-unknown": true,
-	"selector-type-case": "lower"
-  }
+    "extends": [
+        "stylelint-config-wordpress/scss"
+    ],
+    "rules": {
+        "font-family-no-missing-generic-family-keyword": null,
+        "no-descending-specificity": null,
+        "block-no-empty": null,
+        "no-duplicate-selectors": null,
+        "font-family-no-duplicate-names": null,
+        "selector-class-pattern": null
+    }
 }

--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -118,7 +118,7 @@
 		&::before {
 			display: inline-block;
 			content: "\f463";
-			font: normal 20px/1 dashicons;
+			font: 400 20px/1 dashicons;
 			margin: 3px 5px 0 -2px;
 			vertical-align: bottom;
 			-webkit-animation: rotation 2s infinite linear;

--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -118,7 +118,7 @@
 		&::before {
 			display: inline-block;
 			content: "\f463";
-			font: normal 20px/1 "dashicons";
+			font: normal 20px/1 dashicons;
 			margin: 3px 5px 0 -2px;
 			vertical-align: bottom;
 			-webkit-animation: rotation 2s infinite linear;

--- a/assets/css/admin/admin.scss
+++ b/assets/css/admin/admin.scss
@@ -1,4 +1,4 @@
-@import 'buttons';
+@import "buttons";
 
 .sf-notice-nux {
 	background: #e7f5f9;
@@ -7,7 +7,7 @@
 
 	&::before,
 	&::after {
-		content: '';
+		content: "";
 		display: table;
 	}
 
@@ -112,11 +112,13 @@
 }
 
 .sf-nux-button {
+
 	&.updating-message {
+
 		&::before {
 			display: inline-block;
-			content: '\f463';
-			font: normal 20px/1 'dashicons';
+			content: "\f463";
+			font: normal 20px/1 "dashicons";
 			margin: 3px 5px 0 -2px;
 			vertical-align: bottom;
 			-webkit-animation: rotation 2s infinite linear;
@@ -126,7 +128,9 @@
 }
 
 @media only screen and (max-width: 782px) {
+
 	.sf-notice-nux {
+
 		.sf-icon {
 			width: 65px;
 			height: 65px;
@@ -142,6 +146,7 @@
 		}
 
 		label {
+
 			&:first-of-type {
 				margin-top: 1.5em;
 			}

--- a/assets/css/admin/buttons.scss
+++ b/assets/css/admin/buttons.scss
@@ -1,4 +1,4 @@
-@import 'bourbon';
+@import "bourbon";
 
 .sf-nux .sf-nux-button,
 a.sf-nux-button {
@@ -6,7 +6,7 @@ a.sf-nux-button {
 	border-color: #0087be;
 	border-style: solid;
 	border-width: 1px 1px 2px;
-	color: #ffffff;
+	color: #fff;
 	cursor: pointer;
 	display: inline-block;
 	outline: 0;

--- a/assets/css/admin/buttons.scss
+++ b/assets/css/admin/buttons.scss
@@ -30,7 +30,7 @@ a.sf-nux-button {
 	&:hover,
 	&:focus {
 		border-color: #005082;
-		color: white;
+		color: #fff;
 	}
 
 	&:focus {
@@ -45,7 +45,7 @@ a.sf-nux-button {
 
 	&[disabled],
 	&:disabled {
-		color: white;
+		color: #fff;
 		background: tint(#78dcfa, 50%);
 		border-color: tint(#0087be, 55%);
 		cursor: default;

--- a/assets/css/admin/customizer/customizer.scss
+++ b/assets/css/admin/customizer/customizer.scss
@@ -1,12 +1,12 @@
-@import '../buttons';
+@import "../buttons";
 
 $background: #23282d;
 
 .sf-guided-tour {
 	display: block;
-	background-color: rgba( 35, 40, 45, 0.95 );
+	background-color: rgba(35, 40, 45, 0.95);
 	border-radius: 5px;
-	box-shadow: 3px 1px 5px -2px rgba( 0, 0, 0, 0.145 );
+	box-shadow: 3px 1px 5px -2px rgba(0, 0, 0, 0.145);
 	color: #a4a4a4;
 	font-size: 1.1em;
 	z-index: 999999998;
@@ -24,7 +24,7 @@ $background: #23282d;
 	opacity: 0;
 
 	&::before {
-		content: '';
+		content: "";
 		position: absolute;
 		top: 30px;
 		left: -14px;
@@ -33,7 +33,7 @@ $background: #23282d;
 		border-style: solid;
 		border-width: 14px 14px 14px 0;
 		border-color: transparent $background transparent transparent;
-		border-right-color: rgba( 35, 40, 45, 0.95 );
+		border-right-color: rgba(35, 40, 45, 0.95);
 	}
 
 	.sf-guided-tour-step {
@@ -62,8 +62,10 @@ $background: #23282d;
 		}
 	}
 
-	&:not( .sf-first-step ) {
+	&:not(.sf-first-step) {
+
 		.sf-guided-tour-step {
+
 			a.sf-nux-button {
 				display: none;
 			}
@@ -76,7 +78,9 @@ $background: #23282d;
 	}
 
 	&.sf-inside-section {
+
 		.sf-guided-tour-step {
+
 			a.sf-nux-button {
 				display: inline-block;
 			}
@@ -88,7 +92,9 @@ $background: #23282d;
 	}
 
 	&.sf-last-step {
+
 		.sf-guided-tour-step {
+
 			a.sf-nux-button {
 				display: inline-block;
 			}
@@ -111,11 +117,12 @@ a.sf-nux-button {
 .sf-moving {
 	transition-duration: 250ms;
 	transition-property: transform;
-	transition-timing-function: cubic-bezier( 0.84, 0.45, 0.68, 1.44 );
+	transition-timing-function: cubic-bezier(0.84, 0.45, 0.68, 1.44);
 }
 
 .sf-entering,
 .sf-exiting {
+
 	.sf-guided-tour {
 		animation-duration: 0.3s;
 		animation-timing-function: ease-in-out;
@@ -125,6 +132,7 @@ a.sf-nux-button {
 }
 
 .sf-entering {
+
 	.sf-guided-tour {
 		animation-name: bounceInLeft;
 		-webkit-animation-name: bounceInLeft;
@@ -132,6 +140,7 @@ a.sf-nux-button {
 }
 
 .sf-exiting {
+
 	.sf-guided-tour {
 		animation-name: bounceOutRight;
 		-webkit-animation-name: bounceOutRight;
@@ -139,10 +148,12 @@ a.sf-nux-button {
 }
 
 @-webkit-keyframes bounceInLeft {
+
 	from {
 		opacity: 0;
 		-webkit-transform: translateX(100%);
 	}
+
 	to {
 		opacity: 1;
 		-webkit-transform: translateX(0);
@@ -150,10 +161,12 @@ a.sf-nux-button {
 }
 
 @keyframes bounceInLeft {
+
 	from {
 		opacity: 0;
 		transform: translateX(100%);
 	}
+
 	to {
 		opacity: 1;
 		transform: translateX(0);
@@ -161,6 +174,7 @@ a.sf-nux-button {
 }
 
 @-webkit-keyframes bounceOutRight {
+
 	to {
 		opacity: 0;
 		-webkit-transform: translateX(100%);
@@ -168,6 +182,7 @@ a.sf-nux-button {
 }
 
 @keyframes bounceOutRight {
+
 	to {
 		opacity: 0;
 		transform: translateX(100%);

--- a/assets/css/admin/plugin-install.scss
+++ b/assets/css/admin/plugin-install.scss
@@ -5,7 +5,7 @@
 		&::before {
 			display: inline-block;
 			content: "\f463";
-			font: normal 19px/1 dashicons;
+			font: 400 19px/1 dashicons;
 			margin: 0 5px 0 -2px;
 			vertical-align: bottom;
 			-webkit-animation: rotation 2s infinite linear;

--- a/assets/css/admin/plugin-install.scss
+++ b/assets/css/admin/plugin-install.scss
@@ -5,7 +5,7 @@
 		&::before {
 			display: inline-block;
 			content: "\f463";
-			font: normal 19px/1 "dashicons";
+			font: normal 19px/1 dashicons;
 			margin: 0 5px 0 -2px;
 			vertical-align: bottom;
 			-webkit-animation: rotation 2s infinite linear;

--- a/assets/css/admin/plugin-install.scss
+++ b/assets/css/admin/plugin-install.scss
@@ -1,9 +1,11 @@
 .sf-install-now {
+
 	&.updating-message {
+
 		&::before {
 			display: inline-block;
-			content: '\f463';
-			font: normal 19px/1 'dashicons';
+			content: "\f463";
+			font: normal 19px/1 "dashicons";
 			margin: 0 5px 0 -2px;
 			vertical-align: bottom;
 			-webkit-animation: rotation 2s infinite linear;

--- a/assets/css/admin/welcome-screen/welcome.scss
+++ b/assets/css/admin/welcome-screen/welcome.scss
@@ -1,11 +1,12 @@
-@import 'bourbon';
-@import '../../../../assets/css/sass/utils/variables';
-@import '../../../../assets/css/sass/utils/mixins';
-@import '../../../../assets/css/sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../../../assets/css/sass/utils/variables";
+@import "../../../../assets/css/sass/utils/mixins";
+@import "../../../../assets/css/sass/vendors/modular-scale";
 
 $green: #45b964;
 
 .appearance_page_storefront-welcome {
+
 	.storefront-wrap {
 		background: #e9eff3;
 		padding: 50px;
@@ -223,7 +224,9 @@ $green: #45b964;
 }
 
 @media all and (max-width: 768px) {
+
 	.appearance_page_storefront-welcome {
+
 		.storefront-logo {
 			margin-top: 20px;
 		}

--- a/assets/css/admin/welcome-screen/welcome.scss
+++ b/assets/css/admin/welcome-screen/welcome.scss
@@ -10,7 +10,7 @@ $green: #45b964;
 	.storefront-wrap {
 		background: #e9eff3;
 		padding: 50px;
-		border: 10px solid white;
+		border: 10px solid #fff;
 		margin-top: 20px;
 		margin-right: 20px;
 		color: #608299;

--- a/assets/css/admin/welcome-screen/welcome.scss
+++ b/assets/css/admin/welcome-screen/welcome.scss
@@ -104,7 +104,7 @@ $green: #45b964;
 		.notice-input {
 			text-align: left;
 		}
-	
+
 		.notice-input:last-of-type {
 			margin-bottom: 16px;
 		}

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -482,7 +482,7 @@ body {
 .site-info {
 	padding: ms(5) 0;
 
-	span[role=separator] {
+	span[role="separator"] {
 		padding: 0 ms(-6) 0 ms(-5);
 
 		&::before {
@@ -1338,7 +1338,7 @@ button.menu-toggle {
 
 	.handheld-navigation,
 	.menu > ul:not(.nav-menu),
-	ul[aria-expanded=true] {
+	ul[aria-expanded="true"] {
 		max-height: 9999px;
 	}
 }
@@ -1529,13 +1529,13 @@ button.menu-toggle {
 	form {
 		position: relative;
 
-		input[type=text],
-		input[type=search] {
+		input[type="text"],
+		input[type="search"] {
 			width: 100%;
 		}
 
-		input[type=submit],
-		button[type=submit] {
+		input[type="submit"],
+		button[type="submit"] {
 
 			@include screen-reader-text();
 			top: 0;

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -337,6 +337,7 @@ body {
 }
 
 .header-widget-region {
+
 	@include clearfix;
 	position: relative;
 	z-index: 99;
@@ -1514,6 +1515,7 @@ button.menu-toggle {
 		}
 
 		a {
+
 			@include underlined-link();
 			@include remove-button-underline();
 		}

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -1,5 +1,6 @@
 /**
- * Global styles applied to all non-woocommerce theme components. Includes styles for;
+ * Global styles applied to all non-woocommerce theme components.
+ * Includes styles for:
  *
  * Typography
  * Header

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -19,7 +19,7 @@
 
 // Utilities
 // Sass tools and helpers used across the project.
-@import '../sass/utils/mixins';
+@import "../sass/utils/mixins";
 
 /**
  * Typography
@@ -56,7 +56,7 @@ h6 {
 	clear: both;
 	font-weight: 300;
 	margin: 0 0 ms(-3);
-	color: darken( $color_body, 20% );
+	color: darken($color_body, 20%);
 
 	a {
 		font-weight: 300;
@@ -104,6 +104,7 @@ ol,
 table,
 blockquote,
 form {
+
 	& + h2,
 	& + header h2,
 	& + h3,
@@ -165,7 +166,7 @@ i {
 
 blockquote {
 	padding: 0 ms(1);
-	border-left: 3px solid rgba( 0, 0, 0, 0.05 );
+	border-left: 3px solid rgba(0, 0, 0, 0.05);
 	font-style: italic;
 }
 
@@ -174,8 +175,8 @@ address {
 }
 
 pre {
-	background: rgba( #000, 0.1 );
-	font-family: 'Courier 10 Pitch', Courier, monospace;
+	background: rgba(#000, 0.1);
+	font-family: "Courier 10 Pitch", Courier, monospace;
 	margin-bottom: ms(3);
 	padding: ms(3);
 	overflow: auto;
@@ -186,8 +187,8 @@ code,
 kbd,
 tt,
 var {
-	font-family: Monaco, Consolas, 'Andale Mono', 'DejaVu Sans Mono', monospace;
-	background-color: rgba( 0, 0, 0, 0.05 );
+	font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+	background-color: rgba(0, 0, 0, 0.05);
 	padding: 0.202em ms(-3);
 }
 
@@ -249,6 +250,7 @@ a,
 input,
 textarea,
 button {
+
 	&:focus {
 		outline: 2px solid $color_woocommerce;
 	}
@@ -256,7 +258,7 @@ button {
 
 // Wait, what..?
 .storefront-cute * {
-	font-family: 'Comic Sans MS', sans-serif;
+	font-family: "Comic Sans MS", sans-serif;
 }
 
 /**
@@ -277,7 +279,7 @@ body {
 
 .site-content,
 .header-widget-region {
-	-webkit-tap-highlight-color: rgba( 0, 0, 0, 0 );
+	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
 /**
@@ -311,19 +313,22 @@ body {
 }
 
 .home.blog,
-.home.page:not( .page-template-template-homepage ),
+.home.page:not(.page-template-template-homepage),
 .home.post-type-archive-product {
+
 	.site-header {
 		margin-bottom: ms(7);
 	}
 }
 
 .no-wc-breadcrumb {
+
 	.site-header {
 		margin-bottom: ms(7);
 	}
 
 	&.page-template-template-homepage {
+
 		.site-header {
 			margin-bottom: 0;
 		}
@@ -345,7 +350,7 @@ body {
 .site-branding {
 	float: left;
 	margin-bottom: 0;
-	width: calc( 100% - 120px );
+	width: calc(100% - 120px);
 
 	.site-title {
 		font-size: 2em;
@@ -378,13 +383,15 @@ body {
 	outline: none;
 }
 
-.page-template-template-homepage:not( .has-post-thumbnail ) {
+.page-template-template-homepage:not(.has-post-thumbnail) {
+
 	.site-main {
 		padding-top: ms(7);
 	}
 }
 
 .page-template-template-homepage {
+
 	.type-page {
 		padding-top: ms(5);
 		padding-bottom: ms(5);
@@ -407,6 +414,7 @@ body {
 	}
 
 	.entry-header {
+
 		h1 {
 			font-size: ms(6);
 			margin-bottom: ms(-6);
@@ -423,6 +431,7 @@ body {
 }
 
 .page-template-template-homepage.has-post-thumbnail {
+
 	.type-page.has-post-thumbnail {
 		background-size: cover;
 		background-position: center center;
@@ -446,7 +455,7 @@ body {
  */
 .site-footer {
 	background-color: #f3f3f3;
-	color: mix( $color_body, #333 );
+	color: mix($color_body, #333);
 	padding: ms(3) 0 ms(6);
 
 	h1,
@@ -455,7 +464,7 @@ body {
 	h4,
 	h5,
 	h6 {
-		color: mix( $color_body, #222 );
+		color: mix($color_body, #222);
 	}
 
 	a {
@@ -477,7 +486,7 @@ body {
 		padding: 0 ms(-6) 0 ms(-5);
 
 		&::before {
-			content: '\007c';
+			content: "\007c";
 		}
 	}
 }
@@ -490,11 +499,13 @@ body {
 	float: left;
 	margin-right: ms(1);
 }
+
 .alignright {
 	display: inline;
 	float: right;
 	margin-left: ms(1);
 }
+
 .aligncenter {
 	clear: both;
 	display: block;
@@ -505,6 +516,7 @@ body {
  * Accessibility
  */
 .screen-reader-text {
+
 	@include screen-reader-text;
 }
 
@@ -539,6 +551,7 @@ body {
 .site-header,
 .site-content,
 .site-footer {
+
 	@include clearfix;
 }
 
@@ -572,6 +585,7 @@ table {
 	}
 
 	thead {
+
 		th {
 			padding: ms(2);
 			vertical-align: middle;
@@ -579,6 +593,7 @@ table {
 	}
 
 	tbody {
+
 		h2 {
 			font-size: 1em;
 			letter-spacing: normal;
@@ -595,9 +610,10 @@ table {
  * 404 Styles
  */
 .error404 {
+
 	.site-content .widget_product_search {
 		padding: ms(3);
-		background-color: rgba( #000, 0.025 );
+		background-color: rgba(#000, 0.025);
 
 		form {
 			margin: 0;
@@ -610,6 +626,7 @@ table {
 	}
 
 	.fourohfour-columns-2 {
+
 		@include clearfix;
 		padding: ms(5) 0;
 		border: 1px solid $color_border;
@@ -622,10 +639,12 @@ table {
 		}
 
 		.col-1 {
+
 			ul.products {
 				margin-bottom: ms(4);
 
 				li.product {
+
 					@include span( 3 of 6 );
 
 					&:last-child {
@@ -637,7 +656,7 @@ table {
 
 		.col-2 {
 			padding: ms(3);
-			background-color: rgba( #000, 0.025 );
+			background-color: rgba(#000, 0.025);
 		}
 	}
 }
@@ -659,6 +678,7 @@ table {
 		margin-left: 0;
 
 		.comment-body {
+
 			@include clearfix;
 		}
 
@@ -698,6 +718,7 @@ table {
 
 
 		.reply {
+
 			@include clearfix;
 			margin-bottom: ms(3);
 			padding-top: ms(-2);
@@ -725,12 +746,13 @@ table {
 #respond {
 	clear: both;
 	padding: ms(3);
-	background-color: rgba( 0, 0, 0, 0.0125 );
+	background-color: rgba(0, 0, 0, 0.0125);
 	position: relative;
 
 	.comment-form-author,
 	.comment-form-email,
 	.comment-form-url {
+
 		input {
 			width: 100%;
 		}
@@ -783,12 +805,14 @@ table {
 			font-size: ms(-1);
 
 			a {
+
 				@include underlined-link();
 			}
 		}
 	}
 
 	.entry-content {
+
 		a {
 			text-decoration: underline;
 
@@ -803,10 +827,11 @@ table {
 	.entry-taxonomy {
 		margin: ms(2) 0 0;
 		padding-top: 1em;
-		border-top: 1px solid rgba( 0, 0, 0, 0.05 );
+		border-top: 1px solid rgba(0, 0, 0, 0.05);
 	}
 
 	&.type-page {
+
 		.entry-header {
 			border-bottom: 0;
 			margin-bottom: 0;
@@ -826,11 +851,13 @@ table {
 }
 
 .byline,
-.updated:not( .published ) {
+.updated:not(.published) {
 	display: none;
 }
 
-.single, .group-blog {
+.single,
+.group-blog {
+
 	.byline {
 		display: inline;
 	}
@@ -857,9 +884,9 @@ textarea {
 }
 
 button,
-input[type='button'],
-input[type='reset'],
-input[type='submit'],
+input[type="button"],
+input[type="reset"],
+input[type="submit"],
 .button,
 .wc-block-grid__products .wc-block-grid__product .wp-block-button__link,
 .added_to_cart {
@@ -915,8 +942,8 @@ input[type='submit'],
 	}
 }
 
-.wc-block-components-button:not( .is-link ).disabled,
-.wc-block-components-button:not( .is-link ):disabled {
+.wc-block-components-button:not(.is-link).disabled,
+.wc-block-components-button:not(.is-link):disabled {
 	opacity: 0.5;
 	cursor: not-allowed;
 
@@ -925,8 +952,8 @@ input[type='submit'],
 	}
 }
 
-input[type='checkbox'],
-input[type='radio'] {
+input[type="checkbox"],
+input[type="radio"] {
 	padding: 0; /* Addresses excess padding in IE8/9 */
 
 	& + label {
@@ -934,11 +961,11 @@ input[type='radio'] {
 	}
 }
 
-input[type='search']::-webkit-search-decoration { /* Corrects inner padding displayed oddly in S5, Chrome on OSX */
+input[type="search"]::-webkit-search-decoration { /* Corrects inner padding displayed oddly in S5, Chrome on OSX */
 	-webkit-appearance: none;
 }
 
-input[type='search'] {
+input[type="search"] {
 	box-sizing: border-box; // Overrules normalize.css.
 
 	&::placeholder {
@@ -952,27 +979,26 @@ input::-moz-focus-inner { /* Corrects inner padding and border displayed oddly i
 	padding: 0;
 }
 
-input[type='text'],
-input[type='number'],
-input[type='email'],
-input[type='tel'],
-input[type='url'],
-input[type='password'],
-input[type='search'],
+input[type="text"],
+input[type="number"],
+input[type="email"],
+input[type="tel"],
+input[type="url"],
+input[type="password"],
+input[type="search"],
 textarea,
 .input-text {
 	padding: ms(-2);
-	background-color: darken( $body-background, 5% );
+	background-color: darken($body-background, 5%);
 	color: $color_body;
 	border: 0;
 	-webkit-appearance: none;
 	box-sizing: border-box;
 	font-weight: normal;
-	box-shadow:
-		inset 0 1px 1px rgba( 0, 0, 0, 0.125 );
+	box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.125);
 
 	&:focus {
-		background-color: darken( $body-background, 7% );
+		background-color: darken($body-background, 7%);
 	}
 }
 
@@ -988,6 +1014,7 @@ label {
 }
 
 label.inline {
+
 	input {
 		width: auto;
 	}
@@ -1021,6 +1048,7 @@ fieldset {
 .page-content,
 .entry-content,
 .comment-content {
+
 	img.wp-smiley {
 		border: none;
 		margin-bottom: 0;
@@ -1038,10 +1066,11 @@ fieldset {
 	margin-bottom: ms(1);
 	max-width: 100%;
 
-	img[class*='wp-image-'] {
+	img[class*="wp-image-"] {
 		display: block;
 		margin: 0 auto;
 	}
+
 	.wp-caption-text {
 		text-align: left;
 		font-style: italic;
@@ -1054,6 +1083,7 @@ fieldset {
  * Galleries
  */
 .gallery {
+
 	@include clearfix;
 	margin-bottom: ms(1);
 
@@ -1061,6 +1091,7 @@ fieldset {
 		float: left;
 
 		.gallery-icon {
+
 			a {
 				display: block;
 			}
@@ -1079,54 +1110,63 @@ fieldset {
 	}
 
 	&.gallery-columns-1 {
+
 		.gallery-item {
 			width: 100%;
 		}
 	}
 
 	&.gallery-columns-2 {
+
 		.gallery-item {
 			width: 50%;
 		}
 	}
 
 	&.gallery-columns-3 {
+
 		.gallery-item {
 			width: 33.3%;
 		}
 	}
 
 	&.gallery-columns-4 {
+
 		.gallery-item {
 			width: 25%;
 		}
 	}
 
 	&.gallery-columns-5 {
+
 		.gallery-item {
 			width: 20%;
 		}
 	}
 
 	&.gallery-columns-6 {
+
 		.gallery-item {
 			width: 16.666666667%;
 		}
 	}
 
 	&.gallery-columns-7 {
+
 		.gallery-item {
 			width: 14.285714286%;
 		}
 	}
 
 	&.gallery-columns-8 {
+
 		.gallery-item {
 			width: 12.5%;
 		}
 	}
 
 	&.gallery-columns-9 {
+
 		.gallery-item {
 			width: 11.111111111%;
 		}
@@ -1178,7 +1218,7 @@ button.menu-toggle {
 	&::before,
 	&::after,
 	span::before {
-		content: '';
+		content: "";
 		display: block;
 		height: 2px;
 		width: 14px;
@@ -1200,7 +1240,9 @@ button.menu-toggle {
 }
 
 .toggled {
+
 	button.menu-toggle {
+
 		&::before,
 		&::after {
 			transform: rotate(45deg);
@@ -1221,6 +1263,7 @@ button.menu-toggle {
 }
 
 .main-navigation {
+
 	@include clearfix;
 
 	div.menu {
@@ -1238,7 +1281,7 @@ button.menu-toggle {
 
 .handheld-navigation,
 .nav-menu,
-.main-navigation div.menu > ul:not( .nav-menu ) {
+.main-navigation div.menu > ul:not(.nav-menu) {
 	overflow: hidden;
 	max-height: 0; /* We have to use max-height because `height` isn't animatable */
 	transition: all, ease, 0.8s;
@@ -1251,10 +1294,12 @@ button.menu-toggle {
 		margin: 0;
 
 		&.menu {
+
 			li {
 				position: relative;
 
 				button {
+
 					&::after {
 						transition: all, ease, 0.9s;
 					}
@@ -1290,8 +1335,9 @@ button.menu-toggle {
 }
 
 .main-navigation.toggled {
+
 	.handheld-navigation,
-	.menu > ul:not( .nav-menu ),
+	.menu > ul:not(.nav-menu),
 	ul[aria-expanded=true] {
 		max-height: 9999px;
 	}
@@ -1308,6 +1354,7 @@ button.menu-toggle {
 	}
 
 	li {
+
 		a {
 			padding: ms(-1) 0;
 			display: block;
@@ -1324,12 +1371,14 @@ button.menu-toggle {
  */
 
 .site-main nav.navigation {
+
 	@include clearfix;
 	clear: both;
 	padding: ms(5) 0;
 
 	.nav-previous,
 	.nav-next {
+
 		a {
 			display: inline-block;
 		}
@@ -1360,6 +1409,7 @@ button.menu-toggle {
 	clear: both;
 
 	ul.page-numbers {
+
 		@include clearfix;
 	}
 
@@ -1375,7 +1425,7 @@ button.menu-toggle {
 				border-left-width: 0;
 				display: inline-block;
 				padding: ms(-5) ms(-1);
-				background-color: rgba( #000, 0.025 );
+				background-color: rgba(#000, 0.025);
 				color: $color_body;
 
 				&.current {
@@ -1395,8 +1445,9 @@ button.menu-toggle {
 			}
 
 			a.page-numbers {
+
 				&:hover {
-					background-color: rgba( #000, 0.05 );
+					background-color: rgba(#000, 0.05);
 				}
 			}
 		}
@@ -1404,8 +1455,10 @@ button.menu-toggle {
 }
 
 .rtl {
+
 	.pagination,
 	.woocommerce-pagination {
+
 		a.next,
 		a.prev {
 			transform: rotateY(180deg);
@@ -1425,6 +1478,7 @@ button.menu-toggle {
 	}
 
 	.widget-search .search-submit {
+
 		@include screen-reader-text();
 	}
 
@@ -1449,6 +1503,7 @@ button.menu-toggle {
 }
 
 .widget-area {
+
 	.widget {
 		font-size: ms(-1);
 		font-weight: 400;
@@ -1470,6 +1525,7 @@ button.menu-toggle {
 
 .widget_search,
 .widget_product_search {
+
 	form {
 		position: relative;
 
@@ -1480,6 +1536,7 @@ button.menu-toggle {
 
 		input[type=submit],
 		button[type=submit] {
+
 			@include screen-reader-text();
 			top: 0;
 			left: 0;
@@ -1497,6 +1554,7 @@ button.menu-toggle {
 .widget_product_categories,
 .widget_layered_nav,
 .widget_layered_nav_filters {
+
 	ul {
 		margin: 0;
 
@@ -1515,6 +1573,7 @@ button.menu-toggle {
 
 #wp-calendar, // Required by WP <=5.3 widget.
 .wp-calendar-table {
+
 	th,
 	td {
 		padding: 0.236em;
@@ -1524,7 +1583,9 @@ button.menu-toggle {
 
 .widget_recent_entries,
 .widget_pages {
+
 	ul {
+
 		ul.children {
 			margin: ms(-2) 0 0 ms(2);
 		}
@@ -1532,6 +1593,7 @@ button.menu-toggle {
 }
 
 .widget_rating_filter {
+
 	.wc-layered-nav-rating {
 		margin-bottom: ms(-2);
 
@@ -1546,4 +1608,3 @@ button.menu-toggle {
 		}
 	}
 }
-

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -527,7 +527,7 @@ body {
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
 	clip: auto !important;
 	display: block;
-	font-weight: bold;
+	font-weight: 700;
 	height: auto;
 	left: 0;
 	line-height: normal;
@@ -598,10 +598,10 @@ table {
 		h2 {
 			font-size: 1em;
 			letter-spacing: normal;
-			font-weight: normal;
+			font-weight: 400;
 
 			a {
-				font-weight: normal;
+				font-weight: 400;
 			}
 		}
 	}
@@ -995,7 +995,7 @@ textarea,
 	border: 0;
 	-webkit-appearance: none;
 	box-sizing: border-box;
-	font-weight: normal;
+	font-weight: 400;
 	box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.125);
 
 	&:focus {

--- a/assets/css/base/_layout.scss
+++ b/assets/css/base/_layout.scss
@@ -418,7 +418,7 @@
 	/**
 	 * Menus
 	 *
-	 * 1 - We have to use a `left` declaration so that dropdowns are revealed when tabbed.
+	 * 1 - Use a `left` declaration so that dropdowns are revealed when tabbed.
 	 */
 	.menu-toggle,
 	.handheld-navigation,

--- a/assets/css/base/_layout.scss
+++ b/assets/css/base/_layout.scss
@@ -3,9 +3,13 @@
  */
 
 @include susy-media($desktop) {
+
 	table.shop_table_responsive {
+
 		tbody {
+
 			tr {
+
 				td,
 				th {
 					text-align: left;
@@ -20,6 +24,7 @@
 
 		.site-branding {
 			display: block;
+
 			@include span(12 of 12);
 			clear: both;
 
@@ -32,22 +37,28 @@
 	}
 
 	.woocommerce-active {
+
 		.site-header {
+
 			.site-branding {
+
 				@include span(9 of 12);
 			}
 
 			.site-search {
+
 				@include span(last 3 of 12);
 				clear: none;
 			}
 
 			.main-navigation {
+
 				@include span(9 of 12);
 				clear: both;
 			}
 
 			.site-header-cart {
+
 				@include span(last 3 of 12);
 				margin-bottom: 0;
 			}
@@ -55,24 +66,32 @@
 	}
 
 	.storefront-secondary-navigation {
+
 		.site-header {
+
 			.site-branding {
+
 				@include span(5 of 12);
 			}
 
 			.secondary-navigation {
+
 				@include span(last 7 of 12);
 			}
 		}
 
 		&.woocommerce-active {
+
 			.site-header {
+
 				.site-branding {
+
 					@include span(3 of 12);
 
 				}
 
 				.secondary-navigation {
+
 					@include span(6 of 12);
 				}
 			}
@@ -80,6 +99,7 @@
 	}
 
 	.site-branding {
+
 		.site-description {
 			margin-bottom: 0;
 			display: block;
@@ -96,6 +116,7 @@
 	}
 
 	.site-header {
+
 		.subscribe-and-connect-connect {
 			float: right;
 			margin-bottom: 1em;
@@ -117,6 +138,7 @@
 	}
 
 	.col-full {
+
 		@include clearfix;
 		@include container($container-width);
 		padding: 0 ms(5);
@@ -124,39 +146,50 @@
 	}
 
 	.site-content {
+
 		@include clearfix;
 	}
 
 	.content-area {
+
 		@include span(9 of 12);
 	}
 
 	.widget-area {
+
 		@include span(last 3 of 12);
 	}
 
 	.right-sidebar {
+
 		.content-area {
+
 			@include span(9 of 12);
 		}
 
 		.widget-area {
+
 			@include span(last 3 of 12);
 		}
 	}
 
 	.left-sidebar {
+
 		.content-area {
+
 			@include span(last 9 of 12);
 		}
 
 		.widget-area {
+
 			@include span(3 of 12);
 		}
 	}
 
 	.storefront-full-width-content {
+
 		.content-area {
+
 			@include span(full);
 		}
 	}
@@ -171,7 +204,9 @@
 	 */
 	.page-template-template-fullwidth-php,
 	.page-template-template-homepage-php {
+
 		.content-area {
+
 			@include span(full);
 		}
 	}
@@ -180,35 +215,45 @@
 	 * Footer widgets
 	 */
 	.footer-widgets {
+
 		@include clearfix;
 		padding-top: ms(7);
-		border-bottom: 1px solid rgba( 0, 0, 0, 0.05 );
+		border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 
 		&.col-2 {
+
 			.block {
+
 				@include span(6 of 12);
 
 				&.footer-widget-2 {
+
 					@include last;
 				}
 			}
 		}
 
 		&.col-3 {
+
 			.block {
+
 				@include span(4 of 12);
 
 				&.footer-widget-3 {
+
 					@include last;
 				}
 			}
 		}
 
 		&.col-4 {
+
 			.block {
+
 				@include span(3 of 12);
 
 				&.footer-widget-4 {
+
 					@include last;
 				}
 			}
@@ -221,6 +266,7 @@
 
 
 	.comment-list {
+
 		@include clearfix;
 
 		.comment {
@@ -228,6 +274,7 @@
 		}
 
 		.comment-meta {
+
 			@include span(2 of 9);
 			text-align: right;
 
@@ -243,11 +290,13 @@
 
 		.comment-content,
 		#respond {
+
 			@include span(last 7 of 9);
 		}
 
 		#respond {
 			float: right;
+
 			.comment-form-author,
 			.comment-form-email,
 			.comment-form-url {
@@ -257,8 +306,9 @@
 		}
 
 		.comment-body {
+
 			#respond {
-				box-shadow: 0 6px 2em rgba( #000, 0.2 );
+				box-shadow: 0 6px 2em rgba(#000, 0.2);
 				margin-bottom: ms(5);
 				margin-top: - ms(3);
 			}
@@ -270,51 +320,63 @@
 		}
 
 		ol.children {
+
 			@include span(last 8 of 9);
 			list-style: none;
 
 			.comment-meta {
+
 				@include span(2 of 8);
 			}
 
 			.comment-content,
 			#respond {
+
 				@include span(last 6 of 8);
 			}
 
 			ol.children {
+
 				@include span(last 7 of 8);
 
 				.comment-meta {
+
 					@include span(2 of 7);
 				}
 
 				.comment-content,
 				#respond {
+
 					@include span(last 5 of 7);
 				}
 
 				ol.children {
+
 					@include span(last 6 of 7);
 
 					.comment-meta {
+
 						@include span(2 of 6);
 					}
 
 					.comment-content,
 					#respond {
+
 						@include span(last 4 of 6);
 					}
 
 					ol.children {
+
 						@include span(last 5 of 6);
 
 						.comment-meta {
+
 							@include span(2 of 5);
 						}
 
 						.comment-content,
 						#respond {
+
 							@include span(last 3 of 5);
 						}
 					}
@@ -329,10 +391,12 @@
 		.comment-form-author,
 		.comment-form-email,
 		.comment-form-url {
+
 			@include span(3 of 9);
 		}
 
 		.comment-form-url {
+
 			@include last;
 		}
 
@@ -345,6 +409,7 @@
 	 * Content
 	 */
 	.hentry {
+
 		.entry-header {
 			margin-bottom: ms(5);
 		}
@@ -395,11 +460,13 @@
 				// link hover
 				&:hover,
 				&.focus {
+
 					> ul {
 						left: 0;
 						display: block;
 
 						li {
+
 							> ul {
 								left: -9999px; /* 1 */
 
@@ -411,6 +478,7 @@
 
 							&:hover,
 							&.focus {
+
 								> ul {
 									left: 100%;
 									top: 0;
@@ -449,8 +517,11 @@
 	}
 
 	ul.menu {
+
 		li {
+
 			&.current-menu-item {
+
 				> a {
 					color: $color_body;
 				}
@@ -463,10 +534,12 @@
 	 */
 	.storefront-primary-navigation {
 		clear: both;
+
 		@include clearfix;
 	}
 
 	.main-navigation {
+
 		div.menu {
 			display: block;
 		}
@@ -486,7 +559,9 @@
 
 				&.menu-item-has-children,
 				&.page_item_has_children {
+
 					&:hover {
+
 						&::after {
 							display: block;
 						}
@@ -499,6 +574,7 @@
 				margin-left: 0;
 
 				li {
+
 					a {
 						padding: ms(-1) ms(2);
 						font-weight: 400;
@@ -518,7 +594,7 @@
 				a:hover,
 				li:hover > a,
 				li.focus {
-					background-color: rgba( 0, 0, 0, 0.025 );
+					background-color: rgba(0, 0, 0, 0.025);
 				}
 			}
 		}
@@ -547,9 +623,10 @@
 			}
 
 			ul {
+
 				a {
 					padding: 0.326em ms(-1);
-					background: rgba( #000, 0.05 );
+					background: rgba(#000, 0.05);
 				}
 
 				li:first-child a {
@@ -567,7 +644,7 @@
 
 			a {
 				padding: ms(1) ms(-1);
-				color: lighten( $color_body, 20% );
+				color: lighten($color_body, 20%);
 				font-weight: 400;
 
 				&:hover {
@@ -581,8 +658,11 @@
 	 * 404 Styles
 	 */
 	.error404 {
+
 		.fourohfour-columns-2 {
+
 			.col-1 {
+
 				@include span( 6 of 12 );
 
 				ul.products {
@@ -591,6 +671,7 @@
 			}
 
 			.col-2 {
+
 				@include span( last 6 of 12 );
 			}
 		}
@@ -598,6 +679,7 @@
 }
 
 @include susy-media (max-width $container-width) {
+
 	.col-full {
 		margin-left: ms(5);
 		margin-right: ms(5);
@@ -606,6 +688,7 @@
 }
 
 @include susy-media (max-width $handheld) {
+
 	.col-full {
 		margin-left: ms(2);
 		margin-right: ms(2);

--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -1,19 +1,19 @@
 // Bourbon
 // See: https://www.bourbon.io/docs/latest/
-@import 'bourbon';
+@import "bourbon";
 
 // Susy
 // Susy grid system. See: http://oddbird.net/susy/docs/
-@import 'node_modules/susy/sass/susy';
+@import "node_modules/susy/sass/susy";
 
 // Vendors
 // External libraries and frameworks.
-@import '../sass/vendors/modular-scale';
+@import "../sass/vendors/modular-scale";
 
 // Utilities
 // Sass tools and helpers used across the project.
-@import '../sass/utils/variables';
-@import '../sass/utils/mixins';
+@import "../sass/utils/variables";
+@import "../sass/utils/mixins";
 
 /**
  * Front-end only styles
@@ -21,8 +21,10 @@
 .hentry .entry-content {
 	// Global
 	@media ( min-width: $container-width ) {
+
 		.storefront-align-wide.page-template-template-fullwidth-php &,
 		.storefront-align-wide.storefront-full-width-content & {
+
 			.alignfull,
 			.alignwide {
 				width: auto;
@@ -46,9 +48,12 @@
 
 	// Image
 	.wp-block-image {
+
 		@media ( min-width: $container-width ) {
+
 			.storefront-align-wide.page-template-template-fullwidth-php &,
 			.storefront-align-wide.storefront-full-width-content & {
+
 				&.alignfull,
 				&.alignwide {
 					padding-left: 0;
@@ -60,9 +65,12 @@
 
 	.wp-block-cover-image,
 	.wp-block-cover {
+
 		@media ( min-width: $container-width ) {
+
 			.storefront-align-wide.page-template-template-fullwidth-php &,
 			.storefront-align-wide.storefront-full-width-content & {
+
 				&.alignfull,
 				&.alignwide {
 					padding-left: 0;
@@ -75,17 +83,19 @@
 
 // Homepage
 .home.page-template-template-fullwidth {
+
 	.hentry {
 		margin-bottom: 0;
 
 		.entry-content {
+
 			> .wp-block-cover,
 			> .wp-block-image {
 				margin-bottom: ms(7);
 			}
 
 			h2 + .woocommerce,
-			h2 + [class*='wp-block-woocommerce-'] {
+			h2 + [class*="wp-block-woocommerce-"] {
 				margin-top: ms(4);
 			}
 		}
@@ -93,10 +103,14 @@
 }
 
 .home.storefront-align-wide.page-template-template-fullwidth {
+
 	.hentry {
+
 		.entry-content {
+
 			> .wp-block-cover,
 			> .wp-block-image {
+
 				&.alignfull {
 					margin-top: - ms(7);
 				}
@@ -192,6 +206,7 @@
 	}
 
 	.wp-block-latest-posts {
+
 		&__post-date {
 			font-size: ms(-1);
 		}
@@ -201,24 +216,28 @@
 		}
 
 		&.has-dates {
+
 			li {
 				margin: 0 0 1em;
 			}
 		}
 
 		&.is-grid {
+
 			li {
 				margin: 0 ms(1) 0 0;
 			}
 
 			&.has-dates {
+
 				li {
 					margin-bottom: 1em;
 				}
 			}
 		}
 
-		@media (min-width:600px) {
+		@media (min-width: 600px) {
+
 			@for $i from 2 through 6 {
 				&.columns-#{$i} li {
 					margin-right: gutter(12);
@@ -230,7 +249,8 @@
 				}
 			}
 
-			body:not( .page-template-template-fullwidth-php ):not( .storefront-full-width-content ) & {
+			body:not(.page-template-template-fullwidth-php):not(.storefront-full-width-content) & {
+
 				@for $i from 2 through 6 {
 					&.columns-#{$i} li {
 						margin-right: gutter(9);
@@ -247,8 +267,10 @@
 
 	// Paragraphs
 	p {
+
 		&.has-drop-cap {
-			&:not( :focus )::first-letter {
+
+			&:not(:focus)::first-letter {
 				margin: 0.15em ms(-4) 0 0;
 				font-size: ms(7);
 				font-weight: 300;
@@ -300,6 +322,7 @@
 
 	// Embed
 	.wp-block-embed {
+
 		&.alignleft {
 			margin-right: ms(5);
 		}
@@ -311,7 +334,7 @@
 	}
 
 	// Image
-	div.wp-block-image:not( .block-editor-media-placeholder ) {
+	div.wp-block-image:not(.block-editor-media-placeholder) {
 		display: inline;
 
 		figure {
@@ -372,7 +395,7 @@
 			width: calc(100vw - #{ms(1)});
 			max-width: calc(100vw - #{ms(1)});
 
-			*:nth-last-child( -n+1 ) {
+			*:nth-last-child(-n+1) {
 				margin-bottom: 0;
 			}
 
@@ -418,11 +441,12 @@
 			}
 
 			p {
-				&:not( .has-small-font-size ):not( .has-medium-font-size ):not( .has-large-font-size ):not( .has-huge-font-size ) {
+
+				&:not(.has-small-font-size):not(.has-medium-font-size):not(.has-large-font-size):not(.has-huge-font-size) {
 					font-size: 1.1em;
 				}
 
-				&:not( .has-text-color ) {
+				&:not(.has-text-color) {
 					color: #fff;
 				}
 			}
@@ -441,8 +465,10 @@
 		}
 
 		@media ( min-width: $container-width ) {
+
 			.storefront-align-wide.page-template-template-fullwidth-php &,
 			.storefront-align-wide.storefront-full-width-content & {
+
 				&.alignfull,
 				&.alignwide {
 					padding-left: 0;
@@ -462,7 +488,7 @@
 			margin: 0 gutter(12) gutter(12) 0;
 			flex-grow: 0;
 
-			&:nth-of-type( even ) {
+			&:nth-of-type(even) {
 				margin-right: 0;
 			}
 
@@ -472,7 +498,8 @@
 			}
 		}
 
-		@media (min-width:600px) {
+		@media (min-width: 600px) {
+
 			.blocks-gallery-image,
 			.blocks-gallery-item {
 				margin: 0 gutter(12) gutter(12) 0;
@@ -490,7 +517,8 @@
 				}
 			}
 
-			body:not( .page-template-template-fullwidth-php ):not( .storefront-full-width-content ) & {
+			body:not(.page-template-template-fullwidth-php):not(.storefront-full-width-content) & {
+
 				.blocks-gallery-image,
 				.blocks-gallery-item {
 					margin-bottom: gutter(9);
@@ -518,7 +546,7 @@
 		margin: 0 auto ms(2);
 		overflow: hidden;
 
-		&:not( .is-style-wide ):not( .is-style-dots ) {
+		&:not(.is-style-wide):not(.is-style-dots) {
 			max-width: 10%;
 		}
 	}
@@ -540,6 +568,7 @@
 		}
 
 		thead {
+
 			th {
 				padding: ms(2);
 			}
@@ -569,7 +598,7 @@
 	// Code
 	.wp-block-code,
 	.wp-block-preformatted pre {
-		font-family: 'Courier 10 Pitch', Courier, monospace;
+		font-family: "Courier 10 Pitch", Courier, monospace;
 		font-size: ms(1);
 	}
 
@@ -581,35 +610,38 @@
 
 	// Columns
 	.wp-block-columns {
+
 		.wp-block-column {
 			margin-bottom: ms(1);
 
-			@media (min-width:600px) {
+			@media (min-width: 600px) {
 				padding-left: 0;
 				padding-right: gutter(12);
 				margin-left: 0;
 
-				&:not( :last-child ) {
+				&:not(:last-child) {
 					margin-right: 0;
 				}
 
-				&:nth-of-type( even ) {
+				&:nth-of-type(even) {
 					padding-right: 0;
 				}
 
-				body:not( .page-template-template-fullwidth-php ):not( .storefront-full-width-content ) & {
+				body:not(.page-template-template-fullwidth-php):not(.storefront-full-width-content) & {
 					padding-right: gutter(9);
 
-					&:nth-of-type( even ) {
+					&:nth-of-type(even) {
 						padding-right: 0;
 					}
 				}
 			}
 		}
 
-		@media (min-width:782px) {
+		@media (min-width: 782px) {
+
 			@for $i from 2 through 6 {
 				&.has-#{$i}-columns {
+
 					.wp-block-column {
 						&:nth-of-type( #{$i}n ) {
 							margin-right: 0;
@@ -621,19 +653,19 @@
 			.wp-block-column {
 				padding-right: 0;
 
-				&:not( :first-child ) {
+				&:not(:first-child) {
 					padding-left: 0;
 				}
 
-				&:not( :last-child ) {
+				&:not(:last-child) {
 					padding-right: 0;
 					margin-right: gutter(12);
 				}
 
-				body:not( .page-template-template-fullwidth-php ):not( .storefront-full-width-content ) & {
+				body:not(.page-template-template-fullwidth-php):not(.storefront-full-width-content) & {
 					padding-right: 0;
 
-					&:not( :last-child ) {
+					&:not(:last-child) {
 						margin-right: gutter(9);
 					}
 				}
@@ -659,6 +691,7 @@
 		}
 
 		&__comment-excerpt {
+
 			p {
 				margin: ms(-3) 0 ms(1);
 				font-size: 1em;
@@ -667,7 +700,9 @@
 		}
 
 		&.has-avatars {
+
 			.wp-block-latest-comments__comment {
+
 				.wp-block-latest-comments__comment-excerpt,
 				.wp-block-latest-comments__comment-meta {
 					margin-left: ms(6);
@@ -675,7 +710,8 @@
 			}
 		}
 
-		&:not( .has-avatars ):not( .has-dates ):not( .has-excerpts ) {
+		&:not(.has-avatars):not(.has-dates):not(.has-excerpts) {
+
 			.wp-block-latest-comments__comment {
 				margin: 0;
 				line-height: 1.618;
@@ -684,13 +720,14 @@
 
 		br {
 			display: inline;
-			content: '';
+			content: "";
 		}
 	}
 }
 
 // Top rated products
 .wc-block-grid {
+
 	img {
 		display: block;
 		margin: 0 auto ms(3);

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -1,19 +1,19 @@
 // Bourbon
 // See: https://www.bourbon.io/docs/latest/
-@import 'bourbon';
+@import "bourbon";
 
 // Susy
 // Susy grid system. See: http://oddbird.net/susy/docs/
-@import 'node_modules/susy/sass/susy';
+@import "node_modules/susy/sass/susy";
 
 // Vendors
 // External libraries and frameworks.
-@import '../sass/vendors/modular-scale';
+@import "../sass/vendors/modular-scale";
 
 // Utilities
 // Sass tools and helpers used across the project.
-@import '../sass/utils/variables';
-@import '../sass/utils/mixins';
+@import "../sass/utils/variables";
+@import "../sass/utils/mixins";
 
 // Base typography
 body {
@@ -103,6 +103,7 @@ ol,
 table,
 blockquote,
 form {
+
 	& + h2,
 	& + header h2,
 	& + h3,
@@ -166,7 +167,7 @@ blockquote,
 .wp-block-freeform.block-library-rich-text__tinymce blockquote {
 	margin: 1em 40px;
 	padding: 0 ms(1);
-	border-left: 3px solid rgba( 0, 0, 0, 0.05 );
+	border-left: 3px solid rgba(0, 0, 0, 0.05);
 	font-style: italic;
 	box-shadow: none;
 }
@@ -176,8 +177,8 @@ address {
 }
 
 pre {
-	background: rgba( #000, 0.1 );
-	font-family: 'Courier 10 Pitch', Courier, monospace;
+	background: rgba(#000, 0.1);
+	font-family: "Courier 10 Pitch", Courier, monospace;
 	margin-bottom: ms(3);
 	padding: ms(3);
 	overflow: auto;
@@ -188,8 +189,8 @@ code,
 kbd,
 tt,
 var {
-	font-family: Monaco, Consolas, 'Andale Mono', 'DejaVu Sans Mono', monospace;
-	background-color: rgba( 0, 0, 0, 0.05 );
+	font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+	background-color: rgba(0, 0, 0, 0.05);
 	padding: 0.202em ms(-3);
 }
 
@@ -273,6 +274,7 @@ table {
 	}
 
 	thead {
+
 		th {
 			padding: ms(2);
 			vertical-align: middle;
@@ -280,6 +282,7 @@ table {
 	}
 
 	tbody {
+
 		h2 {
 			font-size: 1em;
 			letter-spacing: normal;
@@ -302,16 +305,17 @@ table {
 	max-width: calc(#{$container-width} * #{$span-value / ( $span-value * 0 + 1 )}); // Unitless hack.
 }
 
-.wp-block[data-align='wide'] {
+.wp-block[data-align="wide"] {
 	max-width: ms(19);
 }
 
-.wp-block[data-align='full'] {
+.wp-block[data-align="full"] {
 	max-width: none;
 }
 
 // Tables
 .wp-block-table {
+
 	&__cell-content {
 		padding: 0;
 	}
@@ -334,6 +338,7 @@ ul.wp-block-latest-posts {
 	margin-bottom: ms(2);
 
 	&.is-style-dots {
+
 		&::before {
 			padding-left: 1em;
 			letter-spacing: 1em;
@@ -345,7 +350,7 @@ ul.wp-block-latest-posts {
 		}
 	}
 
-	&:not( .is-style-dots ) {
+	&:not(.is-style-dots) {
 		height: 2px;
 
 		.wp-block & {
@@ -356,10 +361,13 @@ ul.wp-block-latest-posts {
 
 // Grid blocks
 .wc-block-grid__products {
+
 	.wc-block-grid__product {
+
 		.wp-block-button__link {
-			color: #333333;
+			color: #333;
 		}
+
 		.wc-block-grid__product-onsale {
 			border: 1px solid;
 			border-color: $color_body;
@@ -373,10 +381,11 @@ ul.wp-block-latest-posts {
 			border-radius: 3px;
 			position: relative;
 		}
+
 		.wc-block-grid__product-title {
 			font-weight: 400;
 			font-size: 1rem;
-			color: #000000;
+			color: #000;
 		}
 	}
 }

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -286,10 +286,10 @@ table {
 		h2 {
 			font-size: 1em;
 			letter-spacing: normal;
-			font-weight: normal;
+			font-weight: 400;
 
 			a {
-				font-weight: normal;
+				font-weight: 400;
 			}
 		}
 	}

--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -37,8 +37,8 @@
 
 		form {
 
-			input[type=search],
-			input[type=text] {
+			input[type="search"],
+			input[type="text"] {
 				padding-left: ms(5);
 			}
 		}
@@ -211,8 +211,8 @@ input[type="submit"],
 			line-height: 1;
 		}
 
-		input[type=text],
-		input[type=search] {
+		input[type="text"],
+		input[type="search"] {
 			padding-left: ms(5);
 		}
 	}
@@ -695,7 +695,7 @@ a.remove {
 			&.woocommerce-PaymentMethod,
 			&.wc_payment_method {
 
-				> input[type=radio]:first-child {
+				> input[type="radio"]:first-child {
 
 					@include screen-reader-text();
 

--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -1,37 +1,42 @@
-@import 'bourbon';
+@import "bourbon";
 
 // Susy
 // Susy grid system. See: http://susydocs.oddbird.net/en/latest/
-@import '../../../node_modules/susy/sass/susy';
+@import "../../../node_modules/susy/sass/susy";
 
 // Utilities
 // Sass tools and helpers used across the project.
-@import '../sass/utils/variables';
-@import '../sass/utils/mixins';
-@import '../sass/vendors/font-awesome/fontawesome';
-@import '../sass/vendors/font-awesome/brands';
-@import '../sass/vendors/font-awesome/solid';
-@import '../sass/vendors/modular-scale';
+@import "../sass/utils/variables";
+@import "../sass/utils/mixins";
+@import "../sass/vendors/font-awesome/fontawesome";
+@import "../sass/vendors/font-awesome/brands";
+@import "../sass/vendors/font-awesome/solid";
+@import "../sass/vendors/modular-scale";
 
 @mixin sf-fa-icon {
+
 	@include fa-icon;
-	font-family: 'Font Awesome 5 Free';
+	font-family: "Font Awesome 5 Free";
 	font-weight: 900;
 	line-height: inherit;
 	vertical-align: baseline;
 }
 
 @mixin sf-fab-icon {
+
 	@include fab-icon;
-	font-family: 'Font Awesome 5 Brands';
+	font-family: "Font Awesome 5 Brands";
 	font-weight: 900;
 	line-height: inherit;
 	vertical-align: baseline;
 }
 
 .site-search {
+
 	.widget_product_search {
+
 		form {
+
 			input[type=search],
 			input[type=text] {
 				padding-left: ms(5);
@@ -41,29 +46,39 @@
 }
 
 #comments {
+
 	.comment-list {
+
 		.bypostauthor {
+
 			> .comment-body cite a {
+
 				&::after {
+
 					@include sf-fa-icon;
-					content: fa-content( $fa-var-file-alt );
+					content: fa-content($fa-var-file-alt);
 					margin-left: ms(-3);
 				}
 			}
 		}
 
 		.reply {
+
 			a {
+
 				&::after {
+
 					@include sf-fa-icon;
-					content: fa-content( $fa-var-reply );
+					content: fa-content($fa-var-reply);
 					margin-left: ms(-3);
 				}
 
 				&.comment-edit-link {
+
 					&::after {
+
 						@include sf-fa-icon;
-						content: fa-content( $fa-var-pencil-alt );
+						content: fa-content($fa-var-pencil-alt);
 					}
 				}
 			}
@@ -72,20 +87,26 @@
 }
 
 #respond {
+
 	#cancel-comment-reply-link {
+
 		&::before {
+
 			@include sf-fa-icon;
-			content: fa-content( $fa-var-times-circle );
+			content: fa-content($fa-var-times-circle);
 			display: block;
 		}
 	}
 }
 
 .sticky {
+
 	.entry-title {
+
 		&::before {
+
 			@include sf-fa-icon;
-			content: fa-content( $fa-var-thumbtack );
+			content: fa-content($fa-var-thumbtack);
 			margin-right: ms(-3);
 
 		}
@@ -93,18 +114,20 @@
 }
 
 button,
-input[type='button'],
-input[type='reset'],
-input[type='submit'],
+input[type="button"],
+input[type="reset"],
+input[type="submit"],
 .button,
 .wc-block-grid__products .wc-block-grid__product .wp-block-button__link,
 .added_to_cart {
+
 	&.loading {
 		position: relative;
 
 		&::after {
+
 			@include sf-fa-icon;
-			content: fa-content( $fa-var-spinner );
+			content: fa-content($fa-var-spinner);
 			animation: fa-spin 0.75s linear infinite;
 			height: 20px;
 			width: 20px;
@@ -121,13 +144,19 @@ input[type='submit'],
 }
 
 .handheld-navigation {
+
 	ul {
+
 		&.menu {
+
 			li {
+
 				button {
+
 					&::after {
+
 						@include sf-fa-icon;
-						content: fa-content( $fa-var-angle-down );
+						content: fa-content($fa-var-angle-down);
 					}
 				}
 			}
@@ -136,22 +165,30 @@ input[type='submit'],
 }
 
 .site-main {
+
 	nav.navigation {
+
 		.nav-previous {
+
 			a {
+
 				&::before {
+
 					@include sf-fa-icon;
-					content: fa-content( $fa-var-long-arrow-alt-left );
+					content: fa-content($fa-var-long-arrow-alt-left);
 					margin-right: ms(-3);
 				}
 			}
 		}
 
 		.nav-next {
+
 			a {
+
 				&::after {
+
 					@include sf-fa-icon;
-					content: fa-content( $fa-var-long-arrow-alt-right );
+					content: fa-content($fa-var-long-arrow-alt-right);
 					margin-left: ms(-3);
 				}
 			}
@@ -161,10 +198,13 @@ input[type='submit'],
 
 .widget_search,
 .widget_product_search {
+
 	form {
+
 		&::before {
+
 			@include sf-fa-icon;
-			content: fa-content( $fa-var-search );
+			content: fa-content($fa-var-search);
 			position: absolute;
 			top: 1em;
 			left: 1em;
@@ -179,10 +219,15 @@ input[type='submit'],
 }
 
 .storefront-handheld-footer-bar {
+
 	ul {
+
 		li {
+
 			> a {
+
 				&::before {
+
 					@include sf-fa-icon;
 					position: absolute;
 					top: 0;
@@ -199,20 +244,23 @@ input[type='submit'],
 			}
 
 			&.search {
+
 				> a::before {
-					content: fa-content( $fa-var-search );
+					content: fa-content($fa-var-search);
 				}
 			}
 
 			&.my-account {
+
 				> a::before {
-					content: fa-content( $fa-var-user );
+					content: fa-content($fa-var-user);
 				}
 			}
 
 			&.cart {
+
 				> a::before {
-					content: fa-content( $fa-var-shopping-basket );
+					content: fa-content($fa-var-shopping-basket);
 				}
 			}
 		}
@@ -220,24 +268,30 @@ input[type='submit'],
 }
 
 .storefront-product-pagination {
+
 	a {
-		&[rel='prev'],
-		&[rel='next'] {
+
+		&[rel="prev"],
+		&[rel="next"] {
+
 			&::after {
+
 				@include sf-fa-icon;
 			}
 		}
 
-		&[rel='prev'] {
+		&[rel="prev"] {
+
 			&::after {
-				content: fa-content( $fa-var-angle-left );
+				content: fa-content($fa-var-angle-left);
 				padding-right: ms(2);
 			}
 		}
 
-		&[rel='next'] {
+		&[rel="next"] {
+
 			&::after {
-				content: fa-content( $fa-var-angle-right );
+				content: fa-content($fa-var-angle-right);
 				padding-left: ms(2);
 			}
 		}
@@ -245,20 +299,24 @@ input[type='submit'],
 }
 
 .single-product {
+
 	.pswp__button {
 		background-color: transparent;
 	}
 
 	div.product {
+
 		.woocommerce-product-gallery {
+
 			.woocommerce-product-gallery__trigger {
 				text-indent: -999px;
 				overflow: hidden;
 
 				&::before {
+
 					@include sf-fa-icon;
-					content: fa-content( $fa-var-search-plus );
-					display:block;
+					content: fa-content($fa-var-search-plus);
+					display: block;
 					line-height: 2;
 					text-indent: 0;
 				}
@@ -272,38 +330,48 @@ input[type='submit'],
 }
 
 .stock {
+
 	&::before {
+
 		@include sf-fa-icon;
 		margin-right: ms(-3);
 	}
 
 	&.in-stock {
+
 		&::before {
-			content: fa-content( $fa-var-smile );
+			content: fa-content($fa-var-smile);
 		}
 	}
 
 	&.out-of-stock {
+
 		&::before {
-			content: fa-content( $fa-var-frown );
+			content: fa-content($fa-var-frown);
 		}
 	}
 }
 
 a.reset_variations {
+
 	&::before {
+
 		@include sf-fa-icon;
-		content: fa-content( $fa-var-sync );
+		content: fa-content($fa-var-sync);
 		margin-right: ms(-3);
 	}
 }
 
 .woocommerce-breadcrumb {
+
 	a {
+
 		&:first-of-type {
+
 			&::before {
+
 				@include sf-fa-icon;
-				content: fa-content( $fa-var-home );
+				content: fa-content($fa-var-home);
 				margin-right: ms(-3);
 			}
 		}
@@ -320,6 +388,7 @@ a.reset_variations {
 .widget_product_categories,
 .widget_layered_nav,
 .widget_layered_nav_filters {
+
 	ul {
 		margin: 0;
 
@@ -327,6 +396,7 @@ a.reset_variations {
 			padding-left: ms(3);
 
 			&::before {
+
 				@include sf-fa-icon;
 				margin-right: ms(-3);
 				display: block;
@@ -340,16 +410,21 @@ a.reset_variations {
 }
 
 .widget_product_categories {
+
 	ul {
+
 		li {
+
 			&::before {
+
 				@include sf-fa-icon;
-				content: fa-content( $fa-var-folder );
+				content: fa-content($fa-var-folder);
 			}
 
 			&.current-cat {
+
 				&::before {
-					content: fa-content( $fa-var-folder-open );
+					content: fa-content($fa-var-folder-open);
 				}
 			}
 		}
@@ -357,25 +432,32 @@ a.reset_variations {
 }
 
 .widget_layered_nav {
+
 	li {
+
 		&::before {
-			content: fa-content( $fa-var-square );
+			content: fa-content($fa-var-square);
 		}
 	}
 
 	.chosen {
+
 		&::before {
-			content: fa-content( $fa-var-check-square );
+			content: fa-content($fa-var-check-square);
 		}
 	}
 }
 
 .widget_layered_nav_filters {
+
 	ul {
+
 		li {
+
 			&.chosen {
+
 				&::before {
-					content: fa-content( $fa-var-times );
+					content: fa-content($fa-var-times);
 					color: $error;
 					opacity: 1;
 				}
@@ -386,26 +468,34 @@ a.reset_variations {
 
 .widget_recent_entries,
 .widget_pages {
+
 	ul {
+
 		li {
+
 			&::before {
-				content: fa-content( $fa-var-file-alt );
+				content: fa-content($fa-var-file-alt);
 			}
 		}
 	}
 }
 
 .widget_categories {
+
 	ul {
+
 		li {
+
 			&::before {
+
 				@include sf-fa-icon;
-				content: fa-content( $fa-var-folder );
+				content: fa-content($fa-var-folder);
 			}
 
 			&.current-cat {
+
 				&::before {
-					content: fa-content( $fa-var-folder-open );
+					content: fa-content($fa-var-folder-open);
 				}
 			}
 		}
@@ -413,40 +503,52 @@ a.reset_variations {
 }
 
 .widget_archive {
+
 	ul {
+
 		li {
+
 			&::before {
-				content: fa-content( $fa-var-folder-open );
+				content: fa-content($fa-var-folder-open);
 			}
 		}
 	}
 }
 
 .widget_recent_comments {
+
 	ul {
+
 		li {
+
 			&::before {
-				content: fa-content( $fa-var-comment );
+				content: fa-content($fa-var-comment);
 			}
 		}
 	}
 }
 
 .widget_nav_menu {
+
 	ul {
+
 		li {
+
 			&::before {
-				content: fa-content( $fa-var-file-alt );
+				content: fa-content($fa-var-file-alt);
 			}
 		}
 	}
 }
 
 .widget_links {
+
 	ul {
+
 		li {
+
 			&::before {
-				content: fa-content( $fa-var-external-link-alt );
+				content: fa-content($fa-var-external-link-alt);
 			}
 		}
 	}
@@ -463,14 +565,15 @@ a.remove {
 	position: relative;
 
 	&::before {
+
 		@include sf-fa-icon;
-		content: fa-content( $fa-var-times-circle );
+		content: fa-content($fa-var-times-circle);
 		position: absolute;
 		top: 0;
 		left: 0;
 		right: 0;
 		bottom: 0;
-		color: lighten( $color-body, 20% );
+		color: lighten($color-body, 20%);
 		line-height: 1.618;
 		text-indent: 0;
 		text-align: center;
@@ -478,11 +581,15 @@ a.remove {
 }
 
 .woocommerce-shipping-calculator {
+
 	> p:first-child {
+
 		a {
+
 			&::before {
+
 				@include sf-fa-icon;
-				content: fa-content( $fa-var-truck );
+				content: fa-content($fa-var-truck);
 				margin-right: ms(-5);
 			}
 		}
@@ -490,9 +597,11 @@ a.remove {
 }
 
 .blockUI {
+
 	&::before {
+
 		@include sf-fa-icon;
-		content: fa-content( $fa-var-spinner );
+		content: fa-content($fa-var-spinner);
 		animation: fa-spin 0.75s linear infinite;
 		height: 30px;
 		width: 30px;
@@ -507,6 +616,7 @@ a.remove {
 }
 
 .woocommerce-pagination {
+
 	.next,
 	.prev {
 		text-indent: -9999px;
@@ -514,8 +624,9 @@ a.remove {
 		overflow: hidden;
 
 		&::after {
+
 			@include sf-fa-icon;
-			content: fa-content( $fa-var-caret-left );
+			content: fa-content($fa-var-caret-left);
 			text-indent: 0;
 			position: absolute;
 			top: 50%;
@@ -525,13 +636,15 @@ a.remove {
 	}
 
 	.next {
+
 		&::after {
-			content: fa-content( $fa-var-caret-right );
+			content: fa-content($fa-var-caret-right);
 		}
 	}
 }
 
 .woocommerce-breadcrumb {
+
 	.breadcrumb-separator {
 		text-indent: -9999px;
 		position: relative;
@@ -539,8 +652,9 @@ a.remove {
 		padding: 0 ms(9);
 
 		&::after {
+
 			@include sf-fa-icon;
-			content: fa-content( $fa-var-angle-right );
+			content: fa-content($fa-var-angle-right);
 			display: block;
 			font-size: ms(-1);
 			text-indent: 0;
@@ -558,13 +672,18 @@ a.remove {
 }
 
 #payment {
+
 	.payment_methods {
+
 		> .woocommerce-PaymentMethod,
 		> .wc_payment_method {
+
 			> label {
+
 				&::before {
+
 					@include sf-fa-icon;
-					content: fa-content( $fa-var-circle );
+					content: fa-content($fa-var-circle);
 					margin-right: ms(-3);
 					transition: color, ease, 0.2s;
 				}
@@ -572,13 +691,16 @@ a.remove {
 		}
 
 		li {
+
 			&.woocommerce-PaymentMethod,
 			&.wc_payment_method {
+
 				> input[type=radio]:first-child {
+
 					@include screen-reader-text();
 
 					&:checked + label::before {
-						content: fa-content( $fa-var-dot-circle );
+						content: fa-content($fa-var-dot-circle);
 					}
 				}
 			}
@@ -587,38 +709,48 @@ a.remove {
 }
 
 .woocommerce-password-strength {
+
 	&::after {
+
 		@include sf-fa-icon;
-		content: fa-content( $fa-var-frown );
+		content: fa-content($fa-var-frown);
 		margin-left: ms(-3);
 	}
 
 	&.strong {
+
 		&::after {
-			content: fa-content( $fa-var-smile );
+			content: fa-content($fa-var-smile);
 		}
 	}
 
 	&.good {
+
 		&::after {
-			content: fa-content( $fa-var-meh );
+			content: fa-content($fa-var-meh);
 		}
 	}
 }
 
 .woocommerce-MyAccount-navigation {
+
 	ul {
+
 		li {
+
 			&.is-active {
+
 				a::before {
 					opacity: 1;
 				}
 			}
 
 			a {
+
 				&::before {
+
 					@include sf-fa-icon;
-					content: fa-content( $fa-var-file-alt );
+					content: fa-content($fa-var-file-alt);
 					line-height: 1.618;
 					margin-left: ms(-3);
 					width: ms(2);
@@ -628,6 +760,7 @@ a.remove {
 				}
 
 				&:hover {
+
 					&::before {
 						opacity: 1;
 					}
@@ -635,84 +768,99 @@ a.remove {
 			}
 
 			&.woocommerce-MyAccount-navigation-link--dashboard a::before {
-				content: fa-content( $fa-var-tachometer-alt );
+				content: fa-content($fa-var-tachometer-alt);
 			}
 
 			&.woocommerce-MyAccount-navigation-link--orders a::before {
-				content: fa-content( $fa-var-shopping-basket );
+				content: fa-content($fa-var-shopping-basket);
 			}
 
 			&.woocommerce-MyAccount-navigation-link--downloads a::before {
-				content: fa-content( $fa-var-file-archive );
+				content: fa-content($fa-var-file-archive);
 			}
 
 			&.woocommerce-MyAccount-navigation-link--edit-address a::before {
-				content: fa-content( $fa-var-home );
+				content: fa-content($fa-var-home);
 			}
 
 			&.woocommerce-MyAccount-navigation-link--payment-methods a::before {
-				content: fa-content( $fa-var-credit-card );
+				content: fa-content($fa-var-credit-card);
 			}
 
 			&.woocommerce-MyAccount-navigation-link--edit-account a::before {
-				content: fa-content( $fa-var-user );
+				content: fa-content($fa-var-user);
 			}
 
 			&.woocommerce-MyAccount-navigation-link--customer-logout a::before {
-				content: fa-content( $fa-var-sign-out-alt );
+				content: fa-content($fa-var-sign-out-alt);
 			}
 
 			&.woocommerce-MyAccount-navigation-link--subscriptions a::before {
-				content: fa-content( $fa-var-sync );
+				content: fa-content($fa-var-sync);
 			}
 		}
 	}
 }
 
 .my_account_orders {
+
 	.button.view {
+
 		&::after {
+
 			@include sf-fa-icon;
-			content: fa-content( $fa-var-eye );
+			content: fa-content($fa-var-eye);
 			margin-left: ms(-3);
 		}
 	}
 }
 
 p.order-again {
+
 	.button {
+
 		&::after {
+
 			@include sf-fa-icon;
-			content: fa-content( $fa-var-sync );
+			content: fa-content($fa-var-sync);
 			margin-left: ms(-3);
 		}
 	}
 }
 
 .woocommerce-MyAccount-downloads {
+
 	.button {
+
 		&::after {
+
 			@include sf-fa-icon;
-			content: fa-content( $fa-var-cloud-download-alt );
+			content: fa-content($fa-var-cloud-download-alt);
 			margin-left: ms(-3);
 		}
 	}
 }
 
 .demo_store {
+
 	&::before {
+
 		@include sf-fa-icon;
-		content: fa-content( $fa-var-info-circle );
+		content: fa-content($fa-var-info-circle);
 		margin-right: ms(-3);
 	}
 }
 
 .woocommerce-tabs {
+
 	ul.tabs {
+
 		li {
+
 			&::after {
+
 				@include sf-fa-icon;
-				content: fa-content( $fa-var-angle-down );
+				content: fa-content($fa-var-angle-down);
 				display: block;
 				position: absolute;
 				top: 50%;
@@ -723,6 +871,7 @@ p.order-again {
 			}
 
 			&.active {
+
 				&::after {
 					opacity: 1;
 					right: 0;
@@ -734,25 +883,33 @@ p.order-again {
 
 .wc-forward,
 .woocommerce-Button--next {
+
 	&::after {
+
 		@include sf-fa-icon;
-		content: fa-content( $fa-var-long-arrow-alt-right );
+		content: fa-content($fa-var-long-arrow-alt-right);
 		margin-left: ms(-3);
 	}
 }
 
 .woocommerce-Button--previous {
+
 	&::before {
+
 		@include sf-fa-icon;
-		content: fa-content( $fa-var-long-arrow-alt-left );
+		content: fa-content($fa-var-long-arrow-alt-left);
 		margin-right: ms(-3);
 	}
 }
 
 #reviews {
+
 	.commentlist {
+
 		li {
+
 			p.meta {
+
 				.verified {
 					display: inline-block;
 					height: ms(2);
@@ -761,8 +918,9 @@ p.order-again {
 					text-indent: -9999px;
 
 					&::before {
+
 						@include sf-fa-icon;
-						content: fa-content( $fa-var-check-circle );
+						content: fa-content($fa-var-check-circle);
 						color: $success;
 						position: absolute;
 						top: 0;
@@ -783,10 +941,13 @@ p.order-again {
  * Composite Products
  */
 .single-product div.product {
+
 	.component_selections {
+
 		.clear_component_options::before {
+
 			@include sf-fa-icon;
-			content: fa-content( $fa-var-sync );
+			content: fa-content($fa-var-sync);
 			margin-right: ms(-3);
 		}
 	}
@@ -797,11 +958,16 @@ p.order-again {
  */
 .cart,
 .shop_table {
+
 	.mnm_table_item {
+
 		.mnm_table_item_indent {
+
 			&::before {
+
 				@include sf-fa-icon;
-				content: fa-content( $fa-var-level-up-alt );
+				content: fa-content($fa-var-level-up-alt);
+
 				@include fa-icon-rotate(90deg,1);
 				margin-right: ms(-4);
 				opacity: 0.25;
@@ -814,9 +980,11 @@ p.order-again {
  * Quick view
  */
 .quick-view-button {
+
 	&::before {
+
 		@include sf-fa-icon;
-		content: fa-content( $fa-var-eye );
+		content: fa-content($fa-var-eye);
 		margin-right: ms(-2);
 	}
 }
@@ -825,32 +993,42 @@ p.order-again {
  * Ship multiple addresses
  */
 .woocommerce-page {
+
 	.ship_address,
 	.no_shipping_address {
+
 		.gift-form {
+
 			label {
+
 				&::after {
+
 					@include sf-fa-icon;
-					content: fa-content( $fa-var-gift );
+					content: fa-content($fa-var-gift);
 					margin-left: ms(-3);
 				}
 			}
 		}
 
 		.modify-address-button {
+
 			&::before {
+
 				@include sf-fa-icon;
-				content: fa-content( $fa-var-edit );
+				content: fa-content($fa-var-edit);
 				margin-right: ms(-3);
 			}
 		}
 	}
 
 	.addresses {
+
 		+ .addresses {
+
 			header.title {
+
 				a::before {
-					content: fa-content( $fa-var-plus );
+					content: fa-content($fa-var-plus);
 				}
 			}
 		}
@@ -862,11 +1040,15 @@ p.order-again {
  */
 .woocommerce,
 .woocommerce-page {
+
 	.woocommerce-MyAccount-navigation {
+
 		li.woocommerce-MyAccount-navigation-link--contributions {
+
 			a::before {
+
 				@include sf-fa-icon;
-				content: fa-content( $fa-var-star );
+				content: fa-content($fa-var-star);
 			}
 		}
 	}
@@ -876,9 +1058,11 @@ p.order-again {
  * Variation Swatches
  */
 a#variations_clear {
+
 	&::before {
+
 		@include sf-fa-icon;
-		content: fa-content( $fa-var-sync );
+		content: fa-content($fa-var-sync);
 		margin-right: ms(-3);
 	}
 }
@@ -887,33 +1071,43 @@ a#variations_clear {
  * Wishlists
  */
 .wl-add-link {
+
 	&::before {
+
 		@include sf-fa-icon;
-		content: fa-content( $fa-var-heart );
+		content: fa-content($fa-var-heart);
 		margin-right: ms(-3);
 	}
 }
 
 .button.wl-create-new {
+
 	&::before {
+
 		@include sf-fa-icon;
-		content: fa-content( $fa-var-plus );
+		content: fa-content($fa-var-plus);
 		margin-right: ms(-3);
 	}
 }
 
 @include susy-media($desktop) {
+
 	.main-navigation {
+
 		ul.menu,
 		ul.nav-menu {
+
 			> li {
+
 				&.menu-item-has-children,
 				&.page_item_has_children {
+
 					> a {
+
 						&::after {
 							// The dropdown indicator
 							@include sf-fa-icon;
-							content: fa-content( $fa-var-angle-down );
+							content: fa-content($fa-var-angle-down);
 							margin-left: 1em;
 						}
 					}
@@ -923,17 +1117,23 @@ a#variations_clear {
 	}
 
 	.main-navigation {
+
 		ul.menu,
 		ul.nav-menu {
+
 			ul {
+
 				li {
+
 					&.menu-item-has-children,
 					&.page_item_has_children {
+
 						> a {
+
 							&::after {
 								// The dropdown indicator
 								@include sf-fa-icon;
-								content: fa-content( $fa-var-angle-right );
+								content: fa-content($fa-var-angle-right);
 								float: right;
 								line-height: 1.618;
 							}
@@ -945,11 +1145,15 @@ a#variations_clear {
 	}
 
 	.demo_store {
+
 		a {
+
 			&.woocommerce-store-notice__dismiss-link {
+
 				&::before {
+
 					@include sf-fa-icon;
-					content: fa-content( $fa-var-times-circle );
+					content: fa-content($fa-var-times-circle);
 					margin-right: ms(-5);
 				}
 			}
@@ -957,10 +1161,13 @@ a#variations_clear {
 	}
 
 	.site-header-cart {
+
 		.cart-contents {
+
 			&::after {
+
 				@include sf-fa-icon;
-				content: fa-content( $fa-var-shopping-basket );
+				content: fa-content($fa-var-shopping-basket);
 				height: 1em;
 				float: right;
 				line-height: 1.618;
@@ -969,7 +1176,9 @@ a#variations_clear {
 	}
 
 	.addresses {
+
 		header.title {
+
 			a {
 				display: block;
 				width: 1em;
@@ -980,8 +1189,9 @@ a#variations_clear {
 				margin-top: ms(-2);
 
 				&::before {
+
 					@include sf-fa-icon;
-					content: fa-content( $fa-var-edit );
+					content: fa-content($fa-var-edit);
 					line-height: 1.618;
 					position: absolute;
 					top: 0;
@@ -996,10 +1206,13 @@ a#variations_clear {
 	}
 
 	.woocommerce-tabs {
+
 		ul.tabs {
+
 			li {
+
 				&::after {
-					content: fa-content( $fa-var-angle-right );
+					content: fa-content($fa-var-angle-right);
 				}
 			}
 		}
@@ -1009,12 +1222,17 @@ a#variations_clear {
 	 * Wishlists
 	 */
 	#wl-wrapper {
+
 		.wl-tabs {
+
 			> li {
+
 				&.active {
+
 					&::after {
+
 						@include sf-fa-icon;
-						content: fa-content( $fa-var-angle-right );
+						content: fa-content($fa-var-angle-right);
 						display: block !important;
 						position: absolute;
 						top: 50%;

--- a/assets/css/jetpack/infinite-scroll.scss
+++ b/assets/css/jetpack/infinite-scroll.scss
@@ -12,7 +12,7 @@ ul.products + .storefront-sorting,
 	display: none;
 }
 
-/* When Infinite Scroll has reached its end we need to re-display elements that were hidden (via .neverending) before */
+/* Re-display the Theme Footer when Infinite Scroll has reached its end. */
 .infinity-end.neverending .site-footer {
 	display: block;
 }

--- a/assets/css/jetpack/widgets.scss
+++ b/assets/css/jetpack/widgets.scss
@@ -3,14 +3,16 @@
  */
 
 // Imports
-@import 'bourbon';
-@import '../sass/utils/variables';
-@import '../sass/utils/mixins';
-@import '../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../sass/utils/variables";
+@import "../sass/utils/mixins";
+@import "../sass/vendors/modular-scale";
 
 // Subscription widget
 .jetpack_subscription_widget {
+
 	#subscribe-email {
+
 		input {
 			padding: ms(-2) !important;
 			width: 100% !important;
@@ -20,6 +22,7 @@
 
 // Google Translate widget
 .widget_google_translate_widget {
+
 	img {
 		display: inline;
 	}

--- a/assets/css/sass/utils/_mixins.scss
+++ b/assets/css/sass/utils/_mixins.scss
@@ -1,9 +1,11 @@
 @mixin clearfix {
+
 	&::before,
 	&::after {
-		content: '';
+		content: "";
 		display: table;
 	}
+
 	&::after {
 		clear: both;
 	}
@@ -34,8 +36,9 @@
 
 // Remove underline if element has a button class.
 @mixin remove-button-underline() {
+
 	&.button,
-	&.components-button:not( .is-link ),
+	&.components-button:not(.is-link),
 	&.wp-block-button__link {
 		text-decoration: none;
 	}
@@ -56,7 +59,7 @@
 	outline: none;
 	-webkit-appearance: none;
 	border-radius: 0;
-	box-shadow: inset 0 -1px 0 rgba( #000, 0.3 );
+	box-shadow: inset 0 -1px 0 rgba(#000, 0.3);
 }
 
 @mixin wrap-break-word {

--- a/assets/css/sass/utils/_variables.scss
+++ b/assets/css/sass/utils/_variables.scss
@@ -1,7 +1,8 @@
 // Some common variables and mixins to get you started.
-// Variables allow you to re-use colors, sizes, and other values without repeating
-// yourself. This means that changes that should be small, such as tweaking the
-// coloring or the sizing, can be done in one place, not all over the stylesheet.
+// Variables allow you to re-use colors, sizes, and other values without
+// repeating yourself. This means that changes that should be small, such as
+// tweaking the coloring or the sizing, can be done in one place,
+// not all over the stylesheet.
 
 $base-font:         "Source Sans Pro", "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 $header-font:       $base-font;

--- a/assets/css/sass/utils/_variables.scss
+++ b/assets/css/sass/utils/_variables.scss
@@ -3,16 +3,16 @@
 // yourself. This means that changes that should be small, such as tweaking the
 // coloring or the sizing, can be done in one place, not all over the stylesheet.
 
-$base-font:         'Source Sans Pro', 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+$base-font:         "Source Sans Pro", "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 $header-font:       $base-font;
 $ms-base:           1em, 0.875em;
 $ms-ratio:          1.618;
 
 // base color scheme
-$body-background:   #ffffff;
+$body-background:   #fff;
 $color_body:        #43454b;
 $color_links:       #2c2d33;
-$color_border:      rgba( 0, 0, 0, 0.05 );
+$color_border:      rgba(0, 0, 0, 0.05);
 $color_woocommerce: #96588a;
 $error:             #e2401c;
 $success:           #0f834d;
@@ -24,7 +24,7 @@ $handheld:          568px;
 $container-width:   ms(18);
 
 // fontawesome
-$fa-font-path:      '../../../assets/fonts';
+$fa-font-path:      "../../../assets/fonts";
 
 // susy
 $susy: (

--- a/assets/css/woocommerce/extensions/advanced-product-labels.scss
+++ b/assets/css/woocommerce/extensions/advanced-product-labels.scss
@@ -5,9 +5,9 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/vendors/modular-scale";
 
 .wapl-flash,
 .wapl-flash .product-label {

--- a/assets/css/woocommerce/extensions/ajax-layered-nav.scss
+++ b/assets/css/woocommerce/extensions/ajax-layered-nav.scss
@@ -5,14 +5,17 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../sass/vendors/modular-scale";
 
 .widget_layered_nav {
+
 	ul.colors {
+
 		li {
+
 			a {
 				display: block;
 			}
@@ -27,6 +30,7 @@
 			}
 
 			&.chosen {
+
 				a {
 					opacity: 1;
 
@@ -39,7 +43,9 @@
 	}
 
 	ul.checkboxes {
+
 		li {
+
 			input {
 				margin-right: ms(-2);
 			}
@@ -47,7 +53,9 @@
 	}
 
 	ul.sizes {
+
 		li {
+
 			a {
 				opacity: 1;
 			}
@@ -70,6 +78,7 @@
 			}
 
 			&.chosen {
+
 				.size-filter {
 					opacity: 1;
 
@@ -84,14 +93,18 @@
 	ul.colors,
 	ul.checkboxes,
 	ul.sizes {
+
 		li {
+
 			&.chosen {
+
 				&::before {
 					display: none;
 				}
 			}
 
 			&.show-count {
+
 				a {
 					display: inline-block;
 				}

--- a/assets/css/woocommerce/extensions/bookings.scss
+++ b/assets/css/woocommerce/extensions/bookings.scss
@@ -5,11 +5,11 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../../../node_modules/susy/sass/susy';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../../../node_modules/susy/sass/susy";
+@import "../../sass/vendors/modular-scale";
 
 #wc-bookings-booking-form {
 	border: 0;
@@ -21,6 +21,7 @@
 	}
 
 	.wc-bookings-date-picker-date-fields {
+
 		input {
 			margin-bottom: 0;
 		}
@@ -35,6 +36,7 @@
 	}
 
 	.wc-bookings-date-picker {
+
 		.ui-datepicker-header {
 			border: 0;
 			background-image: none;
@@ -48,6 +50,7 @@
 		}
 
 		.ui-datepicker {
+
 			table {
 				font-size: 1em;
 			}
@@ -61,19 +64,22 @@
 				border: 0;
 
 				&.bookable {
+
 					a {
 						text-shadow: none;
 					}
 				}
 
 				&.ui-datepicker-today {
+
 					a,
 					span {
-						box-shadow: inset 0 0 0 3px rgba( #000, 0.2 );
+						box-shadow: inset 0 0 0 3px rgba(#000, 0.2);
 					}
 				}
 
 				&.fully_booked {
+
 					a,
 					span {
 						text-decoration: line-through;
@@ -88,6 +94,7 @@
 		text-align: left;
 
 		li {
+
 			a {
 				border: 0 !important;
 				padding: 0.236em ms(-3);
@@ -104,6 +111,7 @@
 }
 
 .product-type-booking {
+
 	form.cart {
 		padding-left: 0;
 		padding-right: 0;
@@ -111,6 +119,7 @@
 }
 
 @include susy-media($desktop) {
+
 	table.my_account_bookings {
 		font-size: ms(-1);
 	}

--- a/assets/css/woocommerce/extensions/brands.scss
+++ b/assets/css/woocommerce/extensions/brands.scss
@@ -5,18 +5,21 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../../../node_modules/susy/sass/susy';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../../../node_modules/susy/sass/susy";
+@import "../../sass/vendors/modular-scale";
 
 /**
  * Header region
  */
 .header-widget-region {
+
 	.widget_brand_thumbnails {
+
 		ul.brand-thumbnails {
+
 			@include clearfix;
 			text-align: center;
 
@@ -40,8 +43,11 @@
  * WooCommerce Brand Layered Nav
  */
 .widget_brand_nav {
+
 	ul {
+
 		li {
+
 			.count {
 				float: right;
 			}
@@ -53,16 +59,17 @@
  * WooCommerce Brand Archive
  */
 .tax-product_brand {
+
 	.woocommerce-products-header {
 		display: flex;
 		flex-direction: column;
-		margin: 0 0 ms( 4 );
+		margin: 0 0 ms(4);
 		text-align: center;
 
 		.brand-thumbnail {
-			margin: 0 0 ms( 1 );
+			margin: 0 0 ms(1);
 			width: auto;
-			max-height: ms( 4 );
+			max-height: ms(4);
 			align-self: center;
 			order: 1;
 		}
@@ -75,6 +82,7 @@
 }
 
 div#brands_a_z {
+
 	@include clearfix;
 
 	ul.brands_index {
@@ -84,7 +92,7 @@ div#brands_a_z {
 		li {
 			float: none;
 			display: inline-block;
-			margin: 0 ms( -5 ) ms( -6 ) 0;
+			margin: 0 ms(-5) ms(-6) 0;
 			padding: 0;
 			text-transform: uppercase;
 
@@ -93,10 +101,10 @@ div#brands_a_z {
 				float: none;
 				display: block;
 				border: 0;
-				padding: ms( -4 );
-				min-width: ms( 3 );
+				padding: ms(-4);
+				min-width: ms(3);
 				text-align: center;
-				background-color: #eeeeee;
+				background-color: #eee;
 				color: $color_body;
 				line-height: 1;
 			}
@@ -112,8 +120,8 @@ div#brands_a_z {
 	}
 
 	a.top {
-		padding: ms( -2 );
-		background-color: #eeeeee;
+		padding: ms(-2);
+		background-color: #eee;
 		color: $color_body;
 		border: 0;
 		line-height: 1;
@@ -124,8 +132,8 @@ div#brands_a_z {
 		list-style-position: inside;
 
 		li {
-			margin: 0 0 ms( -4 );
-			padding: 0 0 ms( -4 );
+			margin: 0 0 ms(-4);
+			padding: 0 0 ms(-4);
 			border-bottom: 1px solid $color_border;
 		}
 	}
@@ -135,21 +143,25 @@ div#brands_a_z {
  * WooCommerce Brand single product
  */
 .storefront-wc-brands-single-product {
-	margin: 0 0 ms( -3 );
+	margin: 0 0 ms(-3);
 
 	img {
-		max-height: ms( 4 );
+		max-height: ms(4);
 	}
 }
 
 @include susy-media($desktop) {
+
 	div#brands_a_z {
+
 		ul.brands_index {
+
 			@include span(3 of 12);
 			transition: all 0.5s ease;
 		}
 
 		h3 {
+
 			@include span(last 9 of 12);
 			clear: right;
 			text-transform: uppercase;
@@ -164,6 +176,7 @@ div#brands_a_z {
 		}
 
 		ul.brands {
+
 			@include span(last 9 of 12);
 			clear: right;
 		}

--- a/assets/css/woocommerce/extensions/bundles.scss
+++ b/assets/css/woocommerce/extensions/bundles.scss
@@ -6,11 +6,11 @@
  * Imports
  */
 
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../../../node_modules/susy/sass/susy';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../../../node_modules/susy/sass/susy";
+@import "../../sass/vendors/modular-scale";
 
 /**
  * Base
@@ -41,24 +41,34 @@
 		}
 	}
 
-	div.bundled_product_summary, tr.bundled_product_summary {
+	div.bundled_product_summary,
+	tr.bundled_product_summary {
+
 		.details {
 			font-size: ms(-1);
 		}
 	}
 }
 
-.woocommerce, .woocommerce-page {
-	#content div.product, div.product {
+.woocommerce,
+.woocommerce-page {
+
+	#content div.product,
+	div.product {
+
 		.bundle_form div.bundled_product_summary .bundled_product_images {
+
 			@include span( 2 of 10 );
 		}
 	}
 }
 
 .bundle_form {
-	div.bundled_product_summary:not( .thumbnail_hidden ) {
+
+	div.bundled_product_summary:not(.thumbnail_hidden) {
+
 		.details {
+
 			@include span( last 8 of 10 );
 		}
 	}
@@ -66,7 +76,9 @@
 
 
 .bundle_form {
-	div.bundled_product_summary:not( .thumbnail_hidden ) {
+
+	div.bundled_product_summary:not(.thumbnail_hidden) {
+
 		.details {
 			padding: 0 !important;
 		}
@@ -74,6 +86,7 @@
 }
 
 .bundled_table_item {
+
 	.product-name {
 		padding-left: 4rem;
 	}
@@ -97,9 +110,14 @@ table.shop_table_responsive tr.bundled_table_item {
 		display: table-row;
 	}
 
-	.sp-product-gallery-stacked, .storefront-full-width-content, .page-template-template-fullwidth-php {
+	.sp-product-gallery-stacked,
+	.storefront-full-width-content,
+	.page-template-template-fullwidth-php {
+
 		.bundle_form {
+
 			.bundled_product_summary {
+
 				.details {
 					font-size: 1em;
 				}
@@ -107,17 +125,25 @@ table.shop_table_responsive tr.bundled_table_item {
 		}
 	}
 
-	.sp-product-gallery-stacked, .storefront-full-width-content, .page-template-template-fullwidth-php {
+	.sp-product-gallery-stacked,
+	.storefront-full-width-content,
+	.page-template-template-fullwidth-php {
 
-		#content div.product, div.product {
+		#content div.product,
+		div.product {
+
 			.bundle_form div.bundled_product_summary .bundled_product_images {
+
 				@include span( 2 of 8 );
 			}
 		}
 
 		.bundle_form {
-			div.bundled_product_summary:not( .thumbnail_hidden ) {
+
+			div.bundled_product_summary:not(.thumbnail_hidden) {
+
 				.details {
+
 					@include span( last 6 of 8 );
 				}
 			}
@@ -131,17 +157,25 @@ table.shop_table_responsive tr.bundled_table_item {
 
 @include susy-media(max-width $handheld) {
 
-	.woocommerce, .woocommerce-page {
-		#content div.product, div.product {
+	.woocommerce,
+	.woocommerce-page {
+
+		#content div.product,
+		div.product {
+
 			.bundle_form div.bundled_product_summary .bundled_product_images {
+
 				@include span( 10 of 10 );
 			}
 		}
 	}
 
 	.bundle_form {
-		div.bundled_product_summary:not( .thumbnail_hidden ) {
+
+		div.bundled_product_summary:not(.thumbnail_hidden) {
+
 			.details {
+
 				@include span( 10 of 10 );
 			}
 		}
@@ -154,6 +188,7 @@ table.shop_table_responsive tr.bundled_table_item {
 		}
 
 		div.bundled_product_summary .bundled_product_images {
+
 			img {
 				margin-bottom: 1em;
 			}
@@ -174,7 +209,8 @@ table.shop_table_responsive tr.bundled_table_item {
 
 		table.bundled_products tr {
 
-			td.bundled_item_images_col, td.bundled_item_details_col {
+			td.bundled_item_images_col,
+			td.bundled_item_details_col {
 				padding-bottom: 0;
 			}
 

--- a/assets/css/woocommerce/extensions/composite-products.scss
+++ b/assets/css/woocommerce/extensions/composite-products.scss
@@ -6,11 +6,11 @@
  * Imports
  */
 
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../../../node_modules/susy/sass/susy';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../../../node_modules/susy/sass/susy";
+@import "../../sass/vendors/modular-scale";
 
 /**
  * Base
@@ -20,26 +20,28 @@
 
 	.summary_element_wrapper {
 
-		box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0 );
+		box-shadow: 0 0 0 4px rgba(0, 0, 0, 0);
 
 		&.selected,
 		&.selected:hover {
-			box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0.06 );
+			box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.06);
 		}
 
 		&:hover {
-			box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0.03 );
+			box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.03);
 		}
 
 		&.disabled,
 		&.disabled:hover {
-			box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0 );
+			box-shadow: 0 0 0 4px rgba(0, 0, 0, 0);
 		}
 	}
 }
 
 .composite_form {
+
 	.component {
+
 		.component_summary {
 
 			.content {
@@ -67,7 +69,8 @@
 			}
 		}
 
-		&:not( .selection_thumbnail_hidden ) .component_summary {
+		&:not(.selection_thumbnail_hidden) .component_summary {
+
 			.composited_product_details_wrapper > .details {
 				padding: 0;
 			}
@@ -77,26 +80,26 @@
 
 			.component_option_thumbnail {
 
-				box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0 );
+				box-shadow: 0 0 0 4px rgba(0, 0, 0, 0);
 
 				&.selected,
 				&.selected:hover {
-					box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0.06 );
+					box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.06);
 				}
 
-				&.selected:not( .loading ) button {
+				&.selected:not(.loading) button {
 					border-radius: 50%;
 					width: 0;
 					box-sizing: content-box;
 				}
 
 				&:hover {
-					box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0.03 );
+					box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.03);
 				}
 
 				&.disabled,
 				&.disabled:hover {
-					box-shadow: 0 0 0 4px rgba( 0, 0, 0, 0 );
+					box-shadow: 0 0 0 4px rgba(0, 0, 0, 0);
 				}
 			}
 		}
@@ -108,18 +111,27 @@
 	}
 }
 
-.woocommerce, .woocommerce-page {
-	#content div.product, div.product {
+.woocommerce,
+.woocommerce-page {
+
+	#content div.product,
+	div.product {
+
 		.component .composited_product_images {
+
 			@include span( 2 of 10 );
 		}
 	}
 }
 
 .composite_form {
+
 	.component {
-		&:not( .selection_thumbnail_hidden ) .component_summary {
+
+		&:not(.selection_thumbnail_hidden) .component_summary {
+
 			.composited_product_details_wrapper > .details {
+
 				@include span( last 8 of 10 );
 			}
 		}
@@ -127,6 +139,7 @@
 }
 
 .component_table_item {
+
 	.product-name {
 		padding-left: 4rem;
 	}
@@ -150,18 +163,27 @@ table.shop_table_responsive tr.component_table_item {
 		display: table-row;
 	}
 
-	.sp-product-gallery-stacked, .storefront-full-width-content, .page-template-template-fullwidth-php {
+	.sp-product-gallery-stacked,
+	.storefront-full-width-content,
+	.page-template-template-fullwidth-php {
 
-		#content div.product, div.product {
+		#content div.product,
+		div.product {
+
 			.component .composited_product_images {
+
 				@include span( 2 of 8 );
 			}
 		}
 
 		.composite_form {
+
 			.component {
-				&:not( .selection_thumbnail_hidden ) .component_summary {
+
+				&:not(.selection_thumbnail_hidden) .component_summary {
+
 					.composited_product_details_wrapper > .details {
+
 						@include span( last 6 of 8 );
 					}
 				}
@@ -176,24 +198,33 @@ table.shop_table_responsive tr.component_table_item {
 
 @include susy-media(max-width $handheld) {
 
-	.woocommerce, .woocommerce-page {
-		#content div.product, div.product {
+	.woocommerce,
+	.woocommerce-page {
+
+		#content div.product,
+		div.product {
+
 			.component .composited_product_images {
+
 				@include span( 10 of 10 );
 			}
 		}
 	}
 
 	.composite_form {
+
 		.component {
 
-			&:not( .selection_thumbnail_hidden ) .component_summary {
+			&:not(.selection_thumbnail_hidden) .component_summary {
+
 				.composited_product_details_wrapper > .details {
+
 					@include span( 10 of 10 );
 				}
 			}
 
 			.component_summary {
+
 				.composited_product_details_wrapper {
 
 					.composited_product_images {
@@ -222,6 +253,7 @@ table.shop_table_responsive tr.component_table_item {
 }
 
 .widget.widget_composite_summary.widget_position_fixed .widget_composite_summary_content {
+
 	@include clearfix;
 	max-width: 1064px;
 	margin-left: auto;
@@ -231,6 +263,7 @@ table.shop_table_responsive tr.component_table_item {
 }
 
 @include susy-media (max-width $container-width) {
+
 	.widget.widget_composite_summary.widget_position_fixed .widget_composite_summary_content {
 		margin-left: ms(5);
 		margin-right: ms(5);
@@ -239,6 +272,7 @@ table.shop_table_responsive tr.component_table_item {
 }
 
 @include susy-media (max-width $handheld) {
+
 	.widget.widget_composite_summary.widget_position_fixed .widget_composite_summary_content {
 		margin-left: ms(2);
 		margin-right: ms(2);
@@ -251,31 +285,40 @@ table.shop_table_responsive tr.component_table_item {
 }
 
 .widget_composite_summary.widget_position_fixed .widget_composite_summary_content {
+
 	.widget_composite_summary_details_wrapper {
+
 		@include span(9 of 12);
 	}
 
 	.widget_composite_summary_ui_wrapper {
+
 		@include span(last 3 of 12);
 	}
 }
 
 .right-sidebar .widget_composite_summary.widget_position_fixed .widget_composite_summary_content {
+
 	.widget_composite_summary_details_wrapper {
+
 		@include span(9 of 12);
 	}
 
 	.widget_composite_summary_ui_wrapper {
+
 		@include span(last 3 of 12);
 	}
 }
 
 .left-sidebar .widget_composite_summary.widget_position_fixed .widget_composite_summary_content {
+
 	.widget_composite_summary_details_wrapper {
+
 		@include span(last 9 of 12);
 	}
 
 	.widget_composite_summary_ui_wrapper {
+
 		@include span(3 of 12);
 	}
 

--- a/assets/css/woocommerce/extensions/deposits.scss
+++ b/assets/css/woocommerce/extensions/deposits.scss
@@ -5,25 +5,27 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../sass/vendors/modular-scale";
 
 /**
  * Style
  */
 .wc-deposits-wrapper {
+
 	.wc-deposits-option {
+
 		li {
 			padding: ms(-2) 1em;
 			border: none;
-			background: rgba( #000, 0.0125 );
+			background: rgba(#000, 0.0125);
 			box-shadow: none;
 			border-radius: 0;
 
 			&:hover {
-				background: rgba( #000, 0.02 );
+				background: rgba(#000, 0.02);
 			}
 
 			input {
@@ -43,7 +45,7 @@
 		box-shadow: none;
 
 		li.wc-deposits-payment-plan {
-			border: 1em solid rgba( #000, 0.0125 );
+			border: 1em solid rgba(#000, 0.0125);
 			padding: ms(3);
 			margin-bottom: 1em;
 
@@ -52,11 +54,11 @@
 			}
 
 			&:hover {
-				background: rgba( #000, 0.0125 );
+				background: rgba(#000, 0.0125);
 			}
 
 			&:last-child {
-				border-bottom: 1em solid rgba( #000, 0.0125 );
+				border-bottom: 1em solid rgba(#000, 0.0125);
 			}
 
 			.wc-deposits-payment-plan-description {
@@ -73,6 +75,7 @@
 	}
 
 	&.wc-deposits-optional {
+
 		.wc-deposits-payment-plans {
 			margin-bottom: ms(3);
 
@@ -81,7 +84,7 @@
 			}
 
 			&::before {
-				border-bottom-color: rgba( #000, 0.025 );
+				border-bottom-color: rgba(#000, 0.025);
 				top: -1px;
 			}
 		}

--- a/assets/css/woocommerce/extensions/memberships.scss
+++ b/assets/css/woocommerce/extensions/memberships.scss
@@ -5,51 +5,57 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../../../node_modules/susy/sass/susy';
-@import '../../sass/vendors/modular-scale';
-@import '../../sass/vendors/font-awesome/variables';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../../../node_modules/susy/sass/susy";
+@import "../../sass/vendors/modular-scale";
+@import "../../sass/vendors/font-awesome/variables";
 
 .woocommerce,
 .woocommerce-page {
+
 	.woocommerce-MyAccount-navigation {
+
 		ul {
+
 			li.woocommerce-MyAccount-navigation-link--members-area a::before {
-				content: fa-content( $fa-var-lock );
+				content: fa-content($fa-var-lock);
 			}
 
 			li.woocommerce-MyAccount-navigation-link--back-to-memberships a::before {
-				content: fa-content( $fa-var-arrow-circle-left );
+				content: fa-content($fa-var-arrow-circle-left);
 			}
 
 			li.woocommerce-MyAccount-navigation-link--my-membership-content a::before {
-				content: fa-content( $fa-var-lock );
+				content: fa-content($fa-var-lock);
 			}
 
 			li.woocommerce-MyAccount-navigation-link--my-membership-products a::before {
-				content: fa-content( $fa-var-shopping-cart );
+				content: fa-content($fa-var-shopping-cart);
 			}
 
 			li.woocommerce-MyAccount-navigation-link--my-membership-discounts a::before {
-				content: fa-content( $fa-var-tags );
+				content: fa-content($fa-var-tags);
 			}
 
 			li.woocommerce-MyAccount-navigation-link--my-membership-notes a::before {
-				content: fa-content( $fa-var-comment );
+				content: fa-content($fa-var-comment);
 			}
 
 			li.woocommerce-MyAccount-navigation-link--my-membership-details a::before {
-				content: fa-content( $fa-var-cog );
+				content: fa-content($fa-var-cog);
 			}
 		}
 	}
 }
 
 @include susy-media (max-width $desktop) {
+
 	.woocommerce-account {
+
 		table {
+
 			&.my_account_memberships {
 				table-layout: auto;
 			}

--- a/assets/css/woocommerce/extensions/mix-and-match.scss
+++ b/assets/css/woocommerce/extensions/mix-and-match.scss
@@ -5,11 +5,12 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/vendors/modular-scale";
 
 .mnm_table {
+
 	.product-thumbnail,
 	.product-name,
 	.product-quantity,
@@ -18,6 +19,7 @@
 	}
 
 	.mnm_item {
+
 		img {
 			max-width: 100%;
 		}
@@ -30,8 +32,11 @@
 
 .cart,
 .shop_table {
+
 	.mnm_table_item {
+
 		.product-thumbnail {
+
 			img {
 				max-width: ms(5) !important;
 			}

--- a/assets/css/woocommerce/extensions/photography.scss
+++ b/assets/css/woocommerce/extensions/photography.scss
@@ -5,16 +5,19 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../../../node_modules/susy/sass/susy';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../../../node_modules/susy/sass/susy";
+@import "../../sass/vendors/modular-scale";
 
 .woocommerce,
 .woocommerce-page {
+
 	ul.products {
+
 		li.product-type-photography {
+
 			@include clearfix;
 			text-align: left;
 
@@ -25,6 +28,7 @@
 			}
 
 			.photography-image {
+
 				img {
 					width: 100%;
 				}
@@ -43,10 +47,12 @@
 
 .woocommerce,
 .woocommerce-page {
+
 	.photography-products {
+
 		.tools {
 			margin-bottom: ms(5);
-			background-color: rgba( 0, 0, 0, 0.025 );
+			background-color: rgba(0, 0, 0, 0.025);
 			padding: 1em 1em 1em ms(3);
 			border: 0;
 		}

--- a/assets/css/woocommerce/extensions/product-recommendations.scss
+++ b/assets/css/woocommerce/extensions/product-recommendations.scss
@@ -6,11 +6,11 @@
  * Imports
  */
 
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../../../node_modules/susy/sass/susy';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../../../node_modules/susy/sass/susy";
+@import "../../sass/vendors/modular-scale";
 
 /**
  * Base

--- a/assets/css/woocommerce/extensions/product-reviews-pro.scss
+++ b/assets/css/woocommerce/extensions/product-reviews-pro.scss
@@ -5,16 +5,19 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../../../node_modules/susy/sass/susy';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../../../node_modules/susy/sass/susy";
+@import "../../sass/vendors/modular-scale";
 
 .woocommerce,
 .woocommerce-page {
+
 	#reviews {
+
 		.product-rating {
+
 			.product-rating-summary,
 			.product-rating-details {
 				display: block;
@@ -26,17 +29,21 @@
 			}
 
 			.product-rating-details {
+
 				table {
+
 					td {
 						padding: 0.202em ms(-3);
 
 						&.rating-graph {
+
 							.bar {
 								background-color: $color_body;
 							}
 						}
 
 						&.rating-count {
+
 							a {
 								text-decoration: none;
 							}
@@ -51,6 +58,7 @@
 			padding: 1em;
 
 			#review_rating_field {
+
 				fieldset {
 					float: left;
 
@@ -80,7 +88,9 @@
 		}
 
 		#comments {
+
 			ol.commentlist {
+
 				li {
 					padding-top: 0;
 
@@ -121,6 +131,7 @@
 					}
 
 					ul.children {
+
 						li {
 							margin-bottom: ms(3);
 						}
@@ -129,6 +140,7 @@
 			}
 
 			.form-contribution_comment {
+
 				@include span(last 5 of 6);
 				margin-bottom: ms(6);
 				padding-top: ms(3);
@@ -141,13 +153,14 @@
 		}
 
 		.contribution-flag-form {
-			background-color: rgba( 0, 0, 0, 0.1 );
+			background-color: rgba(0, 0, 0, 0.1);
 			padding: ms(3);
 			margin-bottom: ms(3);
 		}
 	}
 
 	.form-photo {
+
 		#photo_attachment_file {
 			color: inherit;
 			margin: 1em 0;
@@ -161,7 +174,7 @@
 			display: inline-block;
 			margin-right: 1em;
 			padding: ms(-3) 0;
-			border-bottom: 0.202em solid rgba( 0, 0, 0, 0.05 );
+			border-bottom: 0.202em solid rgba(0, 0, 0, 0.05);
 
 			&.active {
 				border-bottom-color: $color_border;
@@ -170,6 +183,7 @@
 	}
 
 	.star-rating-selector {
+
 		fieldset {
 			float: none;
 			clear: both;
@@ -180,14 +194,17 @@
 		}
 	}
 
-	.star-rating-selector:not( :checked ) {
+	.star-rating-selector:not(:checked) {
+
 		label.checkbox {
 			float: none;
 		}
 	}
 
 	#wc-product-reviews-pro-modal {
+
 		#customer_login {
+
 			.col-1,
 			.col-2 {
 				width: 100%;
@@ -200,10 +217,10 @@
 .chart-tooltip {
 	font-size: ms(-1);
 	padding: ms(-2) 1em;
-	background-color: rgba( 0, 0, 0, 0.8 );
+	background-color: rgba(0, 0, 0, 0.8);
 }
 
 #tiptip_holder.tip_bottom #tiptip_arrow_inner {
-	border-bottom-color: rgba( 0, 0, 0, 0.8 );
+	border-bottom-color: rgba(0, 0, 0, 0.8);
 	margin-top: -6px;
 }

--- a/assets/css/woocommerce/extensions/quick-view.scss
+++ b/assets/css/woocommerce/extensions/quick-view.scss
@@ -5,18 +5,20 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../sass/vendors/modular-scale";
 
 .quick-view-button {
+
 	span {
 		display: none;
 	}
 }
 
 div.quick-view div.quick-view-image a.button {
+
 	@include button();
 	line-height: inherit;
 	display: block;

--- a/assets/css/woocommerce/extensions/ship-multiple-addresses.scss
+++ b/assets/css/woocommerce/extensions/ship-multiple-addresses.scss
@@ -5,14 +5,16 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../../../node_modules/susy/sass/susy';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../../../node_modules/susy/sass/susy";
+@import "../../sass/vendors/modular-scale";
 
 .woocommerce-page {
+
 	.woocommerce-checkout-review-order-table {
+
 		th.product-name {
 			width: 70%;
 		}
@@ -27,7 +29,7 @@
 		float: none;
 		width: auto;
 		margin: 0 0 ms(3);
-		background-color: rgba( #000, 0.025 );
+		background-color: rgba(#000, 0.025);
 		border: 0;
 		padding: 1em;
 		line-height: inherit;
@@ -59,15 +61,17 @@
 
 	.addresses {
 		clear: both;
+
 		@include clearfix;
 
 		.address-block {
 			margin: 0 0 ms(3);
+
 			@include span(4.5 of 9);
 
-			&:nth-child( 3 ),
-			&:nth-child( 5 ),
-			&:nth-child( 7 ) {
+			&:nth-child(3),
+			&:nth-child(5),
+			&:nth-child(7) {
 				margin-right: 0 !important;
 			}
 
@@ -83,12 +87,14 @@
 	}
 
 	&.page-template-template-fullwidth-php {
+
 		.ship_address,
 		.no_shipping_address {
 			font-size: 1em;
 		}
 
 		.address-block {
+
 			@include span(6 of 12);
 		}
 	}

--- a/assets/css/woocommerce/extensions/smart-coupons.scss
+++ b/assets/css/woocommerce/extensions/smart-coupons.scss
@@ -5,12 +5,13 @@
 /**
  * Imports
  */
-@import '../../sass/utils/variables';
-@import '../../../../node_modules/susy/sass/susy';
-@import '../../sass/vendors/modular-scale';
+@import "../../sass/utils/variables";
+@import "../../../../node_modules/susy/sass/susy";
+@import "../../sass/vendors/modular-scale";
 
 .woocommerce,
 .woocommerce-page {
+
 	.coupon-container {
 		margin: 0;
 		box-shadow: none;
@@ -26,6 +27,7 @@
 	}
 
 	.coupon-content {
+
 		&.small {
 			padding: ms(-2) ms(2);
 		}
@@ -42,8 +44,10 @@
 }
 
 .sd-buttons-transparent {
+
 	&.woocommerce,
 	&.woocommerce-page {
+
 		.coupon-container {
 			background: transparent !important;
 			padding: 0;
@@ -52,13 +56,17 @@
 }
 
 @include susy-media($desktop) {
+
 	.sc_info_box {
+
 		@include span(last 4 of 9);
 		@include gutters(inside);
 	}
 
 	.page-template-template-fullwidth-php {
+
 		.sc_info_box {
+
 			@include span(last 5 of 12);
 			margin-left: 0;
 		}

--- a/assets/css/woocommerce/extensions/variation-swatches.scss
+++ b/assets/css/woocommerce/extensions/variation-swatches.scss
@@ -5,10 +5,10 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../sass/vendors/modular-scale";
 
 .variations-table {
 	margin: 0;
@@ -27,7 +27,7 @@
 	.swatch-wrapper {
 		padding: ms(-2);
 		background-color: transparent;
-		border: 1px solid rgba( #000, 0.1 );
+		border: 1px solid rgba(#000, 0.1);
 		float: left;
 		display: inline-block;
 		margin: 0 0.327em 1em 0;
@@ -37,6 +37,7 @@
 		}
 
 		.swatch-anchor {
+
 			&:focus {
 				outline: none;
 			}
@@ -54,7 +55,7 @@
 
 		&.selected {
 			border-width: 1px;
-			border-color: rgba( #000, 0.1 );
+			border-color: rgba(#000, 0.1);
 		}
 	}
 }

--- a/assets/css/woocommerce/extensions/wishlists.scss
+++ b/assets/css/woocommerce/extensions/wishlists.scss
@@ -5,11 +5,11 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../../sass/utils/variables';
-@import '../../sass/utils/mixins';
-@import '../../../../node_modules/susy/sass/susy';
-@import '../../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../../sass/utils/variables";
+@import "../../sass/utils/mixins";
+@import "../../../../node_modules/susy/sass/susy";
+@import "../../sass/vendors/modular-scale";
 
 #wl-wrapper.wl-button-wrap {
 	padding: ms(3) 0 0 0;
@@ -21,6 +21,7 @@
 }
 
 #wl-wrapper {
+
 	.wl-tabs {
 		border-bottom: 0 !important;
 
@@ -31,19 +32,22 @@
 				padding: 1em ms(2);
 				border: 0 !important;
 				margin: 0 !important;
+
 				@include border-top-radius(0);
 				background-color: transparent !important;
 			}
 
 			&.active {
+
 				a {
-					box-shadow: inset 0 -3px 0 rgba( 0, 0, 0, 0.1 );
+					box-shadow: inset 0 -3px 0 rgba(0, 0, 0, 0.1);
 				}
 			}
 		}
 	}
 
 	.wl-table {
+
 		td {
 			padding: ms(-1) ms(2) !important;
 
@@ -53,6 +57,7 @@
 		}
 
 		&.manage {
+
 			td {
 				padding: ms(-3) !important;
 			}
@@ -66,6 +71,7 @@
 }
 
 .wl-tab-wrap {
+
 	ul.tabs,
 	.panel {
 		width: 100%;
@@ -73,7 +79,9 @@
 	}
 
 	ul.tabs {
+
 		li {
+
 			&::after {
 				display: none !important;
 			}
@@ -82,14 +90,19 @@
 }
 
 @include susy-media($desktop) {
+
 	#wl-wrapper {
+
 		.wl-tabs {
+
 			> li {
+
 				a {
 					padding-left: 0;
 				}
 
 				&.active {
+
 					a {
 						box-shadow: none;
 					}

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -5,20 +5,21 @@
 /**
  * Imports
  */
-@import 'bourbon';
-@import '../sass/utils/variables';
-@import '../sass/utils/mixins';
-@import '../../../node_modules/susy/sass/susy';
-@import '../sass/vendors/modular-scale';
+@import "bourbon";
+@import "../sass/utils/variables";
+@import "../sass/utils/mixins";
+@import "../../../node_modules/susy/sass/susy";
+@import "../sass/vendors/modular-scale";
 
 // Star font, FontAwesome doesn't work :(
 @font-face {
-	font-family: 'star';
-	src: url('../../../../../plugins/woocommerce/assets/fonts/star.eot');
-	src: url('../../../../../plugins/woocommerce/assets/fonts/star.eot?#iefix') format('embedded-opentype'),
-		url('../../../../../plugins/woocommerce/assets/fonts/star.woff') format('woff'),
-		url('../../../../../plugins/woocommerce/assets/fonts/star.ttf') format('truetype'),
-		url('../../../../../plugins/woocommerce/assets/fonts/star.svg#star') format('svg');
+	font-family: "star";
+	src: url("../../../../../plugins/woocommerce/assets/fonts/star.eot");
+	src:
+		url("../../../../../plugins/woocommerce/assets/fonts/star.eot?#iefix") format("embedded-opentype"),
+		url("../../../../../plugins/woocommerce/assets/fonts/star.woff") format("woff"),
+		url("../../../../../plugins/woocommerce/assets/fonts/star.ttf") format("truetype"),
+		url("../../../../../plugins/woocommerce/assets/fonts/star.svg#star") format("svg");
 	font-weight: normal;
 	font-style: normal;
 }
@@ -37,28 +38,31 @@
 
 // Animations
 @keyframes slideInDown {
+
 	from {
-		transform: translate3d( 0, -100%, 0 );
+		transform: translate3d(0, -100%, 0);
 		visibility: visible;
 	}
 
 	to {
-		transform: translate3d( 0, 0, 0 );
+		transform: translate3d(0, 0, 0);
 	}
 }
 
 @keyframes slideOutUp {
+
 	from {
-		transform: translate3d( 0, 0, 0 );
+		transform: translate3d(0, 0, 0);
 	}
 
 	to {
 		visibility: hidden;
-		transform: translate3d( 0, -100%, 0 );
+		transform: translate3d(0, -100%, 0);
 	}
 }
 
 .price {
+
 	ins {
 		font-weight: 400;
 	}
@@ -68,6 +72,7 @@
  * Header Elements
  */
 .woocommerce-active {
+
 	.site-branding {
 		float: left;
 	}
@@ -89,7 +94,9 @@
 		.woocommerce-mini-cart__empty-message {
 			margin: ms(2);
 		}
+
 		.product_list_widget {
+
 			img {
 				margin-left: 1em;
 			}
@@ -103,6 +110,7 @@
 	display: none;
 
 	.widget_product_search {
+
 		input[type=text],
 		input[type=search] {
 			padding: ms(1) ms(2);
@@ -110,6 +118,7 @@
 		}
 
 		form {
+
 			&::before {
 				top: 1.15em;
 				left: 1.15em;
@@ -117,6 +126,7 @@
 		}
 
 		#searchsubmit {
+
 			@include screen-reader-text();
 		}
 	}
@@ -126,13 +136,14 @@
  * Handheld footer bar
  */
 .storefront-handheld-footer-bar {
+
 	@include clearfix;
 	position: fixed;
 	bottom: 0;
 	left: 0;
 	right: 0;
-	border-top: 1px solid rgba( #fff, 0.2 );
-	box-shadow: 0 0 6px rgba( #000, 0.7 );
+	border-top: 1px solid rgba(#fff, 0.2);
+	box-shadow: 0 0 6px rgba(#000, 0.7);
 	z-index: 9999;
 
 	ul {
@@ -144,6 +155,7 @@
 			text-align: center;
 
 			&:last-child {
+
 				> a {
 					border-right: 0;
 				}
@@ -155,7 +167,7 @@
 				position: relative;
 				text-indent: -9999px;
 				z-index: 999;
-				border-right: 1px solid rgba( #fff, 0.2 );
+				border-right: 1px solid rgba(#fff, 0.2);
 				overflow: hidden;
 
 				// Raise it so focus outline is shown.
@@ -165,6 +177,7 @@
 			}
 
 			&.search {
+
 				.site-search {
 					position: absolute;
 					bottom: -2em;
@@ -177,6 +190,7 @@
 				}
 
 				&.active {
+
 					.site-search {
 						bottom: 100%;
 					}
@@ -190,6 +204,7 @@
 			}
 
 			&.cart {
+
 				.count {
 					text-indent: 0;
 					display: block;
@@ -208,6 +223,7 @@
 		}
 
 		&.columns-1 {
+
 			li {
 				width: 100%;
 				display: block;
@@ -216,24 +232,28 @@
 		}
 
 		&.columns-2 {
+
 			li {
 				width: 50%;
 			}
 		}
 
 		&.columns-3 {
+
 			li {
 				width: 33.33333%;
 			}
 		}
 
 		&.columns-4 {
+
 			li {
 				width: 25%;
 			}
 		}
 
 		&.columns-5 {
+
 			li {
 				width: 20%;
 			}
@@ -242,6 +262,7 @@
 }
 
 .sf-input-focused {
+
 	.storefront-handheld-footer-bar {
 		display: none;
 	}
@@ -251,17 +272,20 @@
  * Shop tables
  */
 table.shop_table_responsive {
+
 	thead {
 		display: none;
 	}
 
 	tbody {
+
 		th {
 			display: none;
 		}
 	}
 
 	tr {
+
 		td {
 
 			@include clearfix;
@@ -271,14 +295,16 @@ table.shop_table_responsive {
 			clear: both;
 
 			&[data-title] {
+
 				&::before {
-					content: attr(data-title) ': ';
+					content: attr(data-title) ": ";
 					font-weight: 600;
 					float: left;
 				}
 			}
 
 			&.product-remove {
+
 				a {
 					text-align: left;
 				}
@@ -286,12 +312,14 @@ table.shop_table_responsive {
 
 			&.actions,
 			&.download-actions {
+
 				&::before {
 					display: none;
 				}
 			}
 
 			&.download-actions {
+
 				.button {
 					display: block;
 					text-align: center;
@@ -301,6 +329,7 @@ table.shop_table_responsive {
 	}
 
 	&.my_account_orders {
+
 		.order-actions {
 			text-align: right;
 
@@ -315,6 +344,7 @@ table.shop_table_responsive {
  * Products
  */
 ul.products {
+
 	@include clearfix;
 }
 
@@ -377,6 +407,7 @@ ul.products,
 		}
 
 		&.product-category {
+
 			img {
 				margin-bottom: ms(3);
 			}
@@ -389,8 +420,10 @@ ul.products,
 }
 
 .hentry .entry-content {
+
 	.wc-block-grid__products .wc-block-grid__product,
 	ul.products li.product {
+
 		> a {
 			text-decoration: none;
 		}
@@ -398,6 +431,7 @@ ul.products,
 }
 
 .price {
+
 	del {
 		opacity: 0.5;
 		font-weight: 400;
@@ -412,11 +446,13 @@ ul.products,
  * Single Product
  */
 .single-product {
+
 	.pswp__button {
 		background-color: transparent;
 	}
 
 	div.product {
+
 		@include clearfix;
 		position: relative;
 		overflow: hidden;
@@ -456,6 +492,7 @@ ul.products,
 			}
 
 			.flex-control-thumbs {
+
 				@include clearfix;
 				margin: 0;
 				padding: 0;
@@ -475,6 +512,7 @@ ul.products,
 					}
 
 					&:hover {
+
 						img {
 							opacity: 1;
 						}
@@ -483,15 +521,18 @@ ul.products,
 			}
 
 			&.woocommerce-product-gallery--columns-2 {
+
 				.flex-control-thumbs {
+
 					li {
+
 						@include span( 2 of 4 );
 
-						&:nth-child( 2n ) {
+						&:nth-child(2n) {
 							margin-right: 0;
 						}
 
-						&:nth-child( 2n+1 ) {
+						&:nth-child(2n+1) {
 							clear: both;
 						}
 					}
@@ -499,15 +540,18 @@ ul.products,
 			}
 
 			&.woocommerce-product-gallery--columns-3 {
+
 				.flex-control-thumbs {
+
 					li {
+
 						@include span( 1.333333333 of 4 );
 
-						&:nth-child( 3n ) {
+						&:nth-child(3n) {
 							margin-right: 0;
 						}
 
-						&:nth-child( 3n+1 ) {
+						&:nth-child(3n+1) {
 							clear: both;
 						}
 					}
@@ -515,15 +559,18 @@ ul.products,
 			}
 
 			&.woocommerce-product-gallery--columns-4 {
+
 				.flex-control-thumbs {
+
 					li {
+
 						@include span( 1 of 4 );
 
-						&:nth-child( 4n ) {
+						&:nth-child(4n) {
 							margin-right: 0;
 						}
 
-						&:nth-child( 4n+1 ) {
+						&:nth-child(4n+1) {
 							clear: both;
 						}
 					}
@@ -531,15 +578,18 @@ ul.products,
 			}
 
 			&.woocommerce-product-gallery--columns-5 {
+
 				.flex-control-thumbs {
+
 					li {
+
 						@include span( 0.8 of 4 );
 
-						&:nth-child( 5n ) {
+						&:nth-child(5n) {
 							margin-right: 0;
 						}
 
-						&:nth-child( 5n+1 ) {
+						&:nth-child(5n+1) {
 							clear: both;
 						}
 					}
@@ -548,12 +598,14 @@ ul.products,
 		}
 
 		.images {
+
 			.woocommerce-main-image {
 				margin-bottom: ms(3);
 				display: block;
 			}
 
 			.thumbnails {
+
 				a.zoom {
 					display: block;
 					width: 22.05%;
@@ -573,6 +625,7 @@ ul.products,
 		}
 
 		form.cart {
+
 			@include clearfix;
 			margin-bottom: ms(3);
 			padding: 1em 0;
@@ -583,7 +636,9 @@ ul.products,
 			}
 
 			table.woocommerce-grouped-product-list {
+
 				.woocommerce-grouped-product-list-item__label {
+
 					@include wrap-break-word();
 				}
 
@@ -626,6 +681,7 @@ ul.products,
 		}
 
 		.single_variation {
+
 			.price {
 				margin-bottom: 1em;
 				display: block;
@@ -633,16 +689,19 @@ ul.products,
 		}
 
 		.variations_button {
+
 			@include clearfix;
 			padding-top: 1em;
 		}
 
 		.woocommerce-product-rating {
 			margin-bottom: ms(3);
+
 			@include clearfix;
 			margin-top: - ms(-1);
 
 			a {
+
 				@include underlined-link();
 			}
 
@@ -668,6 +727,7 @@ ul.products,
 			}
 
 			a {
+
 				@include underlined-link();
 			}
 		}
@@ -680,6 +740,7 @@ ul.products,
 }
 
 .stock {
+
 	&:empty::before {
 		display: none;
 	}
@@ -720,13 +781,16 @@ a.reset_variations {
 			margin-bottom: ms(5);
 			list-style: none;
 			clear: both;
+
 			@include clearfix;
 
 			.comment_container {
 				border-radius: 3px;
+
 				@include clearfix;
 
 				.comment-text {
+
 					@include span(last 5 of 6);
 
 					.star-rating {
@@ -749,6 +813,7 @@ a.reset_variations {
 			}
 
 			.avatar {
+
 				@include span(1 of 6);
 				height: auto;
 			}
@@ -776,14 +841,17 @@ a.reset_variations {
 
 			ul.children {
 				margin: 0;
+
 				@include span(last 5 of 6);
 				padding-top: ms(3);
 
 				.avatar {
+
 					@include span(1 of 5);
 				}
 
 				.comment-text {
+
 					@include span(last 4 of 5);
 				}
 
@@ -842,6 +910,7 @@ a.reset_variations {
 	li {
 		padding: 1em 0;
 		border-bottom: 1px solid $color_border;
+
 		@include clearfix;
 
 		img {
@@ -855,6 +924,7 @@ a.reset_variations {
 	}
 
 	a {
+
 		&:hover {
 			color: $color_links;
 		}
@@ -862,8 +932,11 @@ a.reset_variations {
 }
 
 .widget {
+
 	ul.products {
+
 		li.product {
+
 			a {
 				text-decoration: none;
 			}
@@ -872,12 +945,14 @@ a.reset_variations {
 }
 
 .widget_products {
+
 	a {
 		display: block;
 	}
 }
 
 .widget_shopping_cart {
+
 	.product_list_widget {
 		margin-bottom: 0;
 
@@ -906,9 +981,10 @@ a.reset_variations {
 	}
 
 	.buttons {
+
 		a {
 			display: block;
-			margin-bottom: ms( -2 );
+			margin-bottom: ms(-2);
 
 			&:last-child {
 				margin-bottom: 0;
@@ -923,7 +999,9 @@ a.reset_variations {
 }
 
 .site-header {
+
 	.widget_shopping_cart {
+
 		p.total,
 		p.buttons,
 		li {
@@ -934,13 +1012,16 @@ a.reset_variations {
 }
 
 .widget_layered_nav {
+
 	li {
 		margin-bottom: ms(-2);
 	}
 }
 
 .widget.woocommerce {
+
 	li {
+
 		.count {
 			font-size: 1em;
 			float: right;
@@ -949,6 +1030,7 @@ a.reset_variations {
 }
 
 .widget_price_filter {
+
 	.price_slider {
 		margin-bottom: 1em;
 	}
@@ -963,6 +1045,7 @@ a.reset_variations {
 	}
 
 	@media (min-width: $desktop) and (max-width: 1024px) {
+
 		.price_slider_amount {
 			text-align: left;
 
@@ -985,6 +1068,7 @@ a.reset_variations {
 		z-index: 2;
 		width: 1em;
 		height: 1em;
+
 		@include border-top-radius(1em);
 		@include border-bottom-radius(1em);
 		cursor: ew-resize;
@@ -1012,14 +1096,16 @@ a.reset_variations {
 		display: block;
 		border: 0;
 		background: $color_links;
+
 		@include border-top-radius(1em);
 		@include border-bottom-radius(1em);
 	}
 
 	.price_slider_wrapper .ui-widget-content {
+
 		@include border-top-radius(1em);
 		@include border-bottom-radius(1em);
-		background: rgba( 0, 0, 0, 0.1 );
+		background: rgba(0, 0, 0, 0.1);
 		border: 0;
 	}
 
@@ -1047,7 +1133,9 @@ a.reset_variations {
 
 /*!rtl:begin:ignore*/
 .rtl {
+
 	.widget_price_filter {
+
 		.price_label,
 		.price_label span {
 			direction: ltr;
@@ -1055,6 +1143,7 @@ a.reset_variations {
 		}
 	}
 }
+
 /*!rtl:end:ignore*/
 
 /**
@@ -1069,6 +1158,7 @@ table.cart {
 	}
 
 	.product-thumbnail {
+
 		img {
 			margin: 0 auto;
 			max-width: ms(6);
@@ -1081,6 +1171,7 @@ table.cart {
 	}
 
 	tr:first-child {
+
 		td.product-remove {
 			border-top-width: 0;
 		}
@@ -1100,6 +1191,7 @@ table.cart {
 	}
 
 	td.product-quantity {
+
 		.qty {
 			padding: 0.326em;
 			width: ms(6);
@@ -1107,6 +1199,7 @@ table.cart {
 	}
 
 	td.product-name {
+
 		@include wrap-break-word();
 	}
 
@@ -1143,6 +1236,7 @@ table.cart {
 }
 
 .wc-proceed-to-checkout {
+
 	@include clearfix;
 	margin-bottom: ms(3);
 
@@ -1187,6 +1281,7 @@ ul#shipping_method {
 }
 
 .woocommerce-checkout {
+
 	ul#shipping_method {
 		margin-bottom: 0;
 	}
@@ -1203,6 +1298,7 @@ ul#shipping_method {
 }
 
 form.checkout {
+
 	@include clearfix;
 	position: static !important; /* 1 */
 
@@ -1212,6 +1308,7 @@ form.checkout {
 }
 
 #payment {
+
 	@include clearfix;
 
 	.create-account {
@@ -1224,6 +1321,7 @@ form.checkout {
 
 		> .woocommerce-PaymentMethod,
 		> .wc_payment_method {
+
 			> label {
 				display: block;
 				padding: ms(2);
@@ -1243,7 +1341,7 @@ form.checkout {
 				max-height: ms(3);
 			}
 
-			&:last-child:not( .woocommerce-notice ) {
+			&:last-child:not(.woocommerce-notice) {
 				padding-bottom: 0;
 				border-bottom: 0;
 			}
@@ -1269,7 +1367,7 @@ form.checkout {
 					.form-row {
 						margin-bottom: 1em;
 
-						input[type='checkbox'] {
+						input[type="checkbox"] {
 							margin-right: 5px;
 						}
 					}
@@ -1311,38 +1409,38 @@ form.checkout {
 					background-repeat: no-repeat;
 					background-position: right ms(-2) center;
 					background-size: 31px 20px;
-					background-image: url('../../../assets/images/credit-cards/unknown.svg');
+					background-image: url("../../../assets/images/credit-cards/unknown.svg");
 
 					&.visa {
-						background-image: url('../../../assets/images/credit-cards/visa.svg');
+						background-image: url("../../../assets/images/credit-cards/visa.svg");
 					}
 
 					&.mastercard {
-						background-image: url('../../../assets/images/credit-cards/mastercard.svg');
+						background-image: url("../../../assets/images/credit-cards/mastercard.svg");
 					}
 
 					&.laser {
-						background-image: url('../../../assets/images/credit-cards/laser.svg');
+						background-image: url("../../../assets/images/credit-cards/laser.svg");
 					}
 
 					&.dinersclub {
-						background-image: url('../../../assets/images/credit-cards/diners.svg');
+						background-image: url("../../../assets/images/credit-cards/diners.svg");
 					}
 
 					&.maestro {
-						background-image: url('../../../assets/images/credit-cards/maestro.svg');
+						background-image: url("../../../assets/images/credit-cards/maestro.svg");
 					}
 
 					&.jcb {
-						background-image: url('../../../assets/images/credit-cards/jcb.svg');
+						background-image: url("../../../assets/images/credit-cards/jcb.svg");
 					}
 
 					&.amex {
-						background-image: url('../../../assets/images/credit-cards/amex.svg');
+						background-image: url("../../../assets/images/credit-cards/amex.svg");
 					}
 
 					&.discover {
-						background-image: url('../../../assets/images/credit-cards/discover.svg');
+						background-image: url("../../../assets/images/credit-cards/discover.svg");
 					}
 				}
 			}
@@ -1363,9 +1461,9 @@ form.checkout {
 
 	.woocommerce-terms-and-conditions {
 		padding: ms(1);
-		box-shadow: inset 0 1px 3px rgba( #000, 0.2 );
+		box-shadow: inset 0 1px 3px rgba(#000, 0.2);
 		margin-bottom: 16px;
-		background-color: rgba( #000, 0.05 );
+		background-color: rgba(#000, 0.05);
 	}
 
 	.place-order {
@@ -1384,14 +1482,18 @@ form.checkout {
 }
 
 table.woocommerce-checkout-review-order-table {
+
 	.product-name {
 		width: 45%;
+
 		@include wrap-break-word();
 	}
 }
 
 .admin-bar {
+
 	.woocommerce-checkout {
+
 		#wc_checkout_add_ons label + br {
 			display: none;
 		}
@@ -1433,7 +1535,9 @@ label.inline {
 }
 
 .hentry .entry-content {
+
 	.woocommerce-MyAccount-navigation {
+
 		ul {
 			margin-left: 0;
 			border-top: 1px solid $color_border;
@@ -1444,6 +1548,7 @@ label.inline {
 				position: relative;
 
 				&.woocommerce-MyAccount-navigation-link {
+
 					a {
 						text-decoration: none;
 						padding: ms(-1) 0;
@@ -1456,6 +1561,7 @@ label.inline {
 }
 
 ul.order_details {
+
 	@include clearfix;
 	list-style: none;
 	position: relative;
@@ -1463,7 +1569,7 @@ ul.order_details {
 
 	&::before,
 	&::after {
-		content: '';
+		content: "";
 		display: block;
 		position: absolute;
 		top: -16px;
@@ -1504,6 +1610,7 @@ ul.order_details {
 
 .my_account_orders,
 .woocommerce-MyAccount-downloads {
+
 	.button {
 		padding: ms(-2) ms(-1);
 		font-size: ms(-1);
@@ -1512,12 +1619,14 @@ ul.order_details {
 }
 
 .woocommerce-MyAccount-content {
+
 	h2 {
 		font-size: 2em;
 		font-weight: 600;
 	}
 
 	#payment {
+
 		.payment_methods {
 			margin-bottom: ms(3) !important;
 		}
@@ -1538,6 +1647,7 @@ ul.order_details {
 }
 
 .form-row {
+
 	label {
 		display: block;
 	}
@@ -1558,18 +1668,21 @@ ul.order_details {
 	}
 
 	&.create-account {
+
 		label {
 			display: inline-block;
 		}
 	}
 
 	&.woocommerce-validated {
+
 		input.input-text {
 			box-shadow: inset 2px 0 0 $success;
 		}
 	}
 
 	&.woocommerce-invalid {
+
 		input.input-text {
 			box-shadow: inset 2px 0 0 $error;
 		}
@@ -1615,7 +1728,7 @@ ul.order_details {
 }
 
 .show-password-input::after {
-	font-family: 'Font Awesome 5 Free';
+	font-family: "Font Awesome 5 Free";
 	font-weight: 900;
 	vertical-align: baseline;
 	-webkit-font-smoothing: antialiased;
@@ -1624,7 +1737,7 @@ ul.order_details {
 	font-style: normal;
 	font-variant: normal;
 	line-height: 1;
-	content: '\f06e';
+	content: "\f06e";
 }
 
 .show-password-input.display-password::after {
@@ -1664,11 +1777,11 @@ ul.order_details {
 	line-height: 1.618;
 	font-size: 1em;
 	width: 5.3em;
-	font-family: 'star';
+	font-family: "star";
 	font-weight: 400;
 
 	&::before {
-		content: '\53\53\53\53\53';
+		content: "\53\53\53\53\53";
 		opacity: 0.25;
 		float: left;
 		top: 0;
@@ -1686,7 +1799,7 @@ ul.order_details {
 	}
 
 	span::before {
-		content: '\53\53\53\53\53';
+		content: "\53\53\53\53\53";
 		top: 0;
 		position: absolute;
 		left: 0;
@@ -1717,16 +1830,17 @@ p.stars {
 			width: 1em;
 			height: 1em;
 			line-height: 1;
-			font-family: 'star';
-			content: '\53';
+			font-family: "star";
+			content: "\53";
 			color: $color_body;
 			text-indent: 0;
 			opacity: 0.25;
 		}
 
 		&:hover {
+
 			~ a::before {
-				content: '\53';
+				content: "\53";
 				color: $color_body;
 				opacity: 0.25;
 			}
@@ -1734,9 +1848,11 @@ p.stars {
 	}
 
 	&:hover {
+
 		a {
+
 			&::before {
-				content: '\53';
+				content: "\53";
 				color: $color_woocommerce;
 				opacity: 1;
 			}
@@ -1744,23 +1860,26 @@ p.stars {
 	}
 
 	&.selected {
+
 		a.active {
+
 			&::before {
-				content: '\53';
+				content: "\53";
 				color: $color_woocommerce;
 				opacity: 1;
 			}
 
 			~ a::before {
-				content: '\53';
+				content: "\53";
 				color: $color_body;
 				opacity: 0.25;
 			}
 		}
 
-		a:not( .active ) {
+		a:not(.active) {
+
 			&::before {
-				content: '\53';
+				content: "\53";
 				color: $color_woocommerce;
 				opacity: 1;
 			}
@@ -1784,6 +1903,7 @@ p.stars {
 }
 
 .quantity {
+
 	.qty {
 		width: ms(7);
 		text-align: center;
@@ -1796,6 +1916,7 @@ p.stars {
 }
 
 .woocommerce-tabs {
+
 	@include clearfix;
 	overflow: hidden;
 	padding: 1em 0;
@@ -1820,6 +1941,7 @@ p.stars {
 	}
 
 	.panel {
+
 		h2:first-of-type {
 			font-size: ms(3);
 			margin-bottom: 1em;
@@ -1829,6 +1951,7 @@ p.stars {
 
 .related,
 .upsells {
+
 	> h2:first-child {
 		font-size: ms(3);
 		margin-bottom: 1em;
@@ -1847,7 +1970,7 @@ p.no-comments {
 	border-radius: 2px;
 	color: #fff;
 	clear: both;
-	border-left: ms(-2) solid rgba( 0, 0, 0, 0.15 );
+	border-left: ms(-2) solid rgba(0, 0, 0, 0.15);
 	padding: 1em 2em 1em 3.5em;
 	position: relative;
 	list-style: none outside;
@@ -1887,7 +2010,7 @@ p.no-comments {
 		border-width: 0;
 		border-left-width: 1px;
 		border-left-style: solid;
-		border-left-color: rgba( 255, 255, 255, 0.25 ) !important;
+		border-left-color: rgba(255, 255, 255, 0.25) !important;
 		border-radius: 0;
 
 		&:hover {
@@ -1898,7 +2021,7 @@ p.no-comments {
 	}
 
 	pre {
-		background-color: rgba( 0, 0, 0, 0.1 );
+		background-color: rgba(0, 0, 0, 0.1);
 	}
 }
 
@@ -1918,11 +2041,15 @@ p.no-comments {
 }
 
 .site-content {
+
 	> .col-full {
+
 		> .woocommerce {
+
 			> .woocommerce-message,
 			> .woocommerce-info,
 			> .woocommerce-error {
+
 				&:first-child {
 					margin-top: ms(5);
 				}
@@ -1959,6 +2086,7 @@ dl.variation {
 	list-style: none;
 
 	li {
+
 		@include clearfix;
 
 		strong,
@@ -1972,6 +2100,7 @@ dl.variation {
  * My Account
  */
 .woocommerce-MyAccount-content {
+
 	.woocommerce-Pagination {
 		text-align: center;
 	}
@@ -2008,12 +2137,14 @@ dl.variation {
 }
 
 @include susy-media($desktop) {
+
 	.demo_store {
 		bottom: 0;
 
 		a {
+
 			&.woocommerce-store-notice__dismiss-link {
-				background: rgba( #000, 0.1 );
+				background: rgba(#000, 0.1);
 				float: right;
 				display: inline-block;
 				margin: -1em -1.41575em -1em 0;
@@ -2041,17 +2172,20 @@ dl.variation {
 	 * Responsive tables
 	 */
 	table.shop_table_responsive {
+
 		thead {
 			display: table-header-group;
 		}
 
 		tbody {
+
 			th {
 				display: table-cell;
 			}
 		}
 
 		tr {
+
 			td {
 				display: table-cell;
 
@@ -2114,6 +2248,7 @@ dl.variation {
 				height: 0;
 
 				li {
+
 					a.remove {
 						position: relative;
 						float: left;
@@ -2129,6 +2264,7 @@ dl.variation {
 
 		&:hover,
 		&.focus {
+
 			.widget_shopping_cart {
 				left: 0;
 				display: block;
@@ -2153,6 +2289,7 @@ dl.variation {
 	 */
 	ul.products,
 	.wc-block-grid__products {
+
 		li.product,
 		.wc-block-grid__product {
 			clear: none;
@@ -2176,10 +2313,14 @@ dl.variation {
 	.page-template-template-fullwidth-php,
 	.page-template-template-homepage-php,
 	.storefront-full-width-content {
+
 		.site-main,
 		.header-widget-region {
+
 			ul.products {
+
 				&.columns-1 {
+
 					li.product {
 						width: 100%;
 						margin-right: 0;
@@ -2188,25 +2329,32 @@ dl.variation {
 				}
 
 				&.columns-2 {
+
 					li.product {
+
 						@include span(6 of 12);
 					}
 				}
 
 				&.columns-3 {
+
 					li.product {
+
 						@include span(4 of 12);
 					}
 				}
 
 				&.columns-4 {
+
 					li.product {
+
 						@include span(3 of 12);
 					}
 				}
 
 				// The grid wont work for 5 columns :-(
 				&.columns-5 {
+
 					li.product {
 						width: 16.9%;
 						margin-right: 3.8%;
@@ -2214,7 +2362,9 @@ dl.variation {
 				}
 
 				&.columns-6 {
+
 					li.product {
+
 						@include span(2 of 12);
 					}
 				}
@@ -2226,12 +2376,16 @@ dl.variation {
 	 * Main content area (adjacent to sidebar) product layout
 	 */
 	.site-main {
+
 		ul.products {
+
 			li.product {
+
 				@include span(3 of 9);
 			}
 
 			&.columns-1 {
+
 				li.product {
 					width: 100%;
 					margin-right: 0;
@@ -2241,6 +2395,7 @@ dl.variation {
 
 			// The grid wont work for 2 columns :-(
 			&.columns-2 {
+
 				li.product {
 					width: 48%;
 					margin-right: 3.8%;
@@ -2248,13 +2403,16 @@ dl.variation {
 			}
 
 			&.columns-3 {
+
 				li.product {
+
 					@include span(3 of 9);
 				}
 			}
 
 			// The grid wont work for 4 columns :-(
 			&.columns-4 {
+
 				li.product {
 					width: 22.05%;
 					margin-right: 3.8%;
@@ -2263,6 +2421,7 @@ dl.variation {
 
 			// The grid wont work for 5 columns :-(
 			&.columns-5 {
+
 				li.product {
 					width: 16.9%;
 					margin-right: 3.8%;
@@ -2270,7 +2429,9 @@ dl.variation {
 			}
 
 			&.columns-6 {
+
 				li.product {
+
 					@include span(1.5 of 9);
 				}
 			}
@@ -2281,18 +2442,24 @@ dl.variation {
 	 * Single product page
 	 */
 	.single-product {
+
 		div.product {
+
 			.images {
+
 				@include span(4 of 9);
 				margin-bottom: ms(6);
 
 				.thumbnails {
+
 					@include clearfix;
 
 					a.zoom {
+
 						@include span(1 of 4);
 
 						&.last {
+
 							@include last;
 						}
 					}
@@ -2300,11 +2467,13 @@ dl.variation {
 			}
 
 			.woocommerce-product-gallery {
+
 				@include span(4 of 9);
 				margin-bottom: ms(6);
 			}
 
 			.summary {
+
 				@include span(last 5 of 9);
 			}
 
@@ -2315,6 +2484,7 @@ dl.variation {
 	}
 
 	#reviews {
+
 		.comment-form-author,
 		.comment-form-email {
 			width: 47%;
@@ -2327,13 +2497,18 @@ dl.variation {
 
 	// Full width single product
 	.storefront-full-width-content.single-product {
+
 		div.product {
+
 			.images {
+
 				@include span(5 of 12);
 				margin-bottom: ms(6);
 
 				.thumbnails {
+
 					a.zoom {
+
 						@include span(1 of 5);
 
 						&.last {
@@ -2344,15 +2519,19 @@ dl.variation {
 			}
 
 			.woocommerce-product-gallery {
+
 				@include span(5 of 12);
 				margin-bottom: ms(6);
 
 				&.woocommerce-product-gallery--columns-2 {
+
 					.flex-control-thumbs {
+
 						li {
+
 							@include span( 2.5 of 5 );
 
-							&:nth-child( 2n ) {
+							&:nth-child(2n) {
 								margin-right: 0;
 							}
 						}
@@ -2360,11 +2539,14 @@ dl.variation {
 				}
 
 				&.woocommerce-product-gallery--columns-3 {
+
 					.flex-control-thumbs {
+
 						li {
+
 							@include span( 1.666666667 of 5 );
 
-							&:nth-child( 3n ) {
+							&:nth-child(3n) {
 								margin-right: 0;
 							}
 						}
@@ -2372,11 +2554,14 @@ dl.variation {
 				}
 
 				&.woocommerce-product-gallery--columns-4 {
+
 					.flex-control-thumbs {
+
 						li {
+
 							@include span( 1.25 of 5 );
 
-							&:nth-child( 4n ) {
+							&:nth-child(4n) {
 								margin-right: 0;
 							}
 						}
@@ -2384,11 +2569,14 @@ dl.variation {
 				}
 
 				&.woocommerce-product-gallery--columns-5 {
+
 					.flex-control-thumbs {
+
 						li {
+
 							@include span( 1 of 5 );
 
-							&:nth-child( 5n ) {
+							&:nth-child(5n) {
 								margin-right: 0;
 							}
 						}
@@ -2397,6 +2585,7 @@ dl.variation {
 			}
 
 			.summary {
+
 				@include span(last 7 of 12);
 				margin-bottom: ms(6);
 			}
@@ -2407,27 +2596,36 @@ dl.variation {
 		}
 
 		#reviews {
+
 			.commentlist {
+
 				li {
+
 					.avatar {
+
 						@include span(1 of 8);
 					}
 
 					.comment_container {
+
 						.comment-text {
+
 							@include span(last 7 of 8);
 						}
 					}
 				}
 
 				ul.children {
+
 					@include span(last 7 of 8);
 
 					.avatar {
+
 						@include span(1 of 7);
 					}
 
 					.comment-text {
+
 						@include span(last 6 of 7);
 					}
 				}
@@ -2439,6 +2637,7 @@ dl.variation {
 	 * General full-width styles
 	 */
 	.storefront-full-width-content {
+
 		&.woocommerce-cart .entry-header,
 		&.woocommerce-checkout .entry-header,
 		&.woocommerce-account .entry-header,
@@ -2453,6 +2652,7 @@ dl.variation {
 
 		.up-sells,
 		.related.products {
+
 			> h2:first-child {
 				text-align: center;
 			}
@@ -2464,6 +2664,7 @@ dl.variation {
 	}
 
 	.storefront-sorting {
+
 		@include clearfix;
 		margin-bottom: ms(5);
 
@@ -2499,6 +2700,7 @@ dl.variation {
 	 */
 	.woocommerce-cart,
 	.woocommerce-checkout {
+
 		.hentry {
 			border-bottom: 0;
 			padding-bottom: 0;
@@ -2506,7 +2708,9 @@ dl.variation {
 	}
 
 	.page-template-template-fullwidth-php {
+
 		table.cart {
+
 			.product-thumbnail {
 				display: table-cell;
 			}
@@ -2519,6 +2723,7 @@ dl.variation {
 	}
 
 	table.cart {
+
 		th,
 		td {
 			padding: ms(3);
@@ -2549,6 +2754,7 @@ dl.variation {
 		}
 
 		.quantity {
+
 			.qty {
 				padding: ms(-2);
 			}
@@ -2578,6 +2784,7 @@ dl.variation {
 	}
 
 	.cart-collaterals {
+
 		@include clearfix;
 
 		h2 {
@@ -2585,17 +2792,20 @@ dl.variation {
 		}
 
 		.cross-sells {
+
 			@include span(4 of 9);
 		}
 
 		.cart_totals,
 		.shipping_calculator {
+
 			@include span(last 5 of 9);
 			margin: 0;
 			clear: right;
 		}
 
 		.cart_totals {
+
 			small.includes_tax {
 				display: block;
 			}
@@ -2607,13 +2817,17 @@ dl.variation {
 	}
 
 	.page-template-template-fullwidth-php {
+
 		.cart-collaterals {
+
 			.cross-sells {
+
 				@include span(6 of 12);
 			}
 
 			.cart_totals,
 			.shipping_calculator {
+
 				@include span(last 6 of 12);
 			}
 		}
@@ -2639,13 +2853,16 @@ dl.variation {
 	}
 
 	.col2-set {
+
 		@include span(5 of 9);
 
 		.form-row-first {
+
 			@include span(2.5 of 5);
 		}
 
 		.form-row-last {
+
 			@include span(last 2.5 of 5);
 		}
 
@@ -2659,27 +2876,33 @@ dl.variation {
 		}
 
 		.woocommerce-billing-fields {
+
 			@include clearfix;
 		}
 
 		&.addresses {
+
 			@include span(full);
 
 			.col-1 {
+
 				@include span(4.5 of 9);
 			}
 
 			.col-2 {
+
 				@include span(last 4.5 of 9);
 			}
 		}
 	}
 
 	#customer_details + #wc_checkout_add_ons {
+
 		@include span( last 4 of 9 );
 	}
 
 	#wc_checkout_add_ons {
+
 		input[type=radio] {
 			float: left;
 			margin-right: ms(-3);
@@ -2690,6 +2913,7 @@ dl.variation {
 
 	#order_review_heading,
 	#order_review {
+
 		@include span(last 4 of 9);
 		clear: right;
 	}
@@ -2706,11 +2930,13 @@ dl.variation {
 	// Payment forms in account
 	.woocommerce-order-pay,
 	.page-template-template-fullwidth-php.woocommerce-order-pay {
+
 		#order_review {
 			width: 100%;
 			float: none;
 
 			#payment {
+
 				h3 {
 					padding-left: 1em;
 					padding-top: 1em;
@@ -2734,23 +2960,30 @@ dl.variation {
 	}
 
 	.page-template-template-fullwidth-php {
+
 		.col2-set {
+
 			@include span(6 of 12);
 
 			.form-row-first {
+
 				@include span(3 of 6);
 			}
 
 			.form-row-last {
+
 				@include span(last 3 of 6);
 			}
 
 			&.addresses {
+
 				.col-1 {
+
 					@include span(6 of 12);
 				}
 
 				.col-2 {
+
 					@include span(last 6 of 12);
 				}
 			}
@@ -2758,15 +2991,18 @@ dl.variation {
 
 		#order_review_heading,
 		#order_review {
+
 			@include span(last 6 of 12);
 		}
 
 		#customer_details + #wc_checkout_add_ons {
+
 			@include span( last 6 of 12 );
 		}
 	}
 
 	#order_review {
+
 		.shop_table {
 			margin-bottom: ms(5);
 		}
@@ -2781,40 +3017,50 @@ dl.variation {
 
 	.col2-set#customer_login,
 	.col2-set.addresses {
+
 		@include span( full );
 
 		.col-1 {
+
 			@include span( 4 of 9 );
 		}
 
 		.col-2 {
+
 			@include span( 5 of 9 last );
 		}
 	}
 
 
 	.woocommerce-MyAccount-navigation {
+
 		@include span( 2 of 9 );
 	}
 
 	.woocommerce-MyAccount-content {
+
 		@include span( last 7 of 9 );
 
 		.form-row-first {
+
 			@include span( 3 of 7 );
 		}
 
 		.form-row-last {
+
 			@include span( last 4 of 7 );
 		}
 	}
 
-	.left-sidebar:not( .page-template-template-fullwidth-php ) {
+	.left-sidebar:not(.page-template-template-fullwidth-php) {
+
 		.woocommerce-MyAccount-content {
+
 			@include span( 7 of 9 );
 		}
 
 		.woocommerce-MyAccount-navigation {
+
 			@include span( last 2 of 9 );
 		}
 	}
@@ -2824,25 +3070,32 @@ dl.variation {
 	}
 
 	.page-template-template-fullwidth-php {
+
 		.col2-set#customer_login,
 		.col2-set.addresses {
+
 			.col-1 {
+
 				@include span( 6 of 12 );
 			}
 
 			.col-2 {
+
 				@include span( 6 of 12 last );
 			}
 		}
 
 		.woocommerce-MyAccount-content {
+
 			@include span( 9 of 12 );
 
 			.form-row-first {
+
 				@include span( 4 of 8 );
 			}
 
 			.form-row-last {
+
 				@include span( last 4 of 8 );
 			}
 
@@ -2850,22 +3103,27 @@ dl.variation {
 				width: 100%;
 
 				.col-1 {
+
 					@include span( 4 of 8 );
 				}
 
 				.col-2 {
+
 					@include span( last 4 of 8 );
 				}
 			}
 		}
 
 		.woocommerce-MyAccount-navigation {
+
 			@include span( last 3 of 12 );
 		}
 	}
 
 	.addresses {
+
 		header.title {
+
 			@include clearfix;
 
 			a {
@@ -2883,31 +3141,40 @@ dl.variation {
 	 * General WooCommerce Components
 	 */
 	.form-row-first {
+
 		@include span(4.5 of 9);
 		clear: both;
 	}
 
 	.form-row-last {
+
 		@include span(last 4.5 of 9);
 	}
 
 	.page-template-template-fullwidth-php {
+
 		.form-row-first {
+
 			@include span(6 of 12);
 		}
 
 		.form-row-last {
+
 			@include span(last 6 of 12);
 		}
 	}
 
 	.storefront-full-width-content {
+
 		.woocommerce-tabs {
+
 			ul.tabs {
+
 				@include span(4 of 12);
 			}
 
 			.panel {
+
 				@include span(last 8 of 12);
 				margin-bottom: ms(6);
 			}
@@ -2919,9 +3186,11 @@ dl.variation {
 		padding-bottom: ms(5);
 
 		ul.tabs {
+
 			@include span(3 of 9);
 
 			li {
+
 				&.active::after {
 					right: 1em;
 				}
@@ -2929,6 +3198,7 @@ dl.variation {
 		}
 
 		.panel {
+
 			@include span(last 6 of 9);
 			margin-top: 0;
 		}
@@ -2944,7 +3214,7 @@ dl.variation {
 			position: fixed;
 			top: 50%;
 			width: 500px;
-			box-shadow: 0 0 5px rgba( #000, 0.2 );
+			box-shadow: 0 0 5px rgba(#000, 0.2);
 			z-index: 1499; /* Lower than PhotoSwipe */
 			display: flex;
 			align-items: center;
@@ -2954,7 +3224,7 @@ dl.variation {
 				border-radius: 0;
 			}
 
-			&[rel='prev'] {
+			&[rel="prev"] {
 				left: -455px;
 				transition: left 0.3s ease-out;
 				flex-direction: row-reverse;
@@ -2973,7 +3243,7 @@ dl.variation {
 				}
 			}
 
-			&[rel='next'] {
+			&[rel="next"] {
 				right: -455px;
 				transition: right 0.3s ease-in;
 				padding-right: ms(1);
@@ -3003,11 +3273,11 @@ dl.variation {
 		left: 0;
 		right: 0;
 		z-index: 99998;
-		transform: translate3d( 0, -100%, 0 );
+		transform: translate3d(0, -100%, 0);
 		padding: ms(1);
 		overflow: hidden;
 		zoom: 1;
-		box-shadow: 0 1px 2px rgba( #000000, 0.2 );
+		box-shadow: 0 1px 2px rgba(#000, 0.2);
 		animation-duration: 0.5s;
 		animation-fill-mode: both;
 
@@ -3042,7 +3312,7 @@ dl.variation {
 			max-width: ms(6);
 			margin: 0 ms(2) 0 0;
 			padding: 3px;
-			border: 1px solid rgba( #000000, 0.1 );
+			border: 1px solid rgba(#000, 0.1);
 		}
 
 		.star-rating {
@@ -3053,7 +3323,9 @@ dl.variation {
 	}
 
 	.admin-bar {
+
 		.storefront-sticky-add-to-cart {
+
 			&--slideInDown {
 				top: 32px;
 			}
@@ -3062,9 +3334,13 @@ dl.variation {
 }
 
 @media (min-width: $desktop) and (max-width: 900px) {
+
 	body {
-		&:not( .page-template-template-fullwidth-php ) {
+
+		&:not(.page-template-template-fullwidth-php) {
+
 			table.cart {
+
 				td,
 				th {
 					padding: ms(1);

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1290,8 +1290,9 @@ ul#shipping_method {
 /**
  * Checkout
  *
- * 1 - Required to make the blockUI overlay cover the entire page rather than just the checkout form. We do this because
- *     otherwise our sticky order review can break out of the checkout form (and the blockUI element).
+ * 1 - Required to make the blockUI overlay cover the entire page rather than
+ *     just the checkout form. We do this because otherwise our sticky order
+ *     review can break out of the checkout form (and the blockUI element).
  */
 .checkout_coupon {
 	margin-bottom: ms(5);

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -13,7 +13,7 @@
 
 // Star font, FontAwesome doesn't work :(
 @font-face {
-	font-family: "star";
+	font-family: star;
 	src: url("../../../../../plugins/woocommerce/assets/fonts/star.eot");
 	src:
 		url("../../../../../plugins/woocommerce/assets/fonts/star.eot?#iefix") format("embedded-opentype"),
@@ -1777,7 +1777,7 @@ ul.order_details {
 	line-height: 1.618;
 	font-size: 1em;
 	width: 5.3em;
-	font-family: "star";
+	font-family: star;
 	font-weight: 400;
 
 	&::before {
@@ -1830,7 +1830,7 @@ p.stars {
 			width: 1em;
 			height: 1em;
 			line-height: 1;
-			font-family: "star";
+			font-family: star;
 			content: "\53";
 			color: $color_body;
 			text-indent: 0;

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -14,12 +14,12 @@
 // Star font, FontAwesome doesn't work :(
 @font-face {
 	font-family: star;
-	src: url("../../../../../plugins/woocommerce/assets/fonts/star.eot");
+	src: url(../../../../../plugins/woocommerce/assets/fonts/star.eot);
 	src:
-		url("../../../../../plugins/woocommerce/assets/fonts/star.eot?#iefix") format("embedded-opentype"),
-		url("../../../../../plugins/woocommerce/assets/fonts/star.woff") format("woff"),
-		url("../../../../../plugins/woocommerce/assets/fonts/star.ttf") format("truetype"),
-		url("../../../../../plugins/woocommerce/assets/fonts/star.svg#star") format("svg");
+		url(../../../../../plugins/woocommerce/assets/fonts/star.eot?#iefix) format("embedded-opentype"),
+		url(../../../../../plugins/woocommerce/assets/fonts/star.woff) format("woff"),
+		url(../../../../../plugins/woocommerce/assets/fonts/star.ttf) format("truetype"),
+		url(../../../../../plugins/woocommerce/assets/fonts/star.svg#star) format("svg");
 	font-weight: normal;
 	font-style: normal;
 }
@@ -1410,38 +1410,38 @@ form.checkout {
 					background-repeat: no-repeat;
 					background-position: right ms(-2) center;
 					background-size: 31px 20px;
-					background-image: url("../../../assets/images/credit-cards/unknown.svg");
+					background-image: url(../../../assets/images/credit-cards/unknown.svg);
 
 					&.visa {
-						background-image: url("../../../assets/images/credit-cards/visa.svg");
+						background-image: url(../../../assets/images/credit-cards/visa.svg);
 					}
 
 					&.mastercard {
-						background-image: url("../../../assets/images/credit-cards/mastercard.svg");
+						background-image: url(../../../assets/images/credit-cards/mastercard.svg);
 					}
 
 					&.laser {
-						background-image: url("../../../assets/images/credit-cards/laser.svg");
+						background-image: url(../../../assets/images/credit-cards/laser.svg);
 					}
 
 					&.dinersclub {
-						background-image: url("../../../assets/images/credit-cards/diners.svg");
+						background-image: url(../../../assets/images/credit-cards/diners.svg);
 					}
 
 					&.maestro {
-						background-image: url("../../../assets/images/credit-cards/maestro.svg");
+						background-image: url(../../../assets/images/credit-cards/maestro.svg);
 					}
 
 					&.jcb {
-						background-image: url("../../../assets/images/credit-cards/jcb.svg");
+						background-image: url(../../../assets/images/credit-cards/jcb.svg);
 					}
 
 					&.amex {
-						background-image: url("../../../assets/images/credit-cards/amex.svg");
+						background-image: url(../../../assets/images/credit-cards/amex.svg);
 					}
 
 					&.discover {
-						background-image: url("../../../assets/images/credit-cards/discover.svg");
+						background-image: url(../../../assets/images/credit-cards/discover.svg);
 					}
 				}
 			}

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1037,7 +1037,7 @@ a.reset_variations {
 
 	.price_slider_amount {
 		text-align: right;
-		line-height: 2.4em;
+		line-height: 2.4;
 
 		.button {
 			float: left;

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -25,14 +25,14 @@
 }
 
 @font-face {
-	font-family: 'WooCommerce';
-	src: url('../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot');
+	font-family: WooCommerce;
+	src: url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot);
 	src:
-		url('../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot?#iefix') format('embedded-opentype'),
-		url('../../../../../plugins/woocommerce/assets/fonts/WooCommerce.woff') format('woff'),
-		url('../../../../../plugins/woocommerce/assets/fonts/WooCommerce.ttf') format('truetype'),
-		url('../../../../../plugins/woocommerce/assets/fonts/WooCommerce.svg#WooCommerce') format('svg');
-	font-weight: normal;
+		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot?#iefix) format("embedded-opentype"),
+		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.woff) format("woff"),
+		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.ttf) format("truetype"),
+		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.svg#WooCommerce) format("svg");
+	font-weight: 400;
 	font-style: normal;
 }
 
@@ -393,7 +393,7 @@ ul.products,
 		.woocommerce-loop-product__title,
 		.woocommerce-loop-category__title,
 		.wc-block-grid__product-title,
-		.wc-block-grid__product-title > a:not( .has-font-size ) {
+		.wc-block-grid__product-title > a:not(.has-font-size) {
 			font-size: 1rem;
 		}
 
@@ -1964,6 +1964,7 @@ p.stars {
 .woocommerce-error,
 .woocommerce-noreviews,
 p.no-comments {
+
 	@include clearfix;
 	margin-bottom: ms(5);
 	background-color: $success;
@@ -1990,8 +1991,8 @@ p.no-comments {
 	}
 
 	&::before {
-		font-family: 'WooCommerce';
-		content: '\e028';
+		font-family: WooCommerce;
+		content: "\e028";
 		display: inline-block;
 		position: absolute;
 		top: 1em;
@@ -2029,7 +2030,7 @@ p.no-comments {
 .woocommerce-message {
 
 	&::before {
-		content: '\e015';
+		content: "\e015";
 	}
 }
 
@@ -2037,7 +2038,7 @@ p.no-comments {
 .woocommerce-error {
 
 	&::before {
-		content: '\e016';
+		content: "\e016";
 	}
 }
 

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -111,8 +111,8 @@
 
 	.widget_product_search {
 
-		input[type=text],
-		input[type=search] {
+		input[type="text"],
+		input[type="search"] {
 			padding: ms(1) ms(2);
 			line-height: 1;
 		}
@@ -1389,7 +1389,7 @@ form.checkout {
 					li {
 						margin-top: ms(-2);
 
-						input[type=radio] {
+						input[type="radio"] {
 							margin-right: 0.236em;
 						}
 					}
@@ -1658,8 +1658,8 @@ ul.order_details {
 		width: 100%;
 	}
 
-	input[type=checkbox],
-	input[type=radio] {
+	input[type="checkbox"],
+	input[type="radio"] {
 		width: auto;
 	}
 
@@ -2903,7 +2903,7 @@ dl.variation {
 
 	#wc_checkout_add_ons {
 
-		input[type=radio] {
+		input[type="radio"] {
 			float: left;
 			margin-right: ms(-3);
 			clear: left;

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -20,7 +20,7 @@
 		url(../../../../../plugins/woocommerce/assets/fonts/star.woff) format("woff"),
 		url(../../../../../plugins/woocommerce/assets/fonts/star.ttf) format("truetype"),
 		url(../../../../../plugins/woocommerce/assets/fonts/star.svg#star) format("svg");
-	font-weight: normal;
+	font-weight: 400;
 	font-style: normal;
 }
 

--- a/languages/storefront.pot
+++ b/languages/storefront.pot
@@ -1,14 +1,14 @@
-# <!=Copyright (C) 2020 Automattic
+# <!=Copyright (C) 2021 Automattic
 # This file is distributed under the GNU General Public License v2 or later.=!>
 msgid ""
 msgstr ""
 "Project-Id-Version: Storefront 3.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/woothemes/storefront/issues\n"
-"POT-Creation-Date: 2020-12-15 17:33:36+00:00\n"
+"POT-Creation-Date: 2021-01-04 15:03:12+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2020-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2021-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
 "X-Generator: grunt-wp-i18n 1.0.3\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4698,7 +4698,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "grunt": {
       "version": "1.3.0",
@@ -6227,6 +6228,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -8963,6 +8965,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -8977,6 +8980,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -8985,13 +8989,15 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -12364,7 +12370,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13359,6 +13359,53 @@
         }
       }
     },
+    "stylelint-config-recommended": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
+      "integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
+      "dev": true
+    },
+    "stylelint-config-recommended-scss": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-4.2.0.tgz",
+      "integrity": "sha512-4bI5BYbabo/GCQ6LbRZx/ZlVkK65a1jivNNsD+ix/Lw0U3iAch+jQcvliGnnAX8SUPaZ0UqzNVNNAF3urswa7g==",
+      "dev": true,
+      "requires": {
+        "stylelint-config-recommended": "^3.0.0"
+      }
+    },
+    "stylelint-config-wordpress": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-wordpress/-/stylelint-config-wordpress-17.0.0.tgz",
+      "integrity": "sha512-qUU2kVMd2ezIV9AzRdgietIfnavRRENt4180A1OMoVXIowRjjhohZgBiyVPV5EtNKo3GTO63l8g/QGNG27/h9g==",
+      "dev": true,
+      "requires": {
+        "stylelint-config-recommended": "^3.0.0",
+        "stylelint-config-recommended-scss": "^4.2.0",
+        "stylelint-scss": "^3.17.2"
+      }
+    },
+    "stylelint-scss": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.18.0.tgz",
+      "integrity": "sha512-LD7+hv/6/ApNGt7+nR/50ft7cezKP2HM5rI8avIdGaUWre3xlHfV4jKO/DRZhscfuN+Ewy9FMhcTq0CcS0C/SA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "dev": true
+        }
+      }
+    },
     "sugarss": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "postcss": "8.2.2",
     "puppeteer": "5.5.0",
     "stylelint": "13.8.0",
+    "stylelint-config-wordpress": "17.0.0",
     "susy": "2.2.14"
   },
   "engines": {


### PR DESCRIPTION
Rebased and updated https://github.com/woocommerce/storefront/pull/1431

Closes #1431

### How to test the changes in this Pull Request:

- Run npm run css. You should see no linting errors.
- Open a WordPress installation with StoreFront enabled and check for visual regressions.

### Changelog

> Tweak – update stylelint to use stylelint-config-wordpress\scss config and refactor SCSS files to follow WordPress CSS coding standards.
