### PR TITLE
Add missing hooked docs in content.php

### DIFF
--- a/content.php
+++ b/content.php
@@ -15,6 +15,7 @@
 	 *
 	 * @hooked storefront_post_header          - 10
 	 * @hooked storefront_post_content         - 30
+	 * @hooked storefront_post_taxonomy        - 40
 	 */
 	do_action( 'storefront_loop_post' );
 	?>


### PR DESCRIPTION
This is just a minor documentation fix, adding a missing `@hooked` entry.

The undocumented hooking that this PR adds happens here:
https://github.com/woocommerce/storefront/blob/55376f5b7cf857428e2df1a2dec1029a47ab2dc5/inc/storefront-template-hooks.php#L63

Note: Build failing because this has not yet been pushed to `wp-env`: https://github.com/WordPress/gutenberg/pull/29800