### PR TITLE
Add width:auto to full width images

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -24,6 +24,7 @@
 	.storefront-align-wide.storefront-full-width-content & .alignfull {
 		margin-left: calc(50% - 50vw);
 		margin-right: calc(50% - 50vw);
+		width: auto;
 	}
 
 	// Global


### PR DESCRIPTION
This is required because on the Cover block, the image was set to 100% width which meant it didn't stretch the entire width of its parent if the image was smaller than the parent's width.

Changing this will cause the image to stretch, respecting the full width setting from the Cover block.

<!-- Reference any related issues or PRs here -->
See this comment: https://github.com/woocommerce/storefront/pull/1713#issuecomment-900976617
Fixes #1761 

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/129880416-6ff7d66e-fb53-478e-8938-ca1360c614e0.png) | ![image](https://user-images.githubusercontent.com/5656702/129880548-df2435b6-75b9-4a5c-a275-b4aa3eca2669.png) |
### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Add a cover block to a page using the `Full width` template on your site.
2. Set the cover to be full width too.
3. Visit the page and ensure the block covers the full width of the page.
4. Also use a regular image block and ensure it respects the various width settings.


### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix - The image shown in the Cover block will now respect the full-width setting.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
