### PR TITLE
Remove custom WooCommerce font usage

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1802,8 +1802,8 @@ p.stars {
 			width: 1em;
 			height: 1em;
 			line-height: 1;
-			font-family: "Font Awesome 5 Free" !important;
-			content: "\f005" !important;
+			font-family: "Font Awesome 5 Free";
+			content: "\f005";
 			font-size: 0.95em; // Font-awesome glyph is rectangular.
 			color: $color_body;
 			text-indent: 0;

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -11,18 +11,6 @@
 @import "../../../node_modules/susy/sass/susy";
 @import "../sass/vendors/modular-scale";
 
-@font-face {
-	font-family: WooCommerce;
-	src: url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot);
-	src:
-		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot?#iefix) format("embedded-opentype"),
-		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.woff) format("woff"),
-		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.ttf) format("truetype"),
-		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.svg#WooCommerce) format("svg");
-	font-weight: 400;
-	font-style: normal;
-}
-
 // Animations
 @keyframes slideInDown {
 
@@ -1970,11 +1958,11 @@ p.no-comments {
 	}
 
 	&::before {
-		font-family: WooCommerce;
-		content: "\e028";
+		font-family: "Font Awesome 5 Free";
+		content: "\f06a";
 		display: inline-block;
 		position: absolute;
-		top: 1em;
+		top: 1.05em;
 		left: 1.5em;
 		color: #fff;
 	}

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -11,19 +11,6 @@
 @import "../../../node_modules/susy/sass/susy";
 @import "../sass/vendors/modular-scale";
 
-// Star font, FontAwesome doesn't work :(
-@font-face {
-	font-family: star;
-	src: url(../../../../../plugins/woocommerce/assets/fonts/star.eot);
-	src:
-		url(../../../../../plugins/woocommerce/assets/fonts/star.eot?#iefix) format("embedded-opentype"),
-		url(../../../../../plugins/woocommerce/assets/fonts/star.woff) format("woff"),
-		url(../../../../../plugins/woocommerce/assets/fonts/star.ttf) format("truetype"),
-		url(../../../../../plugins/woocommerce/assets/fonts/star.svg#star) format("svg");
-	font-weight: 400;
-	font-style: normal;
-}
-
 @font-face {
 	font-family: WooCommerce;
 	src: url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot);
@@ -1777,17 +1764,21 @@ ul.order_details {
 	height: 1.618em;
 	line-height: 1.618;
 	font-size: 1em;
-	width: 5.3em;
-	font-family: star;
+	width: 5.55em;
+	font-family: "Font Awesome 5 Free";
 	font-weight: 400;
 
-	&::before {
-		content: "\53\53\53\53\53";
-		opacity: 0.25;
-		float: left;
+	&::before,
+	span::before {
+		content: "\f005\f005\f005\f005\f005";
 		top: 0;
 		left: 0;
 		position: absolute;
+	}
+
+	&::before {
+		opacity: 0.25;
+		float: left;
 	}
 
 	span {
@@ -1797,13 +1788,6 @@ ul.order_details {
 		left: 0;
 		position: absolute;
 		padding-top: 1.5em;
-	}
-
-	span::before {
-		content: "\53\53\53\53\53";
-		top: 0;
-		position: absolute;
-		left: 0;
 		color: $color_links;
 	}
 }
@@ -1820,7 +1804,6 @@ p.stars {
 		overflow: hidden;
 		display: inline-block;
 		text-decoration: none;
-		margin-right: 1px;
 		font-weight: 400;
 
 		&::before {
@@ -1831,8 +1814,9 @@ p.stars {
 			width: 1em;
 			height: 1em;
 			line-height: 1;
-			font-family: star;
-			content: "\53";
+			font-family: "Font Awesome 5 Free" !important;
+			content: "\f005" !important;
+			font-size: 0.95em; // Font-awesome glyph is rectangular.
 			color: $color_body;
 			text-indent: 0;
 			opacity: 0.25;
@@ -1841,7 +1825,6 @@ p.stars {
 		&:hover {
 
 			~ a::before {
-				content: "\53";
 				color: $color_body;
 				opacity: 0.25;
 			}
@@ -1853,7 +1836,6 @@ p.stars {
 		a {
 
 			&::before {
-				content: "\53";
 				color: $color_woocommerce;
 				opacity: 1;
 			}
@@ -1865,13 +1847,11 @@ p.stars {
 		a.active {
 
 			&::before {
-				content: "\53";
 				color: $color_woocommerce;
 				opacity: 1;
 			}
 
 			~ a::before {
-				content: "\53";
 				color: $color_body;
 				opacity: 0.25;
 			}
@@ -1880,7 +1860,6 @@ p.stars {
 		a:not(.active) {
 
 			&::before {
-				content: "\53";
 				color: $color_woocommerce;
 				opacity: 1;
 			}


### PR DESCRIPTION
Storefront was using the icon sets from WooCommerce core not by including them in Storefront, but by trying to reference them from the plugin directory. As pointed out in #1519, the plugin directory is not constant and can be changed, therefore breaking icons.

Whilst we could have looked for a method of making the path variable, considering how much usage there is of these icons in Storefront, it didn't seem worth the effort, especially considering how we also include FontAwesome for icons.

To that end, I removed the reference to the two icon fonts and replaced them with FontAwesome. There was a note inline saying that "FontAwesome didn't work for star icons", but I ran into no problems using FontAwesome in this context.

For the "note" icon, FontAwesome notice icon seems more appropriate. See the screenshots below.

Fixes #1519

### Screenshots

Before:
![Screenshot 2021-01-06 at 16 09 40](https://user-images.githubusercontent.com/90977/103791372-4b80f580-503a-11eb-8a9c-243b684e40d7.png)

After:
![Screenshot 2021-01-06 at 16 10 51](https://user-images.githubusercontent.com/90977/103791383-4e7be600-503a-11eb-9a3f-c88434200aee.png)

1. Check a product page; confirm star ratings are displayed correctly, and the rating form is still functional
2. Go to a product with no reviews, an empty cart, or trigger an error notice and confirm the "notice" icon is displayed as pictured above.

### Changelog

> Fix – Replaced WooCommerce and Star icon usage with FontAwesome.
