### PR TITLE
Fix hidden disclosure arrow on <summary> tags

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -48,6 +48,11 @@ select {
 	max-width: 100%;
 }
 
+// Fix outdated summary style from _normalize.scss which prevents the arrow from appearing
+summary {
+	display: list-item;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
This PR closes #1720 and adds a proper fix to the summary bug caused because of the outdated version of normalize.css.

## Testing steps
Create a page with a custom HTML block containing the following markup:
```
<details>
  <summary>Summary</summary>
  <ul>
    <li>Details</li>
    <li>Details</li>
    <li>Details</li>
</ul>
</details>
```
The summary should show, complete with a disclosure arrow to indicate that it is expandable:
![Screenshot 2021-06-30 at 09 43 56](https://user-images.githubusercontent.com/1097338/123930611-d3abdc00-d987-11eb-9246-42a2aff8557e.png)
