### PR TITLE
Enqueue wc-cart-fragments always, remove limit

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -377,24 +377,6 @@ if ( ! class_exists( 'Storefront' ) ) :
 		}
 
 		/**
-		 * Limit Cart Sync functionality to specific WooCommerce pages or when the Widget Cart is active.
-		 * More details: https://developer.woocommerce.com/2023/06/16/best-practices-for-the-use-of-the-cart-fragments-api/
-		 *
-		 * @param string $script_data The script data.
-		 * @param string $handle The script handle.
-		 * @return string|null
-		 */
-		public function limit_cart_sync_to_wc_pages( $script_data, $handle ) {
-			if ( 'wc-cart-fragments' === $handle ) {
-				if ( is_woocommerce() || is_cart() || is_checkout() || is_active_widget( false, false, 'woocommerce_widget_cart', true ) ) {
-					return $script_data;
-				}
-				return null;
-			}
-			 return $script_data;
-		}
-
-		/**
 		 * Register Google fonts.
 		 *
 		 * @since 2.4.0

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -32,7 +32,6 @@ if ( ! class_exists( 'Storefront' ) ) :
 			add_filter( 'wp_page_menu_args', array( $this, 'page_menu_args' ) );
 			add_filter( 'navigation_markup_template', array( $this, 'navigation_markup_template' ) );
 			add_action( 'enqueue_embed_scripts', array( $this, 'print_embed_styles' ) );
-			add_filter( 'woocommerce_get_script_data', array( $this, 'limit_cart_sync_to_wc_pages' ), 10, 2 );
 		}
 
 		/**


### PR DESCRIPTION
As stated in https://github.com/woocommerce/storefront/pull/2113
> From WooCommerce Core 7.8, the wc-cart-fragments isn't enqueued by default anymore. This causes https://github.com/woocommerce/storefront/issues/2101. I followed the ["Best practices for the use of the “cart fragments” API" post](https://developer.woocommerce.com/2023/06/16/best-practices-for-the-use-of-the-cart-fragments-api/) to fix the issue.

This PR removes the `limit_cart_sync_to_wc_pages`, since the cart is present on Storefront on every page we need to always load `wc-cart-fragments` and not limit it to only WC pages.

Fixes https://github.com/woocommerce/storefront/issues/2101 & https://github.com/woocommerce/storefront/issues/2114

### How to test the changes in this Pull Request:

1. Go to a non-WooCommerce page, hover over the cart icon on the header, and confirm it displays the pop-up with the cart info.
2. Add some products to the cart and go to the cart page, update the quantity of some of them, and make sure it's updated on the cart widget.
3. Enable a caching plugin (like WP Super Cache) and visit a non-WooCommerce page.
4. Go to the Shop and add some more products to the cart. Go back to the cached non-WooCommerce page from the last step and check the cart has the correct products and amount.

### Changelog

>  Fix: Enqueue wc-cart-fragments script on all pages.