### PR TITLE
Add actions to single product pagination and sticky add-to-cart template functions

### DIFF
--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -770,23 +770,45 @@ if ( ! function_exists( 'storefront_single_product_pagination' ) ) {
 			return;
 		}
 
+		do_action( 'storefront_before_single_product_pagination' );
+
 		?>
 		<nav class="storefront-product-pagination" aria-label="<?php esc_attr_e( 'More products', 'storefront' ); ?>">
-			<?php if ( $previous_product ) : ?>
+			<?php
+			if ( $previous_product ) {
+
+				do_action( 'storefront_before_single_product_pagination_previous' );
+				?>
+
 				<a href="<?php echo esc_url( $previous_product->get_permalink() ); ?>" rel="prev">
 					<?php echo wp_kses_post( $previous_product->get_image() ); ?>
 					<span class="storefront-product-pagination__title"><?php echo wp_kses_post( $previous_product->get_name() ); ?></span>
 				</a>
-			<?php endif; ?>
 
-			<?php if ( $next_product ) : ?>
+				<?php
+
+				do_action( 'storefront_after_single_product_pagination_previous' );
+
+			}
+			
+			if ( $next_product ) {
+
+				do_action( 'storefront_before_single_product_pagination_next' );
+				?>
+
 				<a href="<?php echo esc_url( $next_product->get_permalink() ); ?>" rel="next">
 					<?php echo wp_kses_post( $next_product->get_image() ); ?>
 					<span class="storefront-product-pagination__title"><?php echo wp_kses_post( $next_product->get_name() ); ?></span>
 				</a>
-			<?php endif; ?>
+				<?php
+
+				do_action( 'storefront_after_single_product_pagination_next' );
+
+			} ?>
 		</nav><!-- .storefront-product-pagination -->
 		<?php
+
+		do_action( 'storefront_after_single_product_pagination' );
 	}
 }
 

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -851,6 +851,8 @@ if ( ! function_exists( 'storefront_sticky_single_add_to_cart' ) ) {
 		wp_localize_script( 'storefront-sticky-add-to-cart', 'storefront_sticky_add_to_cart_params', $params );
 
 		wp_enqueue_script( 'storefront-sticky-add-to-cart' );
+
+		do_action( 'storefront_before_sticky_single_add_to_cart' );
 		?>
 			<section class="storefront-sticky-add-to-cart">
 				<div class="col-full">
@@ -868,6 +870,7 @@ if ( ! function_exists( 'storefront_sticky_single_add_to_cart' ) ) {
 				</div>
 			</section><!-- .storefront-sticky-add-to-cart -->
 		<?php
+		do_action( 'storefront_after_sticky_single_add_to_cart' );
 	}
 }
 


### PR DESCRIPTION
At the moment, the `storefront_single_product_pagination` and `storefront_sticky_single_add_to_cart()` template functions do not feature any action hooks. The proposed changes add some extra calls to `do_action()` inside those two functions so that it would be possible not only to add any extra HTML markup before or after those elements (which could be even achieved by hooking to the appropriate actions those functions are hooked to) but also detect whether something is occurring inside those functions. For example, if a plugin needed to apply some filters but limit their adjustments only inside either the single product pagination or the single product sticky add-to-cart, the following logic could be used:

```php
add_filter( 'woocommerce_single_product_image_html', 'my_change_to_product_thumbnail_html' );
function my_change_to_product_thumbnail_html( $html ) {
    if ( did_action( 'storefront_before_single_product_pagination' ) > did_action( 'storefront_after_single_product_pagination' ) ) {
        // we are inside the pagination element
        // so do something here to alter the markup of the product image
        $html = my_function_to_alter_the_product_thumbnail_html_markup( $html );
    }

    return $html;
}
```
### Changelog

> New - Added actions to single product pagination
> New - Added actions to sticky single add-to-cart
