### PR TITLE
Ensure that the build has min.js files before generating the .zip file

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"scripts": {
 		"build:dev": "npm run build:js && npm run build:css",
 		"build": "npm run build:js && npm run build:css && npm run makepot",
-		"postbuild": "npm run -s archive",
+		"postbuild": "npm run validate-build && npm run -s archive",
 		"archive": "rm -rf $npm_package_name && composer archive --file=$npm_package_name --format=zip",
 		"postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
 		"prebuild:js": "rm -f $npm_package_assets_js_min",
@@ -58,7 +58,8 @@
 		"lint:js-fix": "eslint assets/js --ext=js,jsx,ts,tsx --fix",
 		"lint:php": "composer run-script phpcs ./inc",
 		"wp-env": "wp-env",
-		"test:e2e": "npm run wp-env run tests-cli 'wp theme activate storefront' && cross-env wp-scripts test-e2e"
+		"test:e2e": "npm run wp-env run tests-cli 'wp theme activate storefront' && cross-env wp-scripts test-e2e",
+		"validate-build": "./validate-build.sh"
 	},
 	"jest": {
 		"preset": "jest-puppeteer",

--- a/validate-build.sh
+++ b/validate-build.sh
@@ -32,6 +32,7 @@ done < <(find "$base_dir" -type f -name "*.js" ! -name "*.min.js" -print0)
 
 # Exit with an error code if any .js file is missing its corresponding .min.js file
 if [ "$error_flag" -ne 0 ]; then
+  echo "Error: the ZIP could not be built because minified scripts are missing. Please ensure you are using the correct versions of NPM and Node.js."
   exit 1
 else
   echo "All .js files within $base_dir have corresponding .min.js files."

--- a/validate-build.sh
+++ b/validate-build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Initialize the error flag
+error_flag=0
+
+# Define the base directory to check
+base_dir="./assets"
+
+# Check if the base directory exists
+if [ ! -d "$base_dir" ]; then
+  echo "Error: The directory $base_dir does not exist."
+  exit 1
+fi
+
+# Function to check for corresponding .min.js file
+check_for_min_js() {
+  local js_file="$1"
+  local min_js_file="${js_file%.js}.min.js"
+  if [ ! -f "$min_js_file" ]; then
+    echo "Error: No corresponding .min.js file found for $js_file"
+    return 1
+  fi
+  return 0
+}
+
+# Find all .js files within the base directory (excluding .min.js files)
+while IFS= read -r -d '' js_file; do
+  if ! check_for_min_js "$js_file"; then
+    error_flag=1
+  fi
+done < <(find "$base_dir" -type f -name "*.js" ! -name "*.min.js" -print0)
+
+# Exit with an error code if any .js file is missing its corresponding .min.js file
+if [ "$error_flag" -ne 0 ]; then
+  exit 1
+else
+  echo "All .js files within $base_dir have corresponding .min.js files."
+  exit 0
+fi


### PR DESCRIPTION
This PR adds a sanity check step before generating the .zip file to proceed with the release.

When the right version of node isn't used, the *.min.js files aren't generated and this may create some issues on website. This PR ensures that the `min.js` files exist before creating the zip.


## Testing instructions:

1. Checkout this branch
2. Switch to the node 14 version.
3. Run `npm run build`.
4. Ensure that everything works correctly.
5. Switch to the node 20 version (or another version different from 14).
6. Run `npm run build`.
7. Expect to see an error.