### PR TITLE
remove site-logo support

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -152,7 +152,6 @@ if ( ! class_exists( 'Storefront' ) ) :
 				)
 			);
 
-
 			/**
 			 * Declare support for title theme feature.
 			 */

--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -152,20 +152,6 @@ if ( ! class_exists( 'Storefront' ) ) :
 				)
 			);
 
-			/**
-			 *  Add support for the Site Logo plugin and the site logo functionality in JetPack
-			 *  https://github.com/automattic/site-logo
-			 *  http://jetpack.me/
-			 */
-			add_theme_support(
-				'site-logo',
-				apply_filters(
-					'storefront_site_logo_args',
-					array(
-						'size' => 'full',
-					)
-				)
-			);
 
 			/**
 			 * Declare support for title theme feature.


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #2145

This PR fixes #2145. Jetpack deprecated the `site-logo` functionalities, so this PR removes support for it.

At the same time,  it will always be possible to customize the logo given that we already support `custom-logo` ([source code](https://github.com/woocommerce/storefront/blob/940d937f2def95f2b362be6696c02e11fd8469c3/inc/class-storefront.php/#L75-L86))

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Install Jetpack and activate Storefront
2. Make sure WP_DEBUG is enabled
3. Refresh the page
4. Ensure that you don't see any log like this in debug.log:

```
PHP Deprecated:  Hook site-logo is deprecated since version 13.4! Use custom-logo instead. Jetpack no longer supports site-logo feature. Add custom-logo support to your theme instead: https://developer.wordpress.org/themes/functionality/custom-logo/ in /srv/htdocs/__wp__/wp-includes/functions.php on line 6078

```
5. Visit `wp-admin/customize.php`
6. Go on Site Identity
7. Ensure that you can change the logo

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->


### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – Edit, reply and author icons are now displayed in comment list form. #1319

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
