### PR TITLE
 Remove max-width on image div for Mix and Match Products

### DIFF
--- a/assets/css/woocommerce/extensions/mix-and-match.scss
+++ b/assets/css/woocommerce/extensions/mix-and-match.scss
@@ -53,7 +53,3 @@
 		}
 	}
 }
-
-.mnm_image {
-	max-width: ms(6);
-}


### PR DESCRIPTION
Closes #2122.

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Create a mix and match product.
2. Set the customizer setting to grid display and number of columns to 3.
3. The grid should look the same with or without the rule in question.

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Removed some unnecessary style in the Mix and Match CSS integration

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
