### PR TITLE
[DRAFT] Replace mini-cart widget with mini-cart block and add support for template parts.

### DIFF
--- a/header.php
+++ b/header.php
@@ -15,6 +15,13 @@
 <link rel="profile" href="http://gmpg.org/xfn/11">
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 
+<?php
+// Need to call do_blocks() here to ensure any script/styles are enqueued in wp_head.
+global $storefront_block_mini_cart;
+// todo: could potentially implement better default attributes for the block.
+$storefront_block_mini_cart = function_exists( 'do_blocks' ) ? do_blocks( '<!-- wp:woocommerce/mini-cart /-->' ) : null;
+?>
+
 <?php wp_head(); ?>
 </head>
 

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -247,6 +247,13 @@ if ( ! class_exists( 'Storefront' ) ) :
 					),
 				)
 			);
+
+			/**
+			 * Add support for block emplate parts.
+			 *
+			 * @return void
+			 */
+			add_theme_support('block-template-parts');
 		}
 
 		/**

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -253,7 +253,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 *
 			 * @return void
 			 */
-			add_theme_support('block-template-parts');
+			add_theme_support( 'block-template-parts' );
 		}
 
 		/**

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -115,6 +115,11 @@ if ( ! function_exists( 'storefront_product_search' ) ) {
 	}
 }
 
+function storefront_get_block_mini_cart() {
+	global $storefront_block_mini_cart;
+	return $storefront_block_mini_cart ?? '';
+}
+
 if ( ! function_exists( 'storefront_header_cart' ) ) {
 	/**
 	 * Display Header Cart
@@ -124,6 +129,7 @@ if ( ! function_exists( 'storefront_header_cart' ) ) {
 	 * @return void
 	 */
 	function storefront_header_cart() {
+		$block_mini_cart = storefront_get_block_mini_cart();
 		if ( storefront_is_woocommerce_activated() ) {
 			if ( is_cart() ) {
 				$class = 'current-menu-item';
@@ -131,14 +137,20 @@ if ( ! function_exists( 'storefront_header_cart' ) ) {
 				$class = '';
 			}
 			?>
-		<ul id="site-header-cart" class="site-header-cart menu">
-			<li class="<?php echo esc_attr( $class ); ?>">
-				<?php storefront_cart_link(); ?>
-			</li>
-			<li>
-				<?php the_widget( 'WC_Widget_Cart', 'title=' ); ?>
-			</li>
-		</ul>
+			<ul id="site-header-cart" class="site-header-cart menu">
+				<!-- <li class="<?php echo esc_attr( $class ); ?>">
+					<?php storefront_cart_link(); ?>
+				</li> -->
+				<li>
+					<?php
+					//todo - consider adding a mechansim for either opt-in/opt-out of using the mini-cart block.
+					//old cart
+					//the_widget( 'WC_Widget_Cart', 'title=' );
+					//new cart
+					echo $block_mini_cart;
+					?>
+				</li>
+			</ul>
 			<?php
 		}
 	}

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -115,6 +115,11 @@ if ( ! function_exists( 'storefront_product_search' ) ) {
 	}
 }
 
+/**
+ * Returns the output for the mini-cart block.
+ *
+ * @return string
+ */
 function storefront_get_block_mini_cart() {
 	global $storefront_block_mini_cart;
 	return $storefront_block_mini_cart ?? '';
@@ -143,10 +148,11 @@ if ( ! function_exists( 'storefront_header_cart' ) ) {
 				</li> -->
 				<li>
 					<?php
-					//todo - consider adding a mechansim for either opt-in/opt-out of using the mini-cart block.
-					//old cart
-					//the_widget( 'WC_Widget_Cart', 'title=' );
-					//new cart
+					// todo - consider adding a mechansim for either opt-in/opt-out of using the mini-cart block.
+					// old cart
+					// the_widget( 'WC_Widget_Cart', 'title=' );
+					// new cart
+					// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped by via do_blocks() in header.php.
 					echo $block_mini_cart;
 					?>
 				</li>


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
**Note: this PR should not be merged as is**

This is a very limited proof of concept to aid discussions about having Storefront default to using the Mini-Cart block instead of the Woo Core mini-cart widget. 

The team has been working on some improvements around the use of `get_refreshed_fragments` API in Woo Core, however the mini cart widget will still enqueue this script (and the resulting ajax calls). Implementing some variation of what is suggested in this PR will accomplish a number of things:

- Enable the default state of the theme with a more performant implementation of the mini-cart behaviour via the block version.
- Provide an example for other classic theme shops/developers for how to utilize the new Mini-Cart block in their themes.
- Via enabling template part support (in concert with the changes needed in [WooCommerce Blocks here](https://github.com/woocommerce/woocommerce-blocks/pull/9780)), provides a way for merchants/users of this theme to have more no-code options for customizing the behaviour and design of the Mini-Cart contents panel.

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

The Mini-Cart block in action on the frontend:
![CleanShot 2023-06-09 at 14 40 54](https://github.com/woocommerce/storefront/assets/1429108/4a6bf837-27ef-40f1-b12c-e0ab2e654fe9)

The template part:
![CleanShot 2023-06-09 at 15 02 53](https://github.com/woocommerce/storefront/assets/1429108/6b809613-2ca5-4684-a40d-089926dcdd8b)


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1.
2.
3.

## Additional Notes:

- There are some CSS/styling issues that would need to be handled. Storefront has some custom styles for blocks that impact some of the styles on the frontend. Note that the positioning of the block in the default area is out of alignment vertically.
- The editor WYSIWYG view for the template part does not match the actual rendering on the frontend. I suspect we'd have to either add `theme.json` support to the theme _or_ enqueue relevant styles in the editor context to achieve the parity.
- We'd have to decide how we'd roll this out for all users. For example, would it be something new users of Storefront default to, something that existing users opt-in to? Should we still leave the implementation of the widget available for folks to utilize?
- Merchants would not be able to edit the actual implementation of the block here. This isn't a significant change for users of the Storefront theme because they weren't able to do that beforehand anyways. 
- We'd need to test this with a Storefront child theme and consider what behaviour should exist here.

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Enhancement - Implement Mini-Cart block as a replacement for the Mini-Cart widget. Also enables block template part support for the theme.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
