### PR TITLE
Remove styling from No Products filter results.

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1931,7 +1931,7 @@ p.stars {
 }
 
 .woocommerce-message,
-body:not(.archive.woocommerce) .woocommerce-info,
+.woocommerce-info,
 .woocommerce-error,
 .woocommerce-noreviews,
 p.no-comments {
@@ -2027,11 +2027,24 @@ p.no-comments {
 	list-style: none;
 }
 
-body:not(.archive.woocommerce) .woocommerce-info,
+.woocommerce-info,
 .woocommerce-noreviews,
 p.no-comments {
 	background-color: $info;
 }
+
+p.woocommerce-info.woocommerce-no-products-found {
+	background-color: transparent;
+	border: none;
+	color: inherit;
+	padding: 1em 2em;
+
+	&::before,
+	&::after {
+		content: none;
+	}
+}
+
 
 .woocommerce-error {
 	background-color: $error;

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1931,7 +1931,7 @@ p.stars {
 }
 
 .woocommerce-message,
-.woocommerce-info,
+body:not(.post-type-archive-product) .woocommerce-info,
 .woocommerce-error,
 .woocommerce-noreviews,
 p.no-comments {
@@ -2027,7 +2027,7 @@ p.no-comments {
 	list-style: none;
 }
 
-.woocommerce-info,
+body:not(.post-type-archive-product) .woocommerce-info,
 .woocommerce-noreviews,
 p.no-comments {
 	background-color: $info;

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1931,7 +1931,7 @@ p.stars {
 }
 
 .woocommerce-message,
-body:not(.post-type-archive-product) .woocommerce-info,
+body:not(.archive.woocommerce) .woocommerce-info,
 .woocommerce-error,
 .woocommerce-noreviews,
 p.no-comments {
@@ -2027,7 +2027,7 @@ p.no-comments {
 	list-style: none;
 }
 
-body:not(.post-type-archive-product) .woocommerce-info,
+body:not(.archive.woocommerce) .woocommerce-info,
 .woocommerce-noreviews,
 p.no-comments {
 	background-color: $info;

--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -2033,11 +2033,11 @@ p.no-comments {
 	background-color: $info;
 }
 
-p.woocommerce-info.woocommerce-no-products-found {
+.woocommerce-info.woocommerce-no-products-found {
 	background-color: transparent;
 	border: none;
 	color: inherit;
-	padding: 1em 2em;
+	padding: 1em 0;
 
 	&::before,
 	&::after {

--- a/assets/js/sticky-add-to-cart.js
+++ b/assets/js/sticky-add-to-cart.js
@@ -76,14 +76,15 @@
 							'storefront-sticky-add-to-cart__content-button'
 						);
 
-						selectOptions[ 0 ].addEventListener( 'click', function (
-							event
-						) {
-							event.preventDefault();
-							document
-								.getElementById( 'product-' + productId )
-								.scrollIntoView();
-						} );
+						selectOptions[ 0 ].addEventListener(
+							'click',
+							function ( event ) {
+								event.preventDefault();
+								document
+									.getElementById( 'product-' + productId )
+									.scrollIntoView();
+							}
+						);
 					}
 				}
 			}

--- a/assets/js/woocommerce/extensions/brands.js
+++ b/assets/js/woocommerce/extensions/brands.js
@@ -15,8 +15,8 @@
 		const adminBar = document.body.classList.contains( 'admin-bar' )
 				? 32
 				: 0,
-			brandsContainerHeight = document.getElementById( 'brands_a_z' )
-				.scrollHeight,
+			brandsContainerHeight =
+				document.getElementById( 'brands_a_z' ).scrollHeight,
 			brandsAZHeight = brandsAZ[ 0 ].scrollHeight + 40;
 
 		const stickyBrandsAZ = function () {


### PR DESCRIPTION
This is a small styling update that omits the `.woocommerce-info` styles on the filter results notification when no products match the filter.

See pdnLyh-1cy-p2 for additional context.

<!-- Reference any related issues or PRs here -->
Fixes #2026.

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
| Before | After |
| ------ | ----- |
|  ![CleanShot 2022-08-11 at 15 07 47](https://user-images.githubusercontent.com/481776/184220101-f53c93c9-017e-4542-ab33-ee454bb0d29f.png)    |  ![CleanShot 2022-08-11 at 15 05 09](https://user-images.githubusercontent.com/481776/184220090-ed30bdfe-c7c4-4240-b027-725fe2aff24a.png)   |


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. With the Storefront theme active, go to your site's Store page (displaying the WooCommerce Product Catalog) and add some filter blocks (e.g., Filter Products by Price, Filter Products by Attribute, etc.). You can add this directly on the page or in a widget area.
2. View the frontend and set your filters to where no products will match and be displayed.
3. Inspect the **No products** banner to see if it has a `woocommerce-no-products-found` class. If it does not, add that class via the inspector to see the changes in this PR take effect (the output for the banner comes from [this notice in WC Core](https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/templates/loop/no-products-found.php#L21) - see screenshot below).
4. Confirm the **No products** message appears as it does in the "After" screenshot above (with no blue banner styling).
5. Confirm no related JS or PHP errors.

![CleanShot 2022-08-17 at 16 02 48](https://user-images.githubusercontent.com/481776/185232649-67c80922-d0ab-40bc-b33e-ec2333c2557c.png)


<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->


### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Enhancement - Remove styling from No Products filter results. #2026

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
