### PR TITLE
Remove unnecessary position in `on sale`

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1859,14 +1859,6 @@ p.stars {
 	}
 }
 
-.wc-block-grid__product-onsale {
-	position: absolute;
-}
-
-.onsale {
-	position: relative;
-}
-
 .wc-block-grid__product-onsale,
 .onsale {
 	border: 1px solid;
@@ -1880,6 +1872,14 @@ p.stars {
 	margin-bottom: 1em;
 	border-radius: 3px;
 	position: relative;
+}
+
+.onsale {
+	position: relative;
+}
+
+.wc-block-grid__product-onsale {
+	position: absolute;
 }
 
 .quantity {


### PR DESCRIPTION
This PR updates the CSS fix `position` introduced in https://github.com/woocommerce/storefront/pull/2118/

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

![image](https://github.com/woocommerce/storefront/assets/4463174/f4a50d8d-5e8e-4f4f-bccf-438c03f496a3)


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Ensure you have a WooCommerce Blocks with https://github.com/woocommerce/woocommerce-blocks/pull/10543.
2. Open the post editor.
3. Add the Hand-picked Products and select a sale product.
4. Save.
5. Visit the page.
6. Check the `Sale` badge shows on the right position.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->