### PR TITLE
Fix Dart Sass deprecation warnings

### DIFF
--- a/assets/css/base/gutenberg-blocks.scss
+++ b/assets/css/base/gutenberg-blocks.scss
@@ -1,5 +1,7 @@
 // Bourbon
 // See: https://www.bourbon.io/docs/latest/
+@use "sass:math";
+
 @import "bourbon";
 
 // Susy
@@ -243,7 +245,7 @@
 			@for $i from 2 through 6 {
 				&.columns-#{$i} li {
 					margin-right: gutter(12);
-					width: span(12 / $i);
+					width: span(math.div(12, $i));
 
 					&:nth-of-type( #{$i}n ) {
 						margin-right: 0;
@@ -256,7 +258,7 @@
 				@for $i from 2 through 6 {
 					&.columns-#{$i} li {
 						margin-right: gutter(9);
-						width: span(9 / $i);
+						width: span(math.div(9, $i));
 
 						&:nth-of-type( #{$i}n ) {
 							margin-right: 0;
@@ -511,7 +513,7 @@
 				&.columns-#{$i} .blocks-gallery-image,
 				&.columns-#{$i} .blocks-gallery-item {
 					margin-right: gutter(12);
-					width: ( 100% - ( gutter(12) * ( $i - 1 ) ) ) / $i;
+					width: math.div(100% - ( gutter(12) * ( $i - 1 ) ), $i);
 
 					&:nth-of-type( #{$i}n ) {
 						margin-right: 0;
@@ -531,7 +533,7 @@
 					&.columns-#{$i} .blocks-gallery-image,
 					&.columns-#{$i} .blocks-gallery-item {
 						margin-right: gutter(9);
-						width: ( 100% - ( gutter(9) * ( $i - 1 ) ) ) / $i;
+						width: math.div(100% - ( gutter(9) * ( $i - 1 ) ), $i);
 
 						&:nth-of-type( #{$i}n ) {
 							margin-right: 0;

--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -1,5 +1,7 @@
 // Bourbon
 // See: https://www.bourbon.io/docs/latest/
+@use "sass:math";
+
 @import "bourbon";
 
 // Susy
@@ -301,8 +303,8 @@ table {
 
 // Main content width
 .wp-block {
-	$span-value: span(9) / 100;
-	max-width: calc(#{$container-width} * #{$span-value / ( $span-value * 0 + 1 )}); // Unitless hack.
+	$span-value: span(9) * 0.01;
+	max-width: calc(#{$container-width} * #{math.div($span-value, $span-value * 0 + 1)}); // Unitless hack.
 }
 
 .wp-block[data-align="wide"] {

--- a/assets/css/sass/vendors/font-awesome/_larger.scss
+++ b/assets/css/sass/vendors/font-awesome/_larger.scss
@@ -2,9 +2,11 @@
 // -------------------------
 
 // makes the font 33% larger relative to the icon container
+@use "sass:math";
+
 .#{$fa-css-prefix}-lg {
-  font-size: (4em / 3);
-  line-height: (3em / 4);
+  font-size: math.div(4em, 3);
+  line-height: (3em * 0.25);
   vertical-align: -.0667em;
 }
 

--- a/assets/css/sass/vendors/font-awesome/_list.scss
+++ b/assets/css/sass/vendors/font-awesome/_list.scss
@@ -3,7 +3,7 @@
 
 .#{$fa-css-prefix}-ul {
   list-style-type: none;
-  margin-left: $fa-li-width * 5/4;
+  margin-left: $fa-li-width * 5*0.25;
   padding-left: 0;
 
   > li { position: relative; }

--- a/assets/css/sass/vendors/font-awesome/_variables.scss
+++ b/assets/css/sass/vendors/font-awesome/_variables.scss
@@ -1,6 +1,8 @@
 // Variables
 // --------------------------
 
+@use "sass:math";
+
 $fa-font-path:         "../webfonts" !default;
 $fa-font-size-base:    16px !default;
 $fa-font-display:      block !default;
@@ -9,7 +11,7 @@ $fa-version:           "5.13.0" !default;
 $fa-border-color:      #eee !default;
 $fa-inverse:           #fff !default;
 $fa-li-width:          2em !default;
-$fa-fw-width:          (20em / 16);
+$fa-fw-width:          math.div(20em, 16);
 $fa-primary-opacity:   1 !default;
 $fa-secondary-opacity: .4 !default;
 

--- a/assets/css/sass/vendors/modular-scale/_function.scss
+++ b/assets/css/sass/vendors/modular-scale/_function.scss
@@ -1,4 +1,6 @@
 // The main function that brings it all together
+@use "sass:math";
+
 @function ms($Value: 0, $Bases: $ms-base, $Ratios: $ms-ratio) {
 
   // If no multi-base or multi-ratio stuff is going on
@@ -14,7 +16,7 @@
     $Unit: nth($Bases, 1) * 0 + 1; // Extracts the unit from the base
     $Unitless-Bases: ();
     @each $Base in $Bases {
-      $Base: $Base/$Unit;
+      $Base: math.div($Base, $Unit);
       $Unitless-Bases: join($Unitless-Bases, $Base);
     }
 

--- a/assets/css/sass/vendors/modular-scale/_pow.scss
+++ b/assets/css/sass/vendors/modular-scale/_pow.scss
@@ -1,11 +1,13 @@
 // If a native exponent function doesnt exist
 // this one is needed.
+@use "sass:math";
+
 @function ms-pow($Base, $Exponent) {
 
   // Find and remove unit.
   // Avoids messyness with unit calculations
   $Unit: $Base * 0 + 1;
-  $Base: $Base/$Unit;
+  $Base: math.div($Base, $Unit);
 
   // This function doesnt support non-interger exponents.
   // Warn the user about why this is breaking.
@@ -30,7 +32,7 @@
   @else {
     // Libsass doesnt allow negitive values in loops
     @for $i from (-1 + 1) to (abs($Exponent) + 1) {
-      $Return: $Return / $Base;
+      $Return: math.div($Return, $Base);
     }
   }
 

--- a/assets/css/sass/vendors/modular-scale/_respond.scss
+++ b/assets/css/sass/vendors/modular-scale/_respond.scss
@@ -1,7 +1,9 @@
 // Stripping units is rarely a best practice and this function
 // should not be used elsewhere
+@use "sass:math";
+
 @function ms-unitless($val) {
-  $val: $val / ($val - $val + 1);
+  $val: math.div($val, $val - $val + 1);
   @return $val;
 }
 


### PR DESCRIPTION
Fixes #1828

When running `npm run build`, many deprecation warnings regarding Dart Sass 2.0.0 appeared. This PR aims to fix these deprecation warnings, to ensure that SCSS files can be built once Dart Sass 2.0.0 was released and to ensure that `npm run build` can be run without any warnings.

### How to test the changes in this Pull Request:

1. Check out this PR.
2. Run `npm i && npm run build`.
3. Ensure that no more deprecation warnings are visible.
4. Run `nom run build:css` and ensure that the generated CSS files haven't changed.

### Changelog

> Fix – Replace SCSS division with math.div(), as the current division is deprecated and will be removed with Dart Sass 2.0.0.
