### PR TITLE
Use proper escape function in comments template

### DIFF
--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -50,7 +50,7 @@ if ( ! function_exists( 'storefront_comment' ) ) {
 			<?php endif; ?>
 
 			<a href="<?php echo esc_url( htmlspecialchars( get_comment_link( $comment->comment_ID ) ) ); ?>" class="comment-date">
-				<?php echo '<time datetime="' . esc_html( get_comment_date( 'c' ) ) . '">' . esc_html( get_comment_date() ) . '</time>'; ?>
+				<?php echo '<time datetime="' . esc_attr( get_comment_date( 'c' ) ) . '">' . esc_html( get_comment_date() ) . '</time>'; ?>
 			</a>
 		</div>
 		<?php if ( 'div' !== $args['style'] ) : ?>


### PR DESCRIPTION
<!-- Briefly describe the issue or problem that this PR solves. -->
The comment template was using an incorrect escape function for the `datetime` attribute in the comments template.

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->
This PR updates the code to use `esc_attr` for the `datetime` attribute instead of `esc_html`.

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. View a blog post that has some comments.
2. Ensure the comment date is displayed and that the `datetime` attribute is set.

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix - Use proper escape function for `datetime` attribute in comments template. #1576

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
