### PR TITLE
Updates Storefront Credit in the footer for SEO.

### DIFF
--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -139,9 +139,9 @@ if ( ! function_exists( 'storefront_credit' ) ) {
 
 		if ( apply_filters( 'storefront_credit_link', true ) ) {
 			if ( storefront_is_woocommerce_activated() ) {
-				$links_output .= '<a href="https://woocommerce.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="noreferrer">' . esc_html__( 'Built with Storefront &amp; WooCommerce', 'storefront' ) . '</a>.';
+				$links_output .= '<a href="https://woocommerce.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="noreferrer nofollow">' . esc_html__( 'Built with Storefront &amp; WooCommerce', 'storefront' ) . '</a>.';
 			} else {
-				$links_output .= '<a href="https://woocommerce.com/storefront/" target="_blank" title="' . esc_attr__( 'Storefront -  The perfect platform for your next WooCommerce project.', 'storefront' ) . '" rel="noreferrer">' . esc_html__( 'Built with Storefront', 'storefront' ) . '</a>.';
+				$links_output .= '<a href="https://woocommerce.com/storefront/" target="_blank" title="' . esc_attr__( 'Storefront -  The perfect platform for your next WooCommerce project.', 'storefront' ) . '" rel="noreferrer nofollow">' . esc_html__( 'Built with Storefront', 'storefront' ) . '</a>.';
 			}
 		}
 


### PR DESCRIPTION
Adds nofollow rel attribute to footer credit links.

<!-- Reference any related issues or PRs here -->

<!-- Briefly describe the issue or problem that this PR solves. -->
Fix details as per @kevinbates SEO request paqDfi-7bi-p2#comment-15767

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->
This fix adds a nofollow value to the existing rel attribute, changing the output to be "noreferrer nofollow" instead of just "noreferrer"

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
Before:

<img width="1119" alt="Screenshot 2023-05-10 at 22 16 10" src="https://github.com/woocommerce/storefront/assets/937325/38ab54d5-8b4d-4dff-8eee-fd99cf9098e2">

After:

<img width="1106" alt="Screenshot 2023-05-10 at 22 23 01" src="https://github.com/woocommerce/storefront/assets/937325/ad3723fb-1296-4695-b2a3-0c0d64e9d637">

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Install and activate Storefront.
2. Navigate to the homepage and inspect the markup of the footer credits.
3. The rel attribute should show the correct values of "noreferrer nofollow"

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – Adds nofollow value to rel attribute in footer credit link.