### PR TITLE
Fix #1611 - Handheld-footer and notice only hidden on smaller devices

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -236,10 +236,14 @@
 	}
 }
 
-.sf-input-focused {
+@media screen and (max-height: 320px) {
 
-	.storefront-handheld-footer-bar {
-		display: none;
+	.sf-input-focused {
+
+		.woocommerce-store-notice,
+		.storefront-handheld-footer-bar {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
### Issues

1. Handheld footer bar is hidden when focusing on input fields. (#1611)
This behavior was intended for mobiles that open the on-screen keyboard when an input is focused, so the available vertical space is reduced considerably.
However on modern phones that have a big enough screen, or on devices with an external keyboard this behavior is not necessary at all.

2. Store notice was not being hidden, see screenshots below:
    <details> 
      <summary>Screenshots</summary>
       Initial and focused state.<br>
       <img src="https://user-images.githubusercontent.com/12494197/108862512-352df980-75e8-11eb-9125-5cc0a8577eb7.png" width="50%"><img src="https://user-images.githubusercontent.com/12494197/108862499-32cb9f80-75e8-11eb-8ae4-c0a529276dee.png" width="50%">
    </details>

### Fixes
1. As suggested by @Aljullu, moving the style rule inside a media query based on max-height (320px).
2. Adds the store notice message class to the same rule.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
Before and after on iPhone 5/SE landscape mode
<img src="https://user-images.githubusercontent.com/12494197/108865209-e46bd000-75ea-11eb-9a6d-57439a49d2a2.png" width="50%"><img src="https://user-images.githubusercontent.com/12494197/108865219-e7ff5700-75ea-11eb-912f-7e0ecaeee694.png" width="50%">