### PR TITLE
Remove maximum-scale from viewport meta tag

### DIFF
--- a/header.php
+++ b/header.php
@@ -11,7 +11,7 @@
 <html <?php language_attributes(); ?>>
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2.0">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="profile" href="http://gmpg.org/xfn/11">
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #1599 : Removed maximum-scale from the meta tag in `header.php`