### PR TITLE
Hide the single product page quantity input, when the product is sold individually.

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -715,6 +715,10 @@ ul.products,
 			font-size: ms(-1);
 			margin-top: 1em;
 		}
+
+		&.sold-individually .quantity {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
If a product is set to be sold individually, let's hide the quantity input.

Fixes #2085.

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

| Regular Product | Sold Individually |
| --- | --- |
| ![test-product-regular](https://user-images.githubusercontent.com/3594411/211949010-9e4e2a6f-f897-4bd4-baff-ddb402a5fcdc.png) | ![test-product-soldindiv](https://user-images.githubusercontent.com/3594411/211949016-fa17f352-6de6-4646-8118-512c9f34c8ca.png) |

The above shows how things will look once this change is applied (the quantity input will be hidden, if the product is set to be sold individually).

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Configure a product to be sold individually.
2. View the corresponding single product page (and please test this against WooCommerce 7.2.0 or higher).
3. With this change, the quantity input should be hidden.
4. Without this change, the quantity input will still be visible.
5. Confirm the quantity input **always** renders for products that are **not** set to be sold individually.

💡 When testing this branch, be sure to rebuild the stylesheets using `npm run build:css`. You may also need to clear your browser cache to see the change.


### Changelog

> Fix – Hide the single product page quantity selector if the product is sold individually. #2085

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
