### PR TITLE
Hide spinner when Payment Request button is disabled

### DIFF
--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -615,6 +615,16 @@ a.remove {
 	}
 }
 
+.wc_request_button_is_disabled {
+
+	.blockUI {
+
+		&::before {
+			content: none;
+		}
+	}
+}
+
 .woocommerce-pagination {
 
 	.next,

--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -618,6 +618,7 @@ a.remove {
 .wc_request_button_is_disabled {
 
 	.blockUI {
+		cursor: not-allowed !important;
 
 		&::before {
 			content: none;


### PR DESCRIPTION
Fixes: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1539

We are adding an additional "disabled" state to the Payment Request button in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1542

The behavior for the "disabled" state will be exactly the same as with the "blocked" state with the only difference being the "spinner" icon won't be displayed.

This PR hides the icon only when the "wc_request_button_is_disabled" is present. This way it won't affect previous versions of the theme even when using older versions of the `woocommerce-gateway-stripe` plugin.

### Screenshots

Blocked state

<img width="713" alt="Screen Shot 2021-05-03 at 10 24 18 PM" src="https://user-images.githubusercontent.com/1025173/116957768-4e919880-ac5e-11eb-9550-03541f383441.png">

Disabled state

<img width="693" alt="Screen Shot 2021-05-03 at 10 24 48 PM" src="https://user-images.githubusercontent.com/1025173/116957795-60733b80-ac5e-11eb-8dad-3212fd95c43c.png">

### How to test the changes in this Pull Request:

Change introduced here is pretty straightforward. Testing it locally will require to install `woocommerce-payment-setup` and set up Stripe in dev mode. Then checkout to this PR https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1542 then trigger the changes manually via JS like in the screenshots above. Let me know if you need detailed steps. I wasn't able to use `npm run wp-env` with WC Stripe.