### PR TITLE
Fix the development blog link

### DIFF
--- a/inc/admin/class-storefront-admin.php
+++ b/inc/admin/class-storefront-admin.php
@@ -73,7 +73,7 @@ if ( ! class_exists( 'Storefront_Admin' ) ) :
 					<ul>
 						<li><a href="https://wordpress.org/support/theme/storefront" target="_blank"><?php esc_html_e( 'Support', 'storefront' ); ?></a></li>
 						<li><a href="https://docs.woocommerce.com/documentation/themes/storefront/" target="_blank"><?php esc_html_e( 'Documentation', 'storefront' ); ?></a></li>
-						<li><a href="https://woocommerce.wordpress.com/category/storefront/" target="_blank"><?php esc_html_e( 'Development blog', 'storefront' ); ?></a></li>
+						<li><a href="https://developer.woocommerce.com/category/release-post/storefront-theme-release-notes/" target="_blank"><?php esc_html_e( 'Development blog', 'storefront' ); ?></a></li>
 					</ul>
 				</section>
 


### PR DESCRIPTION
Update the `Development blog` link to point to the ["Storefront Theme Release Notes"](https://developer.woocommerce.com/category/release-post/storefront-theme-release-notes/), it was failing with a 404.

Fixes https://github.com/woocommerce/storefront/issues/2020

### How to test the changes in this Pull Request:

1. Install the Storefront theme.
2. Go to `/wp-admin/themes.php?page=storefront-welcome`.
3. Click on the `Development blog` link on the header.
4. Make sure it goes to the Storefront release notes and does not return a 404.

### Changelog

> Fix: update the "Development blog" link.
