### PR TITLE
Fix command for launch e2e test #1839

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"lint:js-fix": "eslint assets/js --ext=js,jsx,ts,tsx --fix",
 		"lint:php": "composer run-script phpcs ./inc",
 		"wp-env": "wp-env",
-		"test:e2e": "jest"
+		"test:e2e": "npm run wp-env run tests-cli 'wp theme activate storefront' && jest"
 	},
 	"jest": {
 		"preset": "jest-puppeteer",


### PR DESCRIPTION
In accordance with WordPress/gutenberg#26766, now it's no longer possible to activate a certain theme via `.wp-env.json`. This causes the end-to-end tests to fail.

This PR updates the command for launch e2e test, activating the theme first and after launching the e2e test.

(Kudos to @nielslange for sharing in the issue the new command)


<!-- Reference any related issues or PRs here -->
Fixes #1839

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

Check out the trunk.
Start Docker Desktop.
Open the terminal and run npm run wp-env && npm run test:e2e.
See that the e2e test is broken.

1. Start Docker Desktop
2. Open the terminal 
3. Run `npm run build`
4. Run `npm run test:e2e`
5. Check that the e2e test dosn't fail
