### PR TITLE
Fix #1626 navigation menu focus submenu

### DIFF
--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -109,6 +109,16 @@
 			} );
 		} );
 
+		// Ensure the dropdowns close when user taps outside the site header
+		[].forEach.call( document.querySelectorAll( 'body #page > :not( .site-header )' ), function( element ) {
+			element.addEventListener( 'click', function() {
+				[].forEach.call( document.querySelectorAll( '.focus, .blocked' ), function( el ) {
+					el.classList.remove( 'focus' );
+					el.classList.remove( 'blocked' );
+				} );
+			} );
+		} );
+
 		// Add an identifying class to dropdowns when on a touch device
 		// This is required to switch the dropdown hiding method from a negative `left` value to `display: none`.
 		if ( ( 'ontouchstart' in window || navigator.maxTouchPoints ) && window.innerWidth > 767 ) {
@@ -136,16 +146,6 @@
 					} else {
 						acceptClick = true;
 					}
-				} );
-			} );
-
-			// Ensure the dropdowns close when user taps outside the site header
-			[].forEach.call( document.querySelectorAll( 'body #page > :not( .site-header )' ), function( element ) {
-				element.addEventListener( 'click', function() {
-					[].forEach.call( document.querySelectorAll( '.focus, .blocked' ), function( el ) {
-					 	el.classList.remove( 'focus' );
-					 	el.classList.remove( 'blocked' );
-					} );
 				} );
 			} );
 		}


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #1626 

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->
This bug happen because when click menu item it added class `focused`. But only remove this class when using touch (mobile) device with screen width > 767
-> Other devices will have problem

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. run command `npm run build`
2. update theme in test site
3. test issue #1626 

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – #1626

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
