### PR TITLE
Add style to coupon error inline message

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1204,12 +1204,21 @@ table.cart {
 			padding-bottom: 1em;
 			margin-bottom: 1em;
 			border-bottom: 1px solid $color_border;
+
+			.coupon-error-notice {
+				color: $error;
+				text-align: left;
+			}
 		}
 
 		input {
 			display: block;
 			width: 100%;
 			margin: ms(-3) 0;
+
+			&.input-text.has-error {
+				box-shadow: inset 2px 0 0 $error;
+			}
 		}
 	}
 }
@@ -1275,6 +1284,14 @@ ul#shipping_method {
  */
 .checkout_coupon {
 	margin-bottom: ms(5);
+
+	.coupon-error-notice {
+		color: $error;
+	}
+
+	.input-text.has-error {
+		box-shadow: inset 2px 0 0 $error;
+	}
 }
 
 form.checkout {


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
This PR fixes the https://github.com/woocommerce/woocommerce/issues/53534 issue caused by merging the https://github.com/woocommerce/woocommerce/pull/48738 PR.

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

#### Cart page
**Before**
![image](https://github.com/user-attachments/assets/21e9ac66-c3d3-4c94-bfb4-b109e5f5d34a)

**After**
![image](https://github.com/user-attachments/assets/6ec52d0e-6b45-474a-8f35-79ab40f968e8)


#### Checkout page
**Before**
![image](https://github.com/user-attachments/assets/af42121b-604b-4be5-90c5-c0f186a225c5)

**After**
![image](https://github.com/user-attachments/assets/de9e4868-cb3e-44f3-bf85-cf6783194291)


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Go to both the Cart and Checkout pages.
2. Add an invalid coupon code.
3. Verify the error message shows up below the coupon input.
4. Verify the error message uses the `$error` color (red) and is left aligned.

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – Edit, reply and author icons are now displayed in comment list form. #1319

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
