### PR TITLE
Avoid text in buttons breaking in the middle of words

### DIFF
--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -949,6 +949,10 @@ input[type="submit"],
 	}
 }
 
+.button.woocommerce-MyAccount-downloads-file {
+	@include wrap-break-word;
+}
+
 .wc-block-components-button:not(.is-link).disabled,
 .wc-block-components-button:not(.is-link):disabled {
 	opacity: 0.5;

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -910,7 +910,6 @@ input[type="submit"],
 	text-shadow: none;
 	display: inline-block;
 	-webkit-appearance: none;
-	word-break: break-all;
 
 	&::after {
 		display: none;


### PR DESCRIPTION
Fixes #1787.

[Testing instructions](https://github.com/woocommerce/storefront/pull/1797#issuecomment-927186601)

- Revert "Fixed buttons word break (#1624)"
- fix/1787: add break word mixin to fix button word break issue on download buttons with long text
