### PR TITLE
Update Theme URI to point to Woo Marketplace page

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -16,7 +16,7 @@ Storefront is the perfect theme for your next WooCommerce project.
 
 Storefront is the perfect theme for your next WooCommerce project. Designed and developed by WooCommerce Core developers, it features a bespoke integration with WooCommerce itself plus many of the most popular customer facing WooCommerce extensions. There are several layout & color options to personalize your shop, multiple widget regions, a responsive design and much more. Developers will love its lean and extensible codebase making it a joy to customize and extend. Looking for a WooCommerce theme? Look no further!
 
-For more information about Storefront please go to https://woocommerce.com/storefront/.
+For more information about Storefront please go to https://woocommerce.com/products/storefront/.
 
 For even more customization, check out Storefront extensions https://woocommerce.com/product-category/storefront-extensions/ and Storefront child themes https://woocommerce.com/product-category/themes/storefront-child-theme-themes/.
 

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -141,7 +141,7 @@ if ( ! function_exists( 'storefront_credit' ) ) {
 			if ( storefront_is_woocommerce_activated() ) {
 				$links_output .= '<a href="https://woocommerce.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="noreferrer nofollow">' . esc_html__( 'Built with Storefront &amp; WooCommerce', 'storefront' ) . '</a>.';
 			} else {
-				$links_output .= '<a href="https://woocommerce.com/storefront/" target="_blank" title="' . esc_attr__( 'Storefront -  The perfect platform for your next WooCommerce project.', 'storefront' ) . '" rel="noreferrer nofollow">' . esc_html__( 'Built with Storefront', 'storefront' ) . '</a>.';
+				$links_output .= '<a href="https://woocommerce.com/products/storefront/" target="_blank" title="' . esc_attr__( 'Storefront -  The perfect platform for your next WooCommerce project.', 'storefront' ) . '" rel="noreferrer nofollow">' . esc_html__( 'Built with Storefront', 'storefront' ) . '</a>.';
 			}
 		}
 

--- a/languages/storefront.pot
+++ b/languages/storefront.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Storefront 4.3.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/storefront\n"
-"POT-Creation-Date: 2023-05-19 08:43:33+00:00\n"
+"POT-Creation-Date: 2023-07-11 17:42:45+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -874,7 +874,7 @@ msgid "Storefront"
 msgstr ""
 
 #. Theme URI of the plugin/theme
-msgid "https://woocommerce.com/storefront/"
+msgid "https://woocommerce.com/products/storefront/"
 msgstr ""
 
 #. Description of the plugin/theme

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "storefront",
 	"title": "Storefront",
 	"version": "4.3.0",
-	"homepage": "https://woocommerce.com/storefront/",
+	"homepage": "https://woocommerce.com/products/storefront/",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/woothemes/storefront.git"

--- a/style.scss
+++ b/style.scss
@@ -1,6 +1,6 @@
 /*!
 Theme Name:   Storefront
-Theme URI:    https://woocommerce.com/storefront/
+Theme URI:    https://woocommerce.com/products/storefront/
 Author:       Automattic
 Author URI:   https://woocommerce.com/
 Description:  Storefront is the perfect theme for your next WooCommerce project. Designed and developed by WooCommerce Core developers, it features a bespoke integration with WooCommerce itself plus many of the most popular customer facing WooCommerce extensions. There are several layout & color options to personalise your shop, multiple widget regions, a responsive design and much more. Developers will love its lean and extensible codebase making it a joy to customize and extend. Looking for a WooCommerce theme? Look no further!


### PR DESCRIPTION
Previously the Theme URI was pointing to a retired landing page.

This update adjusts the URI to point to the current theme page in the Woo products marketplace.

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Confirm link to Theme URI has been updated to point to the [Woo Marketplace Storefront page](https://woocommerce.com/products/storefront/).
2. Confirm there are no remaining links to the [retired landing page](https://woocommerce.com/storefront/).

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – Theme URI now points to Storefront page in Woo Marketplace. All links to retired theme landing page have also been updated.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
