### PR TITLE
Prevent infinite loop on prev/next product navigation

### DIFF
--- a/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
+++ b/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
@@ -81,18 +81,20 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 
 			$product               = false;
 			$this->current_product = $post->ID;
+			$infinite_loop_blocker = array();
 
 			// Try to get a valid product via `get_adjacent_post()`.
 			// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
-			while ( $adjacent = $this->get_adjacent() ) {
+			while ( ( $adjacent = $this->get_adjacent() ) && ! in_array( $adjacent->ID, $infinite_loop_blocker, true ) ) {
 				$product = wc_get_product( $adjacent->ID );
 
 				if ( $product && $product->is_visible() ) {
 					break;
 				}
 
-				$product               = false;
-				$this->current_product = $adjacent->ID;
+				$product                 = false;
+				$this->current_product   = $adjacent->ID;
+				$infinite_loop_blocker[] = $adjacent->ID;
 			}
 
 			if ( $product ) {


### PR DESCRIPTION
Fixes #2053.
Storefront_WooCommerce_Adjacent_Products::get_product() has no execution time limit. So it may take huge execution time or enter infinite loop.

In my environment, it causes by [Simple Custom Post Order](https://wordpress.org/plugins/simple-custom-post-order/) ( [\SCPO_Engine::scporder_previous_post_where()](https://plugins.trac.wordpress.org/browser/simple-custom-post-order/tags/2.5.6/simple-custom-post-order.php#L472) and [\SCPO_Engine::scporder_next_post_where()](https://plugins.trac.wordpress.org/browser/simple-custom-post-order/tags/2.5.6/simple-custom-post-order.php#L500)).
This is not StoreFront's bug, and it's only occurred in some environments. But it's more better experience by adding infinite loop blocker.
