### PR TITLE
Update Woo's default colour

### DIFF
--- a/assets/css/sass/utils/_variables.scss
+++ b/assets/css/sass/utils/_variables.scss
@@ -14,7 +14,7 @@ $body-background:   #fff;
 $color_body:        #43454b;
 $color_links:       #2c2d33;
 $color_border:      rgba(0, 0, 0, 0.05);
-$color_woocommerce: #96588a;
+$color_woocommerce: #7f54b3;
 $error:             #e2401c;
 $success:           #0f834d;
 $info:              #3d9cd2;

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				$args = array(
 					'storefront_heading_color'           => '#333333',
 					'storefront_text_color'              => '#6d6d6d',
-					'storefront_accent_color'            => '#96588a',
+					'storefront_accent_color'            => '#7f54b3',
 					'storefront_hero_heading_color'      => '#000000',
 					'storefront_hero_text_color'         => '#000000',
 					'storefront_header_background_color' => '#ffffff',
@@ -232,7 +232,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			$wp_customize->add_setting(
 				'storefront_accent_color',
 				array(
-					'default'           => apply_filters( 'storefront_default_accent_color', '#96588a' ),
+					'default'           => apply_filters( 'storefront_default_accent_color', '#7f54b3' ),
 					'sanitize_callback' => 'sanitize_hex_color',
 				)
 			);


### PR DESCRIPTION
The Woo default colour has changed from #96588a to #7f54b3. This PR replaces all instances of the old colour with the new colour. 

To test:

* Install Storefront from scratch -- look for the purple
* Specifically in the customizer -> color the default/accent colour will be updated