### PR TITLE
Add exclusion for `/vendor` directory in zip build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
 		"exclude": [
 			"!/assets",
 			"!/languages",
-			"!/vendor",
 			"!/style.css",
 			"!/style-rtl.css",
 			"/assets/css/sass",
 			"/assets/css/**/*.scss",
 			"/e2e",
+			"/vendor",
 			"composer.json",
 			"composer.lock",
 			"package.json",


### PR DESCRIPTION
The `composer archive` command previously included the `/vendor` directory where the `.gitignore` file excludes it.

This adjusts the exclude array in the `composer.json` file to omit the `/vendor` directory from the zip generation.

See this internal conversation for additional context: p1689174493505199-slack-C7U3Y3VMY.

Props to @danieldudzic for discovering the discrepancy!

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Run the `composer install` command which will generate a `/vendor` folder in the root directory.
2. Run `npm run build` and confirm the `storefront.zip` file is generated.
3. Confirm that the zip file is ~2.9 mb in size.
4. Open the generated zip file and confirm that there is no `/vendor` folder present in the root directory of the theme.


### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – add exclusion for /vendor directory in release zip build.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->