### PR TITLE
Slight updates for Mix and Match 2.3

### DIFF
--- a/assets/css/woocommerce/extensions/mix-and-match.scss
+++ b/assets/css/woocommerce/extensions/mix-and-match.scss
@@ -33,6 +33,10 @@
 
 	}
 
+	.mnm-checkbox {
+		width: initial;
+	}
+
 }
 
 .cart,

--- a/assets/css/woocommerce/extensions/mix-and-match.scss
+++ b/assets/css/woocommerce/extensions/mix-and-match.scss
@@ -9,25 +9,30 @@
 @import "../../sass/utils/variables";
 @import "../../sass/vendors/modular-scale";
 
-.mnm_table {
+.single-product div.product {
 
-	.product-thumbnail,
-	.product-name,
-	.product-quantity,
-	.container-quantity {
-		padding: ms(-2) ms(-1) !important;
-	}
+	// Tabular layout.
+	.mnm_table {
 
-	.mnm_item {
-
-		img {
-			max-width: 100%;
+		.product-thumbnail,
+		.product-description,
+		.product-quantity {
+			padding: ms(-2) ms(-1) !important;
 		}
+
+		.mnm_item {
+
+			img {
+				max-width: 100%;
+			}
+		}
+
+		.product-quantity .quantity {
+			margin-right: 0;
+		}
+
 	}
 
-	.product-name {
-		vertical-align: middle;
-	}
 }
 
 .cart,


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Updates some claassnames, removes some unneeded styles (handled in MNM itself), and fixes Storefront's quantity input width negatively impacting a checkbox field.

### Screenshots
List view
![image](https://user-images.githubusercontent.com/507025/212764576-251ccfee-c2db-4af5-9699-1ecaeb313337.png)

Grid View
![image](https://user-images.githubusercontent.com/507025/212764635-2b000b82-1146-4244-8313-4d78564ebc69.png)

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

https://github.com/kathyisawesome/woocommerce-mix-and-match-products/releases/download/2.3.0/woocommerce-mix-and-match-products.zip

Or otherwise, just deployed it live

Take a look at grid and table layouts, should be about the same as there is nothing major here.

### Changelog

> Style updates for Mix and Match 2.3.0
