### PR TITLE
Stop theme defaults from overriding the Featured Item blocks text color

### DIFF
--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -1254,7 +1254,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				/* WP <=5.3 */
 				.editor-styles-wrapper .editor-block-list__block,
 				/* WP >=5.4 */
-				.editor-styles-wrapper .block-editor-block-list__block {
+				.editor-styles-wrapper .block-editor-block-list__block:not(.wp-block-woocommerce-featured-product):not(.wp-block-woocommerce-featured-category) {
 					color: ' . $storefront_theme_mods['text_color'] . ';
 				}
 

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -858,7 +858,11 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * @package  storefront
 			 * @since    2.0.0
 			 */
+<<<<<<< HEAD
 			$brighten_factor = apply_filters( 'storefront_brighten_factor', 25 );
+=======
+			$brighten_factor       = apply_filters( 'storefront_brighten_factor', 25 );
+>>>>>>> f7bdc6c5 (Add docblocks to hooks used in customizer class.)
 			/**
 			 * Filters for darkening color value.
 			 *
@@ -866,7 +870,11 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * @package  storefront
 			 * @since    2.0.0
 			 */
+<<<<<<< HEAD
 			$darken_factor = apply_filters( 'storefront_darken_factor', -25 );
+=======
+			$darken_factor         = apply_filters( 'storefront_darken_factor', -25 );
+>>>>>>> f7bdc6c5 (Add docblocks to hooks used in customizer class.)
 
 			$styles = '
 			.main-navigation ul li a,

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -858,11 +858,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * @package  storefront
 			 * @since    2.0.0
 			 */
-<<<<<<< HEAD
 			$brighten_factor = apply_filters( 'storefront_brighten_factor', 25 );
-=======
-			$brighten_factor       = apply_filters( 'storefront_brighten_factor', 25 );
->>>>>>> f7bdc6c5 (Add docblocks to hooks used in customizer class.)
 			/**
 			 * Filters for darkening color value.
 			 *
@@ -870,11 +866,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 			 * @package  storefront
 			 * @since    2.0.0
 			 */
-<<<<<<< HEAD
 			$darken_factor = apply_filters( 'storefront_darken_factor', -25 );
-=======
-			$darken_factor         = apply_filters( 'storefront_darken_factor', -25 );
->>>>>>> f7bdc6c5 (Add docblocks to hooks used in customizer class.)
 
 			$styles = '
 			.main-navigation ul li a,

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -1254,8 +1254,14 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 				/* WP <=5.3 */
 				.editor-styles-wrapper .editor-block-list__block,
 				/* WP >=5.4 */
-				.editor-styles-wrapper .block-editor-block-list__block:not(.wp-block-woocommerce-featured-product):not(.wp-block-woocommerce-featured-category) {
+				.editor-styles-wrapper .block-editor-block-list__block:not(:has(div.has-background-dim)) {
 					color: ' . $storefront_theme_mods['text_color'] . ';
+				}
+				/* This following ruleset is a fallback for browsers that do not support the :has() selector. It can be removed once support reaches our requirements. */
+				@supports not (selector(:has(*))) {
+					.editor-styles-wrapper .block-editor-block-list__block:not(.wp-block-woocommerce-featured-product, .wp-block-woocommerce-featured-category) {
+						color: ' . $storefront_theme_mods['text_color'] . ';
+					}
 				}
 
 				.editor-styles-wrapper a,


### PR DESCRIPTION
### Summary

By omitting the Featured Items blocks from the Storefront Customizer ruleset that sets the default text color, we allow the block to use it's set default of white text over the background overlay, improving color contrast. This also allows custom and global styles to be applied correctly, where applicable.

<!-- Reference any related issues or PRs here -->
Fixes #2036 

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
| Before | After |
| ------ | ----- |
|  ![Screen Shot 2022-09-06 at 10 14 27 PM](https://user-images.githubusercontent.com/481776/188970489-5699091e-9424-4f14-9e32-7b14b39501cf.png)  |   ![Screen Shot 2022-09-06 at 10 33 36 PM](https://user-images.githubusercontent.com/481776/188970565-69c2ef2d-0749-46ac-871b-889976907893.png)  |


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Activate the Storefront theme.
2. Add the Featured Product block to a page.
3. Select a product.
4. Confirm that the default color of the text inside is white (as seen in _after_ screenshot above).
5. Change the color using the picker to a custom one (not included in the default palette).
6. The color of the text should change.
7. Repeat steps 2–6 with the Featured Category block.


### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – Featured Item Blocks: omit customizer styles to prevent Storefront from overriding block defaults and preventing custom colors from being applied correctly.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
