### PR TITLE
Fix escape function in comments template

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -57,7 +57,7 @@ if ( post_password_required() ) {
 		</ol><!-- .comment-list -->
 
 		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // Are there comments to navigate through. ?>
-		<nav id="comment-nav-below" class="comment-navigation" role="navigation" aria-label="<?php esc_html_e( 'Comment Navigation Below', 'storefront' ); ?>">
+		<nav id="comment-nav-below" class="comment-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Comment Navigation Below', 'storefront' ); ?>">
 			<span class="screen-reader-text"><?php esc_html_e( 'Comment navigation', 'storefront' ); ?></span>
 			<div class="nav-previous"><?php previous_comments_link( __( '&larr; Older Comments', 'storefront' ) ); ?></div>
 			<div class="nav-next"><?php next_comments_link( __( 'Newer Comments &rarr;', 'storefront' ) ); ?></div>


### PR DESCRIPTION
### How to test the changes in this Pull Request:

1. Go to Settings > Discussion and set the _Break comments into pages with_ option to 5.
2. Add 6 comments to a post. 
3. Verify the aria-label of `#comment-nav-below` has text.

### Changelog

> Fix – Use proper escape function in comments template