### PR TITLE
Enqueue wc-cart-fragments on woocommerce pages

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tested up to: 6.2.2
 Stable tag: 4.4.1
 Version: 4.4.1
 WC requires at least: 4.2
-WC tested up to: 7.7.0
+WC tested up to: 8.0.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Tags: e-commerce, two-columns, left-sidebar, right-sidebar, custom-background, custom-colors, custom-header, custom-menu, featured-images, full-width-template, threaded-comments, accessibility-ready, rtl-language-support, footer-widgets, sticky-post, theme-options, editor-style

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -32,6 +32,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 			add_filter( 'wp_page_menu_args', array( $this, 'page_menu_args' ) );
 			add_filter( 'navigation_markup_template', array( $this, 'navigation_markup_template' ) );
 			add_action( 'enqueue_embed_scripts', array( $this, 'print_embed_styles' ) );
+			add_filter( 'woocommerce_get_script_data', array( $this, 'limit_cart_sync_to_wc_pages' ), 10, 2 );
 		}
 
 		/**
@@ -354,6 +355,8 @@ if ( ! class_exists( 'Storefront' ) ) :
 			 */
 			$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
+			wp_enqueue_script( 'wc-cart-fragments' );
+
 			wp_enqueue_script( 'storefront-navigation', get_template_directory_uri() . '/assets/js/navigation' . $suffix . '.js', array(), $storefront_version, true );
 
 			if ( has_nav_menu( 'handheld' ) ) {
@@ -372,6 +375,24 @@ if ( ! class_exists( 'Storefront' ) ) :
 			if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 				wp_enqueue_script( 'comment-reply' );
 			}
+		}
+
+		/**
+		 * Limit Cart Sync functionality to specific WooCommerce pages
+		 * More details: https://developer.woocommerce.com/2023/06/16/best-practices-for-the-use-of-the-cart-fragments-api/
+		 *
+		 * @param string $script_data The script data.
+		 * @param string $handle The script handle.
+		 * @return string|null
+		 */
+		public function limit_cart_sync_to_wc_pages( $script_data, $handle ) {
+			if ( 'wc-cart-fragments' === $handle ) {
+				if ( is_woocommerce() || is_cart() || is_checkout() ) {
+					return $script_data;
+				}
+				return null;
+			}
+			 return $script_data;
 		}
 
 		/**


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #2101

From WooCommerce Core 7.8, the `wc-cart-fragments` isn't enqueued by default anymore. This causes #2101. I followed the ["Best practices for the use of the “cart fragments” API" post](https://developer.woocommerce.com/2023/06/16/best-practices-for-the-use-of-the-cart-fragments-api/) to fix the issue.

Also, given that the PR is small, I bumped the tested version to 8.0.

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Add a product to the cart
2. Go to the cart or the checkout page (shortcode or blocks versions)
3. Hover over the **Storefront header cart**. Ensure no popup is displayed showing the cart info
4. Update the cart (e.g., Add quantity, remove an item, add a coupon, etc.). Save changes if you are using the shortcode version of the cart and checkout pages. Ensure the **Storefront header cart** reflecting the current changes.



### Changelog

> Fix: Enqueue wc-cart-fragments script on woocommerce pages.


