### PR TITLE
add font swap to google font css api

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -391,6 +391,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 			$query_args = array(
 				'family' => implode( '|', $google_fonts ),
 				'subset' => rawurlencode( 'latin,latin-ext' ),
+				'display' => 'swap',
 			);
 
 			$fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );


### PR DESCRIPTION
Add font swap to google font css display:swap to resolve "Ensure text remains visible" problem on web.dev