### PR TITLE
Check if WC Admin inbox is available before using it

### DIFF
--- a/inc/nux/class-storefront-nux-admin-inbox-messages-customize.php
+++ b/inc/nux/class-storefront-nux-admin-inbox-messages-customize.php
@@ -12,7 +12,7 @@ use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * The initial Storefron inbox Message.
+ * The initial Storefront inbox Message.
  */
 class Storefront_NUX_Admin_Inbox_Messages_Customize {
 

--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -48,9 +48,9 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 		 */
 		private function is_inbox_available() {
 			if (
-				function_exists( 'wc' ) &&
-				is_callable( array( wc(), 'is_wc_admin_active' ) ) &&
-				wc()->is_wc_admin_active() &&
+				function_exists( 'WC' ) &&
+				is_callable( array( WC(), 'is_wc_admin_active' ) ) &&
+				WC()->is_wc_admin_active() &&
 				version_compare( WC_VERSION, '4.8.0', '>=' )
 			) {
 				return true;

--- a/inc/nux/class-storefront-nux-admin.php
+++ b/inc/nux/class-storefront-nux-admin.php
@@ -25,9 +25,9 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
 			/*
-			 * In case the user has installed the Storefront theme without WooCommerce plugin this will detect this scenario and show the admin notice.
+			 * In case the WC Admin inbox is not available, show the admin notice.
 			 */
-			if ( is_callable( array( 'WooCommerce', 'is_wc_admin_active' ) ) && wc()->is_wc_admin_active() ) {
+			if ( $this->is_inbox_available() ) {
 				add_action( 'admin_notices', array( $this, 'admin_inbox_messages' ), 99 );
 			} else {
 				add_action( 'admin_notices', array( $this, 'admin_notices' ), 99 );
@@ -37,6 +37,26 @@ if ( ! class_exists( 'Storefront_NUX_Admin' ) ) :
 			add_action( 'admin_post_storefront_starter_content', array( $this, 'redirect_customizer' ) );
 			add_action( 'init', array( $this, 'log_fresh_site_state' ) );
 			add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
+		}
+
+		/**
+		 * Checks if WC Admin inbox is available. It might not be available if
+		 * WooCommerce is not installed, in old versions of WC or if wc-admin
+		 * has been disabled.
+		 *
+		 * @since 3.3.0
+		 */
+		private function is_inbox_available() {
+			if (
+				function_exists( 'wc' ) &&
+				is_callable( array( wc(), 'is_wc_admin_active' ) ) &&
+				wc()->is_wc_admin_active() &&
+				version_compare( WC_VERSION, '4.8.0', '>=' )
+			) {
+				return true;
+			}
+
+			return false;
 		}
 
 		/**


### PR DESCRIPTION
Fixes #1580.

There were a couple of issues with the inbox notice added to personalize the store:

* It was never added to the WC Admin inbox in PHP 8, because `is_callable( array( 'WooCommerce', 'is_wc_admin_active' ) )` always resolved to false (more info in [PHP 8.0 changelist](https://php.watch/versions/8.0)).
* In old versions of WooCommerce, there was a fatal because we were calling an undefined method. The inbox notice was added in #1544 but in #1566 the version check was removed.

### How to test the changes in this Pull Request:

#### WC up to date
1. Edit your DB options table and delete the `storefront_nux_dismissed` option value, or use a clean install.
2. Activate Storefront.
3. Verify a notice is added to the WC Admin inbox.

#### WC disabled
1. Disable WC admin using the filter: `add_filter( 'woocommerce_admin_disabled', '__return_true' );`
2. Edit your DB options table and delete the `storefront_nux_dismissed` option value, or use a clean install.
3. Activate Storefront.
4. Verify the old style admin notice instead of a fatal error.

#### Old WooCommerce
1. Install a WC version prior to 4.8.
2. Edit your DB options table and delete the `storefront_nux_dismissed` option value, or use a clean install.
3. Activate Storefront.
4. Verify the old style admin notice instead of a fatal error.

### Changelog

> Fix – Fatal error in old versions of WooCommerce.