### PR TITLE
Fix potential error that can occur when product is null on sticky add to cart

### DIFF
--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -799,6 +799,10 @@ if ( ! function_exists( 'storefront_sticky_single_add_to_cart' ) ) {
 	function storefront_sticky_single_add_to_cart() {
 		global $product;
 
+		if ( $product == null ) {
+			return;
+		}
+
 		if ( class_exists( 'Storefront_Sticky_Add_to_Cart' ) || true !== get_theme_mod( 'storefront_sticky_add_to_cart' ) ) {
 			return;
 		}

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -799,15 +799,11 @@ if ( ! function_exists( 'storefront_sticky_single_add_to_cart' ) ) {
 	function storefront_sticky_single_add_to_cart() {
 		global $product;
 
-		if ( $product == null ) {
-			return;
-		}
-
 		if ( class_exists( 'Storefront_Sticky_Add_to_Cart' ) || true !== get_theme_mod( 'storefront_sticky_add_to_cart' ) ) {
 			return;
 		}
 
-		if ( ! is_product() ) {
+		if ( ! $product || ! is_product() ) {
 			return;
 		}
 


### PR DESCRIPTION
<!-- Briefly describe the issue or problem that this PR solves. -->
Sometimes product pages can be presented without a global product as a result of plugins.

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->
Returns out of the sticky add to cart function if the product object is null.

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

We have a certain configuration of plugins that causes this. It may be an edge case in a vanilla installation.

1. Go to a single product page
2. Scroll down until the add to cart button is out of view
3. Confirm the sticky cart shows as normal

### Changelog

> Ensure the product global exists in the sticky add to cart function
