### PR TITLE
Fix missing icons

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -11,31 +11,6 @@
 @import "../../../node_modules/susy/sass/susy";
 @import "../sass/vendors/modular-scale";
 
-// Star font, FontAwesome doesn't work :(
-@font-face {
-	font-family: star;
-	src: url(../../../../../plugins/woocommerce/assets/fonts/star.eot);
-	src:
-		url(../../../../../plugins/woocommerce/assets/fonts/star.eot?#iefix) format("embedded-opentype"),
-		url(../../../../../plugins/woocommerce/assets/fonts/star.woff) format("woff"),
-		url(../../../../../plugins/woocommerce/assets/fonts/star.ttf) format("truetype"),
-		url(../../../../../plugins/woocommerce/assets/fonts/star.svg#star) format("svg");
-	font-weight: 400;
-	font-style: normal;
-}
-
-@font-face {
-	font-family: WooCommerce;
-	src: url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot);
-	src:
-		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot?#iefix) format("embedded-opentype"),
-		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.woff) format("woff"),
-		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.ttf) format("truetype"),
-		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.svg#WooCommerce) format("svg");
-	font-weight: 400;
-	font-style: normal;
-}
-
 // Animations
 @keyframes slideInDown {
 

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -11,6 +11,31 @@
 @import "../../../node_modules/susy/sass/susy";
 @import "../sass/vendors/modular-scale";
 
+// Star font, FontAwesome doesn't work :(
+@font-face {
+	font-family: star;
+	src: url(../../../../../plugins/woocommerce/assets/fonts/star.eot);
+	src:
+		url(../../../../../plugins/woocommerce/assets/fonts/star.eot?#iefix) format("embedded-opentype"),
+		url(../../../../../plugins/woocommerce/assets/fonts/star.woff) format("woff"),
+		url(../../../../../plugins/woocommerce/assets/fonts/star.ttf) format("truetype"),
+		url(../../../../../plugins/woocommerce/assets/fonts/star.svg#star) format("svg");
+	font-weight: 400;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: WooCommerce;
+	src: url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot);
+	src:
+		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.eot?#iefix) format("embedded-opentype"),
+		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.woff) format("woff"),
+		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.ttf) format("truetype"),
+		url(../../../../../plugins/woocommerce/assets/fonts/WooCommerce.svg#WooCommerce) format("svg");
+	font-weight: 400;
+	font-style: normal;
+}
+
 // Animations
 @keyframes slideInDown {
 
@@ -1752,21 +1777,17 @@ ul.order_details {
 	height: 1.618em;
 	line-height: 1.618;
 	font-size: 1em;
-	width: 5.55em;
-	font-family: "Font Awesome 5 Free";
+	width: 5.3em;
+	font-family: star;
 	font-weight: 400;
 
-	&::before,
-	span::before {
-		content: "\f005\f005\f005\f005\f005";
+	&::before {
+		content: "\53\53\53\53\53";
+		opacity: 0.25;
+		float: left;
 		top: 0;
 		left: 0;
 		position: absolute;
-	}
-
-	&::before {
-		opacity: 0.25;
-		float: left;
 	}
 
 	span {
@@ -1776,6 +1797,13 @@ ul.order_details {
 		left: 0;
 		position: absolute;
 		padding-top: 1.5em;
+	}
+
+	span::before {
+		content: "\53\53\53\53\53";
+		top: 0;
+		position: absolute;
+		left: 0;
 		color: $color_links;
 	}
 }
@@ -1792,6 +1820,7 @@ p.stars {
 		overflow: hidden;
 		display: inline-block;
 		text-decoration: none;
+		margin-right: 1px;
 		font-weight: 400;
 
 		&::before {
@@ -1802,9 +1831,8 @@ p.stars {
 			width: 1em;
 			height: 1em;
 			line-height: 1;
-			font-family: "Font Awesome 5 Free";
-			content: "\f005";
-			font-size: 0.95em; // Font-awesome glyph is rectangular.
+			font-family: star;
+			content: "\53";
 			color: $color_body;
 			text-indent: 0;
 			opacity: 0.25;
@@ -1813,6 +1841,7 @@ p.stars {
 		&:hover {
 
 			~ a::before {
+				content: "\53";
 				color: $color_body;
 				opacity: 0.25;
 			}
@@ -1824,6 +1853,7 @@ p.stars {
 		a {
 
 			&::before {
+				content: "\53";
 				color: $color_woocommerce;
 				opacity: 1;
 			}
@@ -1835,11 +1865,13 @@ p.stars {
 		a.active {
 
 			&::before {
+				content: "\53";
 				color: $color_woocommerce;
 				opacity: 1;
 			}
 
 			~ a::before {
+				content: "\53";
 				color: $color_body;
 				opacity: 0.25;
 			}
@@ -1848,6 +1880,7 @@ p.stars {
 		a:not(.active) {
 
 			&::before {
+				content: "\53";
 				color: $color_woocommerce;
 				opacity: 1;
 			}
@@ -1958,11 +1991,11 @@ p.no-comments {
 	}
 
 	&::before {
-		font-family: "Font Awesome 5 Free";
-		content: "\f06a";
+		font-family: WooCommerce;
+		content: "\e028";
 		display: inline-block;
 		position: absolute;
-		top: 1.05em;
+		top: 1em;
 		left: 1.5em;
 		color: #fff;
 	}

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1997,15 +1997,7 @@ p.no-comments {
 .woocommerce-message {
 
 	&::before {
-		content: "\e015";
-	}
-}
-
-
-.woocommerce-error {
-
-	&::before {
-		content: "\e016";
+		content: "\f058";
 	}
 }
 

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1752,17 +1752,21 @@ ul.order_details {
 	height: 1.618em;
 	line-height: 1.618;
 	font-size: 1em;
-	width: 5.3em;
-	font-family: star;
+	width: 5.55em;
+	font-family: "Font Awesome 5 Free";
 	font-weight: 400;
 
-	&::before {
-		content: "\53\53\53\53\53";
-		opacity: 0.25;
-		float: left;
+	&::before,
+	span::before {
+		content: "\f005\f005\f005\f005\f005";
 		top: 0;
 		left: 0;
 		position: absolute;
+	}
+
+	&::before {
+		opacity: 0.25;
+		float: left;
 	}
 
 	span {
@@ -1772,13 +1776,6 @@ ul.order_details {
 		left: 0;
 		position: absolute;
 		padding-top: 1.5em;
-	}
-
-	span::before {
-		content: "\53\53\53\53\53";
-		top: 0;
-		position: absolute;
-		left: 0;
 		color: $color_links;
 	}
 }
@@ -1795,7 +1792,6 @@ p.stars {
 		overflow: hidden;
 		display: inline-block;
 		text-decoration: none;
-		margin-right: 1px;
 		font-weight: 400;
 
 		&::before {
@@ -1806,8 +1802,9 @@ p.stars {
 			width: 1em;
 			height: 1em;
 			line-height: 1;
-			font-family: star;
-			content: "\53";
+			font-family: "Font Awesome 5 Free";
+			content: "\f005";
+			font-size: 0.95em; // Font-awesome glyph is rectangular.
 			color: $color_body;
 			text-indent: 0;
 			opacity: 0.25;
@@ -1816,7 +1813,6 @@ p.stars {
 		&:hover {
 
 			~ a::before {
-				content: "\53";
 				color: $color_body;
 				opacity: 0.25;
 			}
@@ -1828,7 +1824,6 @@ p.stars {
 		a {
 
 			&::before {
-				content: "\53";
 				color: $color_woocommerce;
 				opacity: 1;
 			}
@@ -1840,13 +1835,11 @@ p.stars {
 		a.active {
 
 			&::before {
-				content: "\53";
 				color: $color_woocommerce;
 				opacity: 1;
 			}
 
 			~ a::before {
-				content: "\53";
 				color: $color_body;
 				opacity: 0.25;
 			}
@@ -1855,7 +1848,6 @@ p.stars {
 		a:not(.active) {
 
 			&::before {
-				content: "\53";
 				color: $color_woocommerce;
 				opacity: 1;
 			}
@@ -1966,11 +1958,11 @@ p.no-comments {
 	}
 
 	&::before {
-		font-family: WooCommerce;
-		content: "\e028";
+		font-family: "Font Awesome 5 Free";
+		content: "\f06a";
 		display: inline-block;
 		position: absolute;
-		top: 1em;
+		top: 1.05em;
 		left: 1.5em;
 		color: #fff;
 	}

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -26,7 +26,6 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			add_action( 'after_setup_theme', array( $this, 'setup' ) );
 			add_filter( 'body_class', array( $this, 'woocommerce_body_class' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'woocommerce_scripts' ), 20 );
-			add_filter( 'woocommerce_enqueue_styles', '__return_empty_array' );
 			add_filter( 'woocommerce_output_related_products_args', array( $this, 'related_products_args' ) );
 			add_filter( 'woocommerce_product_thumbnails_columns', array( $this, 'thumbnail_columns' ) );
 			add_filter( 'woocommerce_breadcrumb_defaults', array( $this, 'change_breadcrumb_delimiter' ) );
@@ -35,6 +34,10 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			add_action( 'storefront_woocommerce_setup', array( $this, 'setup_integrations' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'woocommerce_integrations_scripts' ), 99 );
 			add_action( 'wp_enqueue_scripts', array( $this, 'add_customizer_css' ), 140 );
+
+			// Instead of loading Core CSS files, we only register the font families.
+			add_filter( 'woocommerce_enqueue_styles', '__return_empty_array' );
+			add_filter( 'wp_enqueue_scripts', array( $this, 'add_core_fonts' ), 130 );
 		}
 
 		/**
@@ -87,6 +90,41 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 		 */
 		public function add_customizer_css() {
 			wp_add_inline_style( 'storefront-woocommerce-style', $this->get_woocommerce_extension_css() );
+		}
+
+		/**
+		 * Add CSS in <head> to register WooCommerce Core fonts.
+		 *
+		 * @since 3.4.0
+		 * @return void
+		 */
+		public function add_core_fonts() {
+			$fonts_url = plugins_url( '/woocommerce/assets/fonts/' );
+			wp_add_inline_style(
+				'storefront-woocommerce-style',
+				'@font-face {
+				font-family: star;
+				src: url(' . $fonts_url . '/star.eot);
+				src:
+					url(' . $fonts_url . '/star.eot?#iefix) format("embedded-opentype"),
+					url(' . $fonts_url . '/star.woff) format("woff"),
+					url(' . $fonts_url . '/star.ttf) format("truetype"),
+					url(' . $fonts_url . '/star.svg#star) format("svg");
+				font-weight: 400;
+				font-style: normal;
+			}
+			@font-face {
+				font-family: WooCommerce;
+				src: url(' . $fonts_url . '/WooCommerce.eot);
+				src:
+					url(' . $fonts_url . '/WooCommerce.eot?#iefix) format("embedded-opentype"),
+					url(' . $fonts_url . '/WooCommerce.woff) format("woff"),
+					url(' . $fonts_url . '/WooCommerce.ttf) format("truetype"),
+					url(' . $fonts_url . '/WooCommerce.svg#WooCommerce) format("svg");
+				font-weight: 400;
+				font-style: normal;
+			}'
+			);
 		}
 
 		/**


### PR DESCRIPTION
Fixes #1582.
Fixes #1586.

This PR partially reverts the changes in #1574 (cc @mikejolley). Even though in theory we could update Storefront so it doesn't use any font family from WooCommerce, some extensions (at least, WC Blocks) rely on those fonts being loaded in the page. So I don't think we can remove them.

In order not to regress #1519 I moved the font loading to the PHP side.

### How to test the changes in this Pull Request:

#### Bug #1586

1. Verify stars in rated products are correctly displayed in PHP-based grid blocks (ie: Products by Category), All Products block and Review blocks.

![imatge](https://user-images.githubusercontent.com/3616980/104724627-3b9b9c80-5731-11eb-88d1-ae756f2441fe.png)

#### Bug #1586

1. Force WC to show an error, you can do that in the Checkout block submitting the form with an empty address.
2. Verify the icon in the notice is displayed.

![imatge](https://user-images.githubusercontent.com/3616980/104724887-9af9ac80-5731-11eb-88d3-046a3306d754.png)

#### Bug #1519

1. Rename your `/wp-content/plugins/` folder to `/wp-content/modules/`.
2. Add these lines to `wp-config.php`:
```PHP
define( 'WP_PLUGIN_DIR', dirname(__FILE__) . '/wp-content/modules' );
define( 'WP_PLUGIN_URL',  'https://{yoursite.com}/wp-content/modules' );
```
3. Verify icons are displayed across the store.

### Changelog

> Fix missing icons in WC Blocks and some other parts of the UI.
