### PR TITLE
fix: composer 2.2+ excludes handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
 	"archive": {
 		"exclude": [
 			"!/assets",
-			"/assets/css/sass",
-			"/assets/css/**/*.scss",
 			"!/languages",
 			"!/style.css",
 			"!/style-rtl.css",
 			"/assets/css/sass",
+			"/assets/css/**/*.scss",
 			"/e2e",
+			"/vendor",
 			"composer.json",
 			"composer.lock",
 			"package.json",
@@ -28,15 +28,8 @@
 			"STOREFRONT_STATUS.md",
 			"renovate.json",
 			"node_modules",
-			".stylelintrc.json",
-			".stylelintignore",
-			".editorconfig",
-			".gitignore",
-			".github",
-			".browserslistrc",
-			".eslintrc.js",
-			".prettierrc.js",
-			".wp-env.json"
+			"storefront.zip",
+			".*"
 		]
 	},
 	"require-dev": {
@@ -72,6 +65,12 @@
 			"test": "Run unit tests",
 			"phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
 			"phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"composer/installers": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
 		"exclude": [
 			"!/assets",
 			"!/languages",
+			"!/vendor",
 			"!/style.css",
 			"!/style-rtl.css",
 			"/assets/css/sass",
 			"/assets/css/**/*.scss",
 			"/e2e",
-			"/vendor",
 			"composer.json",
 			"composer.lock",
 			"package.json",


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes composer 2.2+ handling of archive excludes [as reported](https://teamrubik.wordpress.com/2022/02/11/tuesday-release-on-thursday-10th-feb-2022/#:~:text=Composer%20v2.2.0%2B%20ignores%20.gitignore%20file) by Alex Florsica 

|  | build size |
|-|-|
|before | ~5.1MB (or double if zip included) |
|after | ~2.8MB |

### Steps to test

1. Build package
2. ensure `vendors` or `node_modules` and other hidden or not needed files are not included
3. ensure old zip archive file is not included if it was present


### Notes

🟠  This can wait for next feature/fix release, changes affect only DX and build pipeline


### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – update composer.json to Composer 2.2 archive excludes handling.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
