### PR TITLE
Fix: different Add to Cart Button color inside products grid blocks between editor and front end.

### DIFF
--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -366,10 +366,6 @@ ul.wp-block-latest-posts {
 
 	.wc-block-grid__product {
 
-		.wp-block-button__link {
-			color: #333;
-		}
-
 		.wc-block-grid__product-onsale {
 			border: 1px solid;
 			border-color: $color_body;

--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -1097,6 +1097,12 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 					background-color: ' . storefront_adjust_color_brightness( $storefront_theme_mods['button_background_color'], $darken_factor ) . ';
 				}
 
+				.wc-block-grid__products .wc-block-grid__product .wp-block-button__link {
+					background-color: ' . $storefront_theme_mods['button_background_color'] . ';
+					border-color: ' . $storefront_theme_mods['button_background_color'] . ';
+					color: ' . $storefront_theme_mods['button_text_color'] . ';
+				}
+
 				.wp-block-quote footer,
 				.wp-block-quote cite,
 				.wp-block-quote__citation {


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #2065

On WP 6.1, the editor style is updated, which breaks the style of the Add to Cart Button inside products grid blocks like `All Products` or `On Sale Products` block. This PR fixes that issue by dynamically generating the style for Add to Cart Button using theme modifications.

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

<table>
<tr>
	<td> Before
	<td> After
<tr>
	<td> <img src="https://user-images.githubusercontent.com/5423135/200507794-5b187f09-46f9-4fe5-b796-4455e194b191.png" />
	<td> <img src="https://user-images.githubusercontent.com/5423135/200507520-a221dfb5-d657-4eaf-8006-deed0a7ae3de.png">

</table>

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Check and build this PR.
2. Add `All Products` block to the page.
3. See the color of add to cart button look as expected.
4. Save the page, see the style of the button look the same between editor and front end.
5. Use Customizer to change the text and background color of the button.
6. See the color apply to both front end and editor.

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

### Changelog

Fix - Ensure the style of the poducts grid Add to Cart button is consistent between the editor and front end.

<!-- Add suggested changelog entry here. For example: -->

> Fix – Edit, reply and author icons are now displayed in comment list form. #1319

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
