### PR TITLE
Fixed buttons word break

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -905,6 +905,7 @@ input[type="submit"],
 	text-shadow: none;
 	display: inline-block;
 	-webkit-appearance: none;
+	word-break: break-all;
 
 	&::after {
 		display: none;


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #1604

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

## Steps To Reproduce:
1. Create any test site using Jurassic Ninja.
1. Install and activate all required plugins.
1. Complete the Onboarding setup wizard.
1. Create a Downloadable product and Add its File Name as "supercalifraglisticexpialidociousABCDEFGHIJKLMNOPQRST".
1. From front end, add the product to cart and Proceed for checkout.
1. Complete the Payment via Card.
1. After Checkout, On "Order Received" page, Note the file name to download the file appears truncated.
1. Click on "My Account"
1. Click on "Downloads" tab
1. Observe that Downloadable "File Name" appears misaligned on "Downloads" Page 

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – Buttons word break. #1604

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
