### PR TITLE
Set consistent sale badge background (#1509)

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1863,6 +1863,7 @@ p.stars {
 .onsale {
 	border: 1px solid;
 	border-color: $color_body;
+	background: $body-background;
 	color: $color_body;
 	padding: 0.202em ms(-2);
 	font-size: ms(-1);


### PR DESCRIPTION
Fixes #1509 

The sale badge styles should be consistent independently of which page they are displayed on.

I simply set the sales background color to $body-background color. Maybe an improvement could be allowing set sale badge text forecolor and background color through customizer.

### Screenshots
Shop page before
<img width="839" alt="shop_screenshot_before" src="https://user-images.githubusercontent.com/11697084/115780724-64c36d00-a3b1-11eb-8b5d-0f809f81ca85.png">

Single product before
<img width="834" alt="single_product_screenshot_before" src="https://user-images.githubusercontent.com/11697084/115780772-7442b600-a3b1-11eb-8439-1a342b5e4b7e.png">

Related products before
<img width="909" alt="related_products_screenshot_before" src="https://user-images.githubusercontent.com/11697084/115780794-7a389700-a3b1-11eb-93d5-eec6c7717a1e.png">

Shop page after
<img width="845" alt="shop_screenshot_after" src="https://user-images.githubusercontent.com/11697084/115780947-b10ead00-a3b1-11eb-84ba-4d053d1b9d2e.png">

Single product after
<img width="831" alt="single_product_screenshot_after" src="https://user-images.githubusercontent.com/11697084/115780992-bd930580-a3b1-11eb-9eb6-5597f97aa17c.png">

Related products after
<img width="921" alt="related_products_screenshot_after" src="https://user-images.githubusercontent.com/11697084/115781016-c5eb4080-a3b1-11eb-8332-af58c9e5d9d6.png">

### How to test the changes in this Pull Request:

1.Build CSS `npm run css`
2.Make sure you have at least one product on sale.
3.Create a page with the Handpicked products block and select a product on sale.
4.View it in the frontend and notice the sale badge has a white background.
5.Go to the single product page and inspect the related products. Notice the sale badge has a white background too.

### Changelog

<!-- Add suggested changelog entry here. For example: -->
> Fix - Set consistent sale badge background. #1509