### PR TITLE
Updates WooCommerce.com links to Woo.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ When contributing please ensure you follow the guidelines below to help us keep 
 
 GitHub is for _bug reports and contributions only_ - if you have a support question or a request for a customization this is not the right place to post it. Use [WooThemes Support](https://support.woothemes.com) for customer support, [WordPress.org](http://wordpress.org/support/themes/storefront) for community support, and for customizations we recommend one of the following services:
 
--   [Woo Experts](https://woocommerce.com/experts/)
+-   [Woo Experts](https://woo.com/experts/)
 -   [Codeable](https://codeable.io/)
 
 ## Storefront Status

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 
 <p align="center">
   <img src="https://poser.pugx.org/woocommerce/woocommerce/license" alt="license">
-  <a href="https://woocommerce.com/"><img src="http://img.shields.io/badge/Designed%20for-WooCommerce-a46497.svg" alt="Designed for WooCommerce"></a>
+  <a href="https://woo.com/"><img src="http://img.shields.io/badge/Designed%20for-WooCommerce-a46497.svg" alt="Designed for WooCommerce"></a>
   <img src="https://img.shields.io/wordpress/theme/dt/storefront.svg" alt="WordPress.org downloads">
   <img src="https://img.shields.io/wordpress/theme/r/storefront.svg" alt="WordPress.org rating">
 </p>
 
-_Storefront_ is a robust and flexible [WordPress](https://wordpress.org) theme, designed and built by the team at [WooCommerce](https://woocommerce.com/) to help you make the most out of using the [WooCommerce](https://woocommerce.com) plugin to power your online store. It's available to download for free from the WordPress [theme repository](https://wordpress.org/themes/storefront/).
+_Storefront_ is a robust and flexible [WordPress](https://wordpress.org) theme, designed and built by the team at [WooCommerce](https://woo.com/) to help you make the most out of using the [WooCommerce](https://woo.com) plugin to power your online store. It's available to download for free from the WordPress [theme repository](https://wordpress.org/themes/storefront/).
 
 It features deep integration with WooCommerce core plus several of the most popular extensions:
 
--   [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/)
--   [WooCommerce Wishlists](https://woocommerce.com/products/woocommerce-wishlists/)
--   [WooCommerce Brands](https://woocommerce.com/products/brands/)
--   [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/)
+-   [WooCommerce Bookings](https://woo.com/products/woocommerce-bookings/)
+-   [WooCommerce Wishlists](https://woo.com/products/woocommerce-wishlists/)
+-   [WooCommerce Brands](https://woo.com/products/brands/)
+-   [WooCommerce Subscriptions](https://woo.com/products/woocommerce-subscriptions/)
 
 For developers, Storefront is the perfect starting point for your project. Its lean and extensible codebase will allow you to easily add functionality to your site via a child theme and/or custom plugin(s).
 
@@ -26,11 +26,11 @@ Please read [this document](./STOREFRONT_STATUS.md) explaining the current statu
 
 ## Storefront extensions
 
-Looking to take your storefront powered store to the next level? Be sure to checkout the premium [Storefront extensions](https://woocommerce.com/product-category/storefront-extensions/).
+Looking to take your storefront powered store to the next level? Be sure to checkout the premium [Storefront extensions](https://woo.com/product-category/storefront-extensions/).
 
 ## Storefront Documentation
 
-You can view detailed Storefront documentation on the [WooCommerce documentation website](https://docs.woocommerce.com/documentation/themes/storefront/).
+You can view detailed Storefront documentation on the [WooCommerce documentation website](https://woo.com/documentation/themes/storefront/).
 
 ## Storefront in your language
 
@@ -38,7 +38,7 @@ Storefront translations can be downloaded from [WordPress.org](https://translate
 
 ## Storefront help & support
 
-WooCommerce customers can get support at the [WooCommerce support portal](https://woocommerce.com/contact-us/). Otherwise, you can try posting on the [WordPress support forums](https://wordpress.org/support/theme/storefront/). Please remember, GitHub is for bug reports and contributions, _not_ support.
+WooCommerce customers can get support at the [WooCommerce support portal](https://woo.com/contact-us/). Otherwise, you can try posting on the [WordPress support forums](https://wordpress.org/support/theme/storefront/). Please remember, GitHub is for bug reports and contributions, _not_ support.
 
 ## Contributing to Storefront
 

--- a/README.txt
+++ b/README.txt
@@ -16,16 +16,16 @@ Storefront is the perfect theme for your next WooCommerce project.
 
 Storefront is the perfect theme for your next WooCommerce project. Designed and developed by WooCommerce Core developers, it features a bespoke integration with WooCommerce itself plus many of the most popular customer facing WooCommerce extensions. There are several layout & color options to personalize your shop, multiple widget regions, a responsive design and much more. Developers will love its lean and extensible codebase making it a joy to customize and extend. Looking for a WooCommerce theme? Look no further!
 
-For more information about Storefront please go to https://woocommerce.com/products/storefront/.
+For more information about Storefront please go to https://woo.com/products/storefront/.
 
-For even more customization, check out Storefront extensions https://woocommerce.com/product-category/storefront-extensions/ and Storefront child themes https://woocommerce.com/product-category/themes/storefront-child-theme-themes/.
+For even more customization, check out Storefront extensions https://woo.com/product-category/storefront-extensions/ and Storefront child themes https://woo.com/product-category/themes/storefront-child-theme-themes/.
 
 == Installation ==
 
 1. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
 2. Type in Storefront in the search form and press the 'Enter' key on your keyboard.
 3. Click on the 'Activate' button to use your new theme right away.
-4. Go to https://docs.woocommerce.com/documentation/themes/storefront/ guides on how to customize this theme.
+4. Go to https://woo.com/documentation/themes/storefront/ guides on how to customize this theme.
 5. Navigate to Appearance > Customize in your admin panel and customize to taste.
 
 == Copyright ==

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/storefront",
 	"description": "Storefront is a robust and flexible WordPress theme, designed and built by the team at WooCommerce to help you make the most out of using the WooCommerce plugin to power your online store. It's available to download for free from the WordPress theme repository.",
-	"homepage": "https://woocommerce.com/",
+	"homepage": "https://woo.com/",
 	"type": "wordpress-theme",
 	"license": "GPL-3.0+",
 	"require": {

--- a/e2e/specs/browser.test.js
+++ b/e2e/specs/browser.test.js
@@ -3,7 +3,7 @@ describe( 'Storefront', () => {
 		await page.goto( STORE_URL );
 	} );
 
-	it( 'should have "built with Storefront" footer', async () => {
-		await expect( page ).toMatch( 'Built with Storefront & WooCommerce.' );
+	it( 'should have "built with WooCommerce" footer', async () => {
+		await expect( page ).toMatch( 'Built with WooCommerce.' );
 	} );
 } );

--- a/inc/admin/class-storefront-admin.php
+++ b/inc/admin/class-storefront-admin.php
@@ -72,8 +72,8 @@ if ( ! class_exists( 'Storefront_Admin' ) ) :
 					<span class="storefront-welcome-nav__version">Storefront <?php echo esc_attr( $storefront_version ); ?></span>
 					<ul>
 						<li><a href="https://wordpress.org/support/theme/storefront" target="_blank"><?php esc_html_e( 'Support', 'storefront' ); ?></a></li>
-						<li><a href="https://docs.woocommerce.com/documentation/themes/storefront/" target="_blank"><?php esc_html_e( 'Documentation', 'storefront' ); ?></a></li>
-						<li><a href="https://developer.woocommerce.com/category/release-post/storefront-theme-release-notes/" target="_blank"><?php esc_html_e( 'Development blog', 'storefront' ); ?></a></li>
+						<li><a href="https://woo.com/documentation/themes/storefront/" target="_blank"><?php esc_html_e( 'Documentation', 'storefront' ); ?></a></li>
+						<li><a href="https://developer.woo.com/category/release-post/storefront-theme-release-notes/" target="_blank"><?php esc_html_e( 'Development blog', 'storefront' ); ?></a></li>
 					</ul>
 				</section>
 
@@ -130,7 +130,7 @@ if ( ! class_exists( 'Storefront_Admin' ) ) :
 
 
 						<p>
-							<a href="https://woocommerce.com/products/storefront-extensions-bundle/?utm_source=storefront&utm_medium=product&utm_campaign=storefrontaddons" class="storefront-button" target="_blank"><?php esc_html_e( 'Read more and purchase', 'storefront' ); ?></a>
+							<a href="https://woo.com/products/storefront-extensions-bundle/?utm_source=storefront&utm_medium=product&utm_campaign=storefrontaddons" class="storefront-button" target="_blank"><?php esc_html_e( 'Read more and purchase', 'storefront' ); ?></a>
 						</p>
 					</div>
 					<div class="storefront-enhance__column storefront-child-themes">
@@ -150,7 +150,7 @@ if ( ! class_exists( 'Storefront_Admin' ) ) :
 						</p>
 
 						<p>
-							<a href="https://woocommerce.com/product-category/themes/storefront-child-theme-themes/?utm_source=storefront&utm_medium=product&utm_campaign=storefrontaddons" class="storefront-button" target="_blank"><?php esc_html_e( 'Check \'em out', 'storefront' ); ?></a>
+							<a href="https://woo.com/product-category/themes/storefront-child-theme-themes/?utm_source=storefront&utm_medium=product&utm_campaign=storefrontaddons" class="storefront-button" target="_blank"><?php esc_html_e( 'Check \'em out', 'storefront' ); ?></a>
 						</p>
 					</div>
 				</div>

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -139,9 +139,9 @@ if ( ! function_exists( 'storefront_credit' ) ) {
 
 		if ( apply_filters( 'storefront_credit_link', true ) ) {
 			if ( storefront_is_woocommerce_activated() ) {
-				$links_output .= '<a href="https://woocommerce.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="noreferrer nofollow">' . esc_html__( 'Built with Storefront &amp; WooCommerce', 'storefront' ) . '</a>.';
+				$links_output .= '<a href="https://woo.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="noreferrer nofollow">' . esc_html__( 'Built with Storefront &amp; WooCommerce', 'storefront' ) . '</a>.';
 			} else {
-				$links_output .= '<a href="https://woocommerce.com/products/storefront/" target="_blank" title="' . esc_attr__( 'Storefront -  The perfect platform for your next WooCommerce project.', 'storefront' ) . '" rel="noreferrer nofollow">' . esc_html__( 'Built with Storefront', 'storefront' ) . '</a>.';
+				$links_output .= '<a href="https://woo.com/products/storefront/" target="_blank" title="' . esc_attr__( 'Storefront -  The perfect platform for your next WooCommerce project.', 'storefront' ) . '" rel="noreferrer nofollow">' . esc_html__( 'Built with Storefront', 'storefront' ) . '</a>.';
 			}
 		}
 

--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -139,7 +139,7 @@ if ( ! function_exists( 'storefront_credit' ) ) {
 
 		if ( apply_filters( 'storefront_credit_link', true ) ) {
 			if ( storefront_is_woocommerce_activated() ) {
-				$links_output .= '<a href="https://woo.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="noreferrer nofollow">' . esc_html__( 'Built with Storefront &amp; WooCommerce', 'storefront' ) . '</a>.';
+				$links_output .= '<a href="https://woo.com" target="_blank" title="' . esc_attr__( 'WooCommerce - The Best eCommerce Platform for WordPress', 'storefront' ) . '" rel="noreferrer nofollow">' . esc_html__( 'Built with WooCommerce', 'storefront' ) . '</a>.';
 			} else {
 				$links_output .= '<a href="https://woo.com/products/storefront/" target="_blank" title="' . esc_attr__( 'Storefront -  The perfect platform for your next WooCommerce project.', 'storefront' ) . '" rel="noreferrer nofollow">' . esc_html__( 'Built with Storefront', 'storefront' ) . '</a>.';
 			}

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -858,7 +858,7 @@ if ( ! function_exists( 'storefront_woocommerce_brands_homepage_section' ) ) {
 	 * Requires WooCommerce Brands.
 	 *
 	 * @since  2.3.0
-	 * @link   https://woocommerce.com/products/brands/
+	 * @link   https://woo.com/products/brands/
 	 * @uses   apply_filters()
 	 * @uses   storefront_do_shortcode()
 	 * @uses   wp_kses_post()
@@ -912,7 +912,7 @@ if ( ! function_exists( 'storefront_woocommerce_brands_archive' ) ) {
 	 * Requires WooCommerce Brands.
 	 *
 	 * @since  2.3.0
-	 * @link   https://woocommerce.com/products/brands/
+	 * @link   https://woo.com/products/brands/
 	 * @uses   is_tax()
 	 * @uses   wp_kses_post()
 	 * @uses   get_brand_thumbnail_image()
@@ -932,7 +932,7 @@ if ( ! function_exists( 'storefront_woocommerce_brands_single' ) ) {
 	 * Requires WooCommerce Brands.
 	 *
 	 * @since  2.3.0
-	 * @link   https://woocommerce.com/products/brands/
+	 * @link   https://woo.com/products/brands/
 	 * @uses   storefront_do_shortcode()
 	 * @uses   wp_kses_post()
 	 * @return void

--- a/languages/README.md
+++ b/languages/README.md
@@ -4,4 +4,4 @@ Storefront will look in this directory for translations as a fallback. It is how
 
 Alternatively you can put translations in your child theme: `/wp-content/themes/your-child-theme/languages/it_IT.mo`.
 
-You can read more about installing Storefront in your language [here](http://docs.woocommerce.com/document/installing-storefront-in-your-language/).
+You can read more about installing Storefront in your language [here](https://woo.com/document/installing-storefront-in-your-language/).

--- a/languages/storefront.pot
+++ b/languages/storefront.pot
@@ -1,14 +1,14 @@
-# <!=Copyright (C) 2023 Automattic
+# <!=Copyright (C) 2024 Automattic
 # This file is distributed under the GNU General Public License v3 or later.=!>
 msgid ""
 msgstr ""
 "Project-Id-Version: Storefront 4.5.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/storefront\n"
-"POT-Creation-Date: 2023-09-26 20:27:34+00:00\n"
+"POT-Creation-Date: 2024-01-11 04:47:05+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2023-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2024-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: node-wp-i18n 1.2.7\n"
@@ -874,7 +874,7 @@ msgid "Storefront"
 msgstr ""
 
 #. Theme URI of the plugin/theme
-msgid "https://woocommerce.com/products/storefront/"
+msgid "https://woo.com/products/storefront/"
 msgstr ""
 
 #. Description of the plugin/theme
@@ -894,7 +894,7 @@ msgid "Automattic"
 msgstr ""
 
 #. Author URI of the plugin/theme
-msgid "https://woocommerce.com/"
+msgid "https://woo.com/"
 msgstr ""
 
 #. Template Name of the plugin/theme

--- a/languages/storefront.pot
+++ b/languages/storefront.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Storefront 4.5.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/storefront\n"
-"POT-Creation-Date: 2024-01-11 04:47:05+00:00\n"
+"POT-Creation-Date: 2024-01-11 23:26:43+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -678,7 +678,7 @@ msgid "WooCommerce - The Best eCommerce Platform for WordPress"
 msgstr ""
 
 #: inc/storefront-template-functions.php:142
-msgid "Built with Storefront &amp; WooCommerce"
+msgid "Built with WooCommerce"
 msgstr ""
 
 #: inc/storefront-template-functions.php:144

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "storefront",
 	"title": "Storefront",
 	"version": "4.5.3",
-	"homepage": "https://woocommerce.com/products/storefront/",
+	"homepage": "https://woo.com/products/storefront/",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/woothemes/storefront.git"

--- a/style.scss
+++ b/style.scss
@@ -1,8 +1,8 @@
 /*!
 Theme Name:   Storefront
-Theme URI:    https://woocommerce.com/products/storefront/
+Theme URI:    https://woo.com/products/storefront/
 Author:       Automattic
-Author URI:   https://woocommerce.com/
+Author URI:   https://woo.com/
 Description:  Storefront is the perfect theme for your next WooCommerce project. Designed and developed by WooCommerce Core developers, it features a bespoke integration with WooCommerce itself plus many of the most popular customer facing WooCommerce extensions. There are several layout & color options to personalise your shop, multiple widget regions, a responsive design and much more. Developers will love its lean and extensible codebase making it a joy to customize and extend. Looking for a WooCommerce theme? Look no further!
 Version:      4.5.3
 Tested up to: 6.3


### PR DESCRIPTION
Updates all instances of WooCommerce.com links in both the wp-admin and frontend. This includes the developer composer and package files, readme, and language files.

<!-- Reference any related issues or PRs here -->
Fixes request from @kevinbates as per p1704919648335339-slack-C02PXDRC67P 

### How to test the changes in this Pull Request:

1. Install and activate Storefront.
2. Navigate to /wp-admin/themes.php?page=storefront-welcome and check if outbound links point to woo.com instead of woocommerce.com
3. Navigate to /wp-admin/themes.php?theme=storefront and check if outbound links point to woo.com instead of woocommerce.com
4. Navigate to the frontend of your website and check that the "[Built with Storefront](https://woo.com/products/storefront/)." link navigate to the product page on woo.com correctly.

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – Updates wp-admin and frontend credit links to point to Woo.com instead of WooCommerce.com

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->