### PR TITLE
Include prettier alias as a dependency

### DIFF
--- a/assets/js/sticky-add-to-cart.js
+++ b/assets/js/sticky-add-to-cart.js
@@ -76,15 +76,14 @@
 							'storefront-sticky-add-to-cart__content-button'
 						);
 
-						selectOptions[ 0 ].addEventListener(
-							'click',
-							function ( event ) {
-								event.preventDefault();
-								document
-									.getElementById( 'product-' + productId )
-									.scrollIntoView();
-							}
-						);
+						selectOptions[ 0 ].addEventListener( 'click', function (
+							event
+						) {
+							event.preventDefault();
+							document
+								.getElementById( 'product-' + productId )
+								.scrollIntoView();
+						} );
 					}
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16805,6 +16805,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "npm:wp-prettier@2.0.5",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
+      "integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+      "dev": true
+    },
     "prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
 		"onchange": "7.1.0",
 		"postcss-cli": "8.3.1",
 		"puppeteer": "9.1.1",
+		"prettier": "npm:wp-prettier@2.0.5",
 		"rtlcss": "3.1.2",
 		"susy": "2.2.14",
 		"uglify-js": "3.13.6"


### PR DESCRIPTION
JavaScript linting job seems to be failing due to a missing prettier dependency (see #1677). This PR adds prettier to the list of dependencies linking to the `wp-prettier` version.

### How to test the changes in this Pull Request:

1. Verify all GitHub actions pass in this PR.
2. Run `npm run lint:js:report` locally and verify no errors appear.
