### PR TITLE
Account for order attribution being between customer details and add-ons

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -2874,7 +2874,8 @@ dl.variation {
 		}
 	}
 
-	#customer_details + #wc_checkout_add_ons {
+	#customer_details + #wc_checkout_add_ons,
+	#customer_details + wc-order-attribution-inputs + #wc_checkout_add_ons {
 
 		@include span( last 4 of 9 );
 	}


### PR DESCRIPTION
Storefront has CSS to integrate with the [WooCommerce Checkout Add-Ons](https://woocommerce.com/products/woocommerce-checkout-add-ons/) plugin. However, the existing CSS does not work when "Order Attribution" is turned on, because that changes the markup of the page in a way that the CSS selector is no longer accurate.

### Screenshots

Here's what it looks like before (`trunk`):

![Screenshot 2024-06-19 103011](https://github.com/woocommerce/storefront/assets/99189195/dd702304-2d2a-4ce5-b06f-62694d22e723)

And the corresponding markup:

![Screenshot 2024-06-19 103114](https://github.com/woocommerce/storefront/assets/99189195/6c982536-30dd-4a80-b5fd-0542768e51a4)

Here's how it's fixed with this PR:

![Screenshot 2024-06-19 103335](https://github.com/woocommerce/storefront/assets/99189195/95b51a11-8372-4b6a-807e-f777873846f7)

### How to test the changes in this Pull Request:
1. Install the [WooCommerce Checkout Add-Ons](https://woocommerce.com/products/woocommerce-checkout-add-ons/) plugin.
2. Go to WooCommerce > Checkout Add-Ons and create an add-on.
3. Go to WooCommerce > Settings > Advanced > Features and make sure "Order Attribution" is checked on.
4. Go to Appearance > Customize > WooCommerce > Checkout and configure the add-on settings like this:
![Screenshot 2024-06-21 124721](https://github.com/woocommerce/storefront/assets/99189195/0dd45c56-6ae0-4dc7-bbca-0d8e09984db7)
6. Add an item to your cart and go to the checkout page.
7. In `trunk` you will see the layout is broken. Specifically the order summary appears very far down on the page.
8. With this fix applied, you will see the expected column layout is restored.

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

- Checkout and complete purchase. -- checkout layout improved
-

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix checkout page layout when using "Order Attribution" setting and "WooCommerce Checkout Add-Ons" extension.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
