### PR TITLE
Add &display=swap to googlefont URLs

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -384,7 +384,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 			$google_fonts = apply_filters(
 				'storefront_google_font_families',
 				array(
-					'source-sans-pro' => 'Source+Sans+Pro:400,300,300italic,400italic,600,700,900',
+					'source-sans-pro' => 'Source+Sans+Pro:400,300,300italic,400italic,600,700,900&display=swap',
 				)
 			);
 
@@ -507,7 +507,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 		public function print_embed_styles() {
 			global $storefront_version;
 
-			wp_enqueue_style( 'source-sans-pro', '//fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,300italic,400italic,700,900', array(), $storefront_version );
+			wp_enqueue_style( 'source-sans-pro', '//fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,300italic,400italic,700,900&display=swap', array(), $storefront_version );
 			$accent_color     = get_theme_mod( 'storefront_accent_color' );
 			$background_color = storefront_get_content_background_color();
 			?>


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->

<!-- Briefly describe the issue or problem that this PR solves. -->

Google fonts will add font-display: swap if you pass a parameter to it. This fixes FOIT in many modern browsers which probably makes the user experience a little better.

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

This PR just adds the display=swap parameter to the two places where the google font URL is used.

As I understand it this shouldn't be a problem for older browsers, and will be better on newer ones.

<!-- Don't forget to update the title with something descriptive. -->

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

You could review the score given on google's pagespeed tool. Before patch you will get a fail on " All text remains visible during webfont loads ", after the patch you won't.

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Improvement – Add &display=swap to googlefont URLs

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
