### PR TITLE
Add support for sub menu description

### DIFF
--- a/assets/css/base/_layout.scss
+++ b/assets/css/base/_layout.scss
@@ -448,6 +448,7 @@
 				position: relative;
 				display: inline-block;
 				text-align: left;
+				vertical-align: text-top;
 
 				a {
 					display: block;

--- a/assets/css/base/_layout.scss
+++ b/assets/css/base/_layout.scss
@@ -630,8 +630,13 @@
 				text-decoration: none;
 			}
 
-			ul {
+			.menu-item-description {
+				font-size: ms(-1);
+				opacity: 0.67;
+				margin: 1em 0 0;
+			}
 
+			ul {
 				a {
 					padding: 0.326em ms(-1);
 					background: rgba(#000, 0.05);


### PR DESCRIPTION
Fixes #1595

This PR is an extension of #1771 and adds support for the submenu description. @gigitux mentioned this specific problem in https://github.com/woocommerce/storefront/pull/1771#issuecomment-1087301359.

In this PR, I simply enhanced the SCSS styles to style the descriptions of both the menu and the submenu items similar.

### Screenshots

<table>
<tr>
<td>Before:
<br><br>

![#1595-before](https://user-images.githubusercontent.com/3323310/161521300-9c236104-3d26-4716-ba14-f797aa8d5ecf.png)
</td>
<td>After:
<br><br>

![#1595-after](https://user-images.githubusercontent.com/3323310/161521291-d9ed56e7-1112-42b9-9b77-02cf9e7228d9.png)
</td>
</tr>
</table>

### How to test the changes in this Pull Request:

1. Go to `/wp-admin/nav-menus.php`.
2. Click on screen options in the upper-right corner and activate the option `Description` within `Show advanced menu properties`.
3. Create a custom menu and assign it to the menu location ` Secondary Menu`.
4. Add 2-3 menu items with a description.

### Changelog

> Add support for submenu description.