### PR TITLE
remove-full-width-image-mobile-margin-1585: remove full width image block margins on mobile

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -19,24 +19,25 @@
  * Front-end only styles
  */
 .hentry .entry-content {
+
+	.storefront-align-wide.page-template-template-fullwidth-php & .alignfull,
+	.storefront-align-wide.storefront-full-width-content & .alignfull {
+		margin-left: calc(50% - 50vw);
+		margin-right: calc(50% - 50vw);
+	}
+
 	// Global
 	@media ( min-width: $container-width ) {
 
 		.storefront-align-wide.page-template-template-fullwidth-php &,
 		.storefront-align-wide.storefront-full-width-content & {
 
-			.alignfull,
 			.alignwide {
 				width: auto;
 				max-width: 1000%;
 				padding-left: ms(2);
 				padding-right: ms(2);
 				clear: both;
-			}
-
-			.alignfull {
-				margin-left: calc(50% - 50vw);
-				margin-right: calc(50% - 50vw);
 			}
 
 			.alignwide {


### PR DESCRIPTION
Moved styles targeting entry content full width images from applying only on 1024+ to apply on all viewport sizes.  This fixes the issue of image blocks marked as full width not going full width on mobile.

**Steps to test the fix** (originally posted here: https://github.com/woocommerce/storefront/issues/1585#issue-786076052):
- Add an Image block to a new page, set it to full width;
- Make sure the page's template is also set to Full Width, and save/publish the changes;
- Open the created page on a browser with at least 1064px width. Verify that the image is full width.
- Switch to browser responsive mode and reduce the screen size to 1063px width or less. Verify that there are no margins on both sides.

**Before Fix**
![Screen Shot 2021-06-23 at 11 23 54 AM](https://user-images.githubusercontent.com/1033613/123149063-bc17a500-d415-11eb-9c5c-90cea2c00821.png)
![Screen Shot 2021-06-23 at 11 23 35 AM](https://user-images.githubusercontent.com/1033613/123149070-be79ff00-d415-11eb-9c6f-709f0b871d5c.png)

**After Fix**
![Screen Shot 2021-06-23 at 11 21 45 AM](https://user-images.githubusercontent.com/1033613/123149169-d6ea1980-d415-11eb-84af-943e05f234e6.png)
![Screen Shot 2021-06-23 at 11 21 32 AM](https://user-images.githubusercontent.com/1033613/123149177-d94c7380-d415-11eb-9673-b522ee8a55f4.png)
