### PR TITLE
Use proper escape functions in several templates

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -37,7 +37,7 @@ if ( post_password_required() ) {
 		</h2>
 
 		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // Are there comments to navigate through. ?>
-		<nav id="comment-nav-above" class="comment-navigation" role="navigation" aria-label="<?php esc_html_e( 'Comment Navigation Above', 'storefront' ); ?>">
+		<nav id="comment-nav-above" class="comment-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Comment Navigation Above', 'storefront' ); ?>">
 			<span class="screen-reader-text"><?php esc_html_e( 'Comment navigation', 'storefront' ); ?></span>
 			<div class="nav-previous"><?php previous_comments_link( __( '&larr; Older Comments', 'storefront' ) ); ?></div>
 			<div class="nav-next"><?php next_comments_link( __( 'Newer Comments &rarr;', 'storefront' ) ); ?></div>

--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -158,7 +158,7 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 							<?php endif; ?>
 
 							<input type="submit" name="storefront-guided-tour" class="sf-nux-button" value="<?php esc_attr_e( 'Let\'s go!', 'storefront' ); ?>">
-							<a href="#" class="sf-nux-dismiss-button" ><?php esc_attr_e( 'Skip', 'storefront' ); ?></a>
+							<a href="#" class="sf-nux-dismiss-button" ><?php esc_html_e( 'Skip', 'storefront' ); ?></a>
 						</form>
 					<?php endif; ?>
 				</div>

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -270,7 +270,7 @@ if ( ! function_exists( 'storefront_secondary_navigation' ) ) {
 	function storefront_secondary_navigation() {
 		if ( has_nav_menu( 'secondary' ) ) {
 			?>
-			<nav class="secondary-navigation" role="navigation" aria-label="<?php esc_html_e( 'Secondary Navigation', 'storefront' ); ?>">
+			<nav class="secondary-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Secondary Navigation', 'storefront' ); ?>">
 				<?php
 					wp_nav_menu(
 						array(


### PR DESCRIPTION
Fixing some warnings about not using the proper escape functions that I received when releasing 3.2.0.

### How to test the changes in this Pull Request:
Changes are quite safe, but they can be tested as follows:

1. `comments.php`: go to Settings > Discussion and set the _Break comments into pages with_ option to 5. Then, add 6 comments to a post. **Verify:** the aria-label of `#comment-nav-above` has text.
2. `inc/storefront-template-functions.php`: in Appearance > Customize > Menus add a new menu to the secondary menu and publish it. **Verify:** the aria-label of `.secondary-navigation` has text.
3. `inc/nux/class-storefront-nux-admin.php` in a new site, install WooCommerce and activate it. After that, install Storefront. (Otherwise, in an existing install set `storefront_nux_dismissed` option to `0`). Go to Appearance > Storefront. **Verify.** the _Skip_ button is displayed correctly.
![imatge](https://user-images.githubusercontent.com/3616980/104351344-905acf80-5505-11eb-9957-89e5a0f76539.png)


### Changelog

> Updated several escape functions.