### PR TITLE
Disable renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,6 @@
     }
   ],
   "ignoreDeps": ["susy"],
-  "reviewers": ["team:kirigami"]
+  "reviewers": ["team:woo-fse"],
+  "enabled": false
 }


### PR DESCRIPTION
This PR disables renovate bot. Currently all dependencies are `devDependencies` so keeping them updated is not critical. This will make it so there are fewer PRs in this project and reduce the maintenance cost.

This PR also fixes the GH team name.

See context in pdCMQf-1wc-p2#comment-701.
