### PR TITLE
Prevent search widget styles leaking into the Search block when added to a widget area

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -1535,7 +1535,7 @@ button.menu-toggle {
 .widget_search,
 .widget_product_search {
 
-	form {
+	form:not(.wp-block-search) {
 		position: relative;
 
 		input[type="text"],

--- a/assets/css/base/icons.scss
+++ b/assets/css/base/icons.scss
@@ -199,7 +199,7 @@ input[type="submit"],
 .widget_search,
 .widget_product_search {
 
-	form {
+	form:not(.wp-block-search) {
 
 		&::before {
 


### PR DESCRIPTION
Fixes #1745.

Some selectors targeting the Search widget were also affecting the Search block when added to a widget area.

### How to test the changes in this Pull Request:

1. With WordPress 5.8, go to Appearance > Widgets.
2. Add the Search block into the sidebar.
3. Go to the frontend, and verify there isn't a magnifier icon which overlaps the label:

| Before | After |
| --- | --- |
| ![Screenshot before](https://user-images.githubusercontent.com/3616980/127869784-79eef702-5e80-4b81-81ab-37663f14f822.png) | <img alt="Screenshot after" src="https://user-images.githubusercontent.com/3616980/128709774-e3519c44-b10c-4870-956d-d7f803876053.png" width="253" /> |

4. Try toggling some attributes of the Search block and verify it's displayed as expected in the frontend.

### Changelog

> Fix – Several visual issues when a Search block was added to a widget area.