### PR TITLE
Load wc-cart-fragments-script when the widget cart is active

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -378,7 +378,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 		}
 
 		/**
-		 * Limit Cart Sync functionality to specific WooCommerce pages
+		 * Limit Cart Sync functionality to specific WooCommerce pages or when the Widget Cart is active.
 		 * More details: https://developer.woocommerce.com/2023/06/16/best-practices-for-the-use-of-the-cart-fragments-api/
 		 *
 		 * @param string $script_data The script data.
@@ -387,7 +387,7 @@ if ( ! class_exists( 'Storefront' ) ) :
 		 */
 		public function limit_cart_sync_to_wc_pages( $script_data, $handle ) {
 			if ( 'wc-cart-fragments' === $handle ) {
-				if ( is_woocommerce() || is_cart() || is_checkout() ) {
+				if ( is_woocommerce() || is_cart() || is_checkout() || is_active_widget( false, false, 'woocommerce_widget_cart', true ) ) {
 					return $script_data;
 				}
 				return null;


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #2114

With #2113, we start to enqueue the `wc-cart-fragments-script` only on WooCommerce Pages, but the `Mini Cart Widget` can be loaded in all the pages of WordPress. So, I update the logic to ensure that the script is loaded when the `Mini Cart Widget` is active.

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Install WP-Optimize - Clean, Compress, Cache plugin. 
2. Enable the cache.
3. Add the Mini Cart widget via the widget page (Appareance > Widget). Add in the header.
4. Create a post  and add the `On Sale Products` block (it is important that it is an old block that it is server side). Save it.
5. Visit the post.
6. Add the products in the cart.
7. Ensure that the Mini Cart widget is updated.
8. Refresh the page.
9. Ensure that the Mini Cart widget is loaded and shows the right product in the cart.

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

-
-

### Changelog


> Load  `wc-cart-fragments-script` when Mini Cart widget is active.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
