### PR TITLE
Fix: allow svg in storefront messages, such as notices

### DIFF
--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -235,9 +235,33 @@ if ( ! function_exists( 'storefront_shop_messages' ) ) {
 	 */
 	function storefront_shop_messages() {
 		if ( ! is_checkout() ) {
-			echo wp_kses_post( storefront_do_shortcode( 'woocommerce_messages' ) );
+			$kses_defaults = wp_kses_allowed_html( 'post' );
+
+			$svg_args = array(
+				'svg'   => array(
+					'class'           => true,
+					'aria-hidden'     => true,
+					'aria-labelledby' => true,
+					'role'            => true,
+					'xmlns'           => true,
+					'width'           => true,
+					'height'          => true,
+					'viewbox'         => true,
+				),
+				'g'     => array( 'fill' => true ),
+				'title' => array( 'title' => true ),
+				'path'  => array(
+					'd'               => true,
+					'fill'            => true
+				)
+			);
+
+			$allowed_tags = array_merge( $kses_defaults, $svg_args );
+
+			echo wp_kses( storefront_do_shortcode( 'woocommerce_messages' ), $allowed_tags );
 		}
 	}
+
 }
 
 if ( ! function_exists( 'storefront_woocommerce_pagination' ) ) {

--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -248,12 +248,16 @@ if ( ! function_exists( 'storefront_shop_messages' ) ) {
 					'height'          => true,
 					'viewbox'         => true,
 				),
-				'g'     => array( 'fill' => true ),
-				'title' => array( 'title' => true ),
+				'g'     => array(
+					'fill' => true,
+				),
+				'title' => array(
+					'title' => true,
+				),
 				'path'  => array(
-					'd'               => true,
-					'fill'            => true
-				)
+					'd'    => true,
+					'fill' => true,
+				),
 			);
 
 			$allowed_tags = array_merge( $kses_defaults, $svg_args );
@@ -261,7 +265,6 @@ if ( ! function_exists( 'storefront_shop_messages' ) ) {
 			echo wp_kses( storefront_do_shortcode( 'woocommerce_messages' ), $allowed_tags );
 		}
 	}
-
 }
 
 if ( ! function_exists( 'storefront_woocommerce_pagination' ) ) {


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #2129

This PR fix the missing icon issue of Woo notices with Storefront theme by adding `svg` and its child elements to the allowed html list for `wp_kses()`.

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Alternative
Do nothing, as commented here: https://github.com/woocommerce/storefront/issues/2129#issuecomment-1891565160

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
![image](https://github.com/woocommerce/storefront/assets/5423135/fa05905a-abb3-41de-9f9f-5678995bd6da)


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Create a test page and add the following shortcode to it `[woocommerce_cart]`
2. Go to a product page and click the Add to cart button.
3. See that the notice `“{PRODUCT}” has been added to your cart.` shows an icon. ✅ 
4. Go to the test page from step 1. and update the quantity of the added product.
5. See that the notice `Cart updated.` shows an icon. ✅  
6. Add a coupon code to the cart.
7. See that the notice `Coupon code applied successfully.` shows an icon. ✅
8. Add the same code again.
9. See that the notice `Coupon code already applied!` shows an icon. ✅
10. Add an invalid code.
11. See that the notice `Coupon "{CODE}" does not exist!` shows an icon. ✅
12. Remove the coupon code.
13. See that the notice `Coupon has been removed.` shows an icon. ✅
14. Remove the product from the cart.
15. See that the notice `Your cart is currently empty.` shows an icon. ✅
16. See that the notice `“{PRODUCT}” removed. Undo?` shows an icon. ✅ 

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – Allow SVG in Storefront messages. #1319

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
