### PR TITLE
Remove deprecated functions

### DIFF
--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -1205,47 +1205,6 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			return true;
 		}
 
-		/**
-		 * Setup the WordPress core custom header feature.
-		 *
-		 * @deprecated 2.4.0
-		 * @return void
-		 */
-		public function custom_header_setup() {
-			if ( function_exists( 'wc_deprecated_function' ) ) {
-				wc_deprecated_function( __FUNCTION__, '2.4.0' );
-			} else {
-				_deprecated_function( __FUNCTION__, '2.4.0' );
-			}
-		}
-
-		/**
-		 * Get Customizer css associated with WooCommerce.
-		 *
-		 * @deprecated 2.4.0
-		 * @return void
-		 */
-		public function get_woocommerce_css() {
-			if ( function_exists( 'wc_deprecated_function' ) ) {
-				wc_deprecated_function( __FUNCTION__, '2.3.1' );
-			} else {
-				_deprecated_function( __FUNCTION__, '2.3.1' );
-			}
-		}
-
-		/**
-		 * Assign Storefront styles to individual theme mods.
-		 *
-		 * @deprecated 2.3.1
-		 * @return void
-		 */
-		public function set_storefront_style_theme_mods() {
-			if ( function_exists( 'wc_deprecated_function' ) ) {
-				wc_deprecated_function( __FUNCTION__, '2.3.1' );
-			} else {
-				_deprecated_function( __FUNCTION__, '2.3.1' );
-			}
-		}
 	}
 
 endif;

--- a/inc/storefront-functions.php
+++ b/inc/storefront-functions.php
@@ -224,24 +224,3 @@ function storefront_sanitize_choices( $input, $setting ) {
 function storefront_sanitize_checkbox( $checked ) {
 	return ( ( isset( $checked ) && true === $checked ) ? true : false );
 }
-
-/**
- * Storefront Sanitize Hex Color
- *
- * @param string $color The color as a hex.
- * @todo remove in 2.1.
- */
-function storefront_sanitize_hex_color( $color ) {
-	_deprecated_function( 'storefront_sanitize_hex_color', '2.0', 'sanitize_hex_color' );
-
-	if ( '' === $color ) {
-		return '';
-	}
-
-	// 3 or 6 hex digits, or the empty string.
-	if ( preg_match( '|^#([A-Fa-f0-9]{3}){1,2}$|', $color ) ) {
-		return $color;
-	}
-
-	return null;
-}

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -597,17 +597,6 @@ if ( ! function_exists( 'storefront_post_nav' ) ) {
 	}
 }
 
-if ( ! function_exists( 'storefront_posted_on' ) ) {
-	/**
-	 * Prints HTML with meta information for the current post-date/time and author.
-	 *
-	 * @deprecated 2.4.0
-	 */
-	function storefront_posted_on() {
-		_deprecated_function( 'storefront_posted_on', '2.4.0' );
-	}
-}
-
 if ( ! function_exists( 'storefront_homepage_content' ) ) {
 	/**
 	 * Display homepage content

--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -128,21 +128,6 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 		}
 
 		/**
-		 * Assign styles to individual theme mod.
-		 *
-		 * @deprecated 2.3.1
-		 * @since 2.1.0
-		 * @return void
-		 */
-		public function set_storefront_style_theme_mods() {
-			if ( function_exists( 'wc_deprecated_function' ) ) {
-				wc_deprecated_function( __FUNCTION__, '2.3.1' );
-			} else {
-				_deprecated_function( __FUNCTION__, '2.3.1' );
-			}
-		}
-
-		/**
 		 * Add WooCommerce specific classes to the body tag
 		 *
 		 * @param  array $classes css classes applied to the body tag.


### PR DESCRIPTION
This PR removes functions that got deprecated in Storefront 2.4.0 or earlier versions.
### Changelog

> Dev – Remove deprecated functions. https://github.com/woocommerce/storefront/pull/1652

