### PR TITLE
Fix: Rating block is showing "S" instead of star on Editor side.

### DIFF
--- a/inc/woocommerce/class-storefront-woocommerce.php
+++ b/inc/woocommerce/class-storefront-woocommerce.php
@@ -38,6 +38,10 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 			// Instead of loading Core CSS files, we only register the font families.
 			add_filter( 'woocommerce_enqueue_styles', '__return_empty_array' );
 			add_filter( 'wp_enqueue_scripts', array( $this, 'add_core_fonts' ), 130 );
+			add_action(
+				'enqueue_block_editor_assets',
+				array( $this, 'add_woocommerce_font_to_editor' )
+			);
 		}
 
 		/**
@@ -125,6 +129,28 @@ if ( ! class_exists( 'Storefront_WooCommerce' ) ) :
 				font-style: normal;
 			}'
 			);
+		}
+
+		/**
+		 * Add WooCommerce fonts to the block editor.
+		 *
+		 * @since 4.6.0
+		 * @return void
+		 */
+		public function add_woocommerce_font_to_editor() {
+			$fonts_url = plugins_url( '/woocommerce/assets/fonts/' );
+			$inline_font = '
+				@font-face {
+					font-family: "WooCommerce";
+					src: url("' . $fonts_url . 'WooCommerce.woff2") format("woff2"),
+						url("' . $fonts_url . 'WooCommerce.woff") format("woff"),
+						url("' . $fonts_url . 'WooCommerce.ttf") format("truetype");
+					font-weight: normal;
+					font-style: normal;
+				}
+			';
+
+			wp_add_inline_style( 'wp-edit-blocks', $inline_font );
 		}
 
 		/**


### PR DESCRIPTION
Rating block is showing "S" instead of star on Editor side, for example on new posts or pages. This PR fixes the issue by enqueuing the WooCommerce font in the editor.

<!-- Reference any related issues or PRs here -->
Fixes #

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Add "All Reviews" block to a new post or page.
2. Verify that the rating block is displaying correctly.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/aba0e878-13e9-4899-adaa-2bba75bdf66c) | ![image](https://github.com/user-attachments/assets/a88d4d02-3608-4e9d-9a4e-a2395041e118) |

3. Publish the post or page, and verify that the rating block is displaying correctly on the frontend.

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix: Rating block is showing "S" instead of star on Editor side.
