### PR TITLE
Update actions/upload-artifact from v3 to v4 to use the latest version. Also fix E2E test artifacts generation by configuring jest-html-reporters.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,7 +44,7 @@ jobs:
                   npm run test:e2e
 
             - name: Archive debug artifacts (screenshots, HTML snapshots)
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               if: always()
               with:
                   name: failures-artifacts

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     Setup:
         name: Setup
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v3
             - name: Cache node modules

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,7 +44,7 @@ jobs:
                   npm run test:e2e
 
             - name: Archive debug artifacts (screenshots, HTML snapshots)
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v3
               if: always()
               with:
                   name: failures-artifacts

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -49,7 +49,7 @@ jobs:
               continue-on-error: true
             - if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
               name: Upload ESLint report
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: eslint_report.json
                   path: eslint_report.json

--- a/e2e/specs/browser.test.js
+++ b/e2e/specs/browser.test.js
@@ -4,9 +4,7 @@ describe( 'Storefront', () => {
 	} );
 
 	it( 'should have "built with WooCommerce" footer', async () => {
-		const footerText = await page.evaluate(
-			() => document.querySelector( 'body' ).innerText
-		);
-		expect( footerText ).toMatch( 'This text does not exist' );
+		const footerText = await page.evaluate( () => document.querySelector( 'body' ).innerText );
+		expect( footerText ).toMatch( 'Built with WooCommerce.' );
 	} );
 } );

--- a/e2e/specs/browser.test.js
+++ b/e2e/specs/browser.test.js
@@ -4,7 +4,9 @@ describe( 'Storefront', () => {
 	} );
 
 	it( 'should have "built with WooCommerce" footer', async () => {
-		const footerText = await page.evaluate( () => document.querySelector( 'body' ).innerText );
-		expect( footerText ).toMatch( 'Built with WooCommerce.' );
+		const footerText = await page.evaluate(
+			() => document.querySelector( 'body' ).innerText
+		);
+		expect( footerText ).toMatch( 'This text does not exist' );
 	} );
 } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"cross-env": "7.0.3",
 				"eslint-plugin-import": "2.29.1",
 				"github-label-sync": "2.3.1",
-				"jest-html-reporters": "^3.1.4",
+				"jest-html-reporters": "^3.1.7",
 				"jest-puppeteer": "10.1.0",
 				"lodash": "4.17.21",
 				"node-wp-i18n": "1.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"cross-env": "7.0.3",
 				"eslint-plugin-import": "2.29.1",
 				"github-label-sync": "2.3.1",
+				"jest-html-reporters": "^3.1.4",
 				"jest-puppeteer": "10.1.0",
 				"lodash": "4.17.21",
 				"node-wp-i18n": "1.2.7",
@@ -35,8 +36,8 @@
 				"uglify-js": "3.19.3"
 			},
 			"engines": {
-				"node": "^20.11.1",
-				"npm": "9.1.3"
+				"node": "20.17.0",
+				"npm": "10.8.2"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -14042,6 +14043,30 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "^2.3.2"
+			}
+		},
+		"node_modules/jest-html-reporters": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/jest-html-reporters/-/jest-html-reporters-3.1.7.tgz",
+			"integrity": "sha512-GTmjqK6muQ0S0Mnksf9QkL9X9z2FGIpNSxC52E0PHDzjPQ1XDu2+XTI3B3FS43ZiUzD1f354/5FfwbNIBzT7ew==",
+			"dev": true,
+			"dependencies": {
+				"fs-extra": "^10.0.0",
+				"open": "^8.0.3"
+			}
+		},
+		"node_modules/jest-html-reporters/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/jest-leak-detector": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,17 @@
 		],
 		"globals": {
 			"STORE_URL": "http://localhost:8802"
-		}
+		},
+		"reporters": [
+			"default",
+			[
+				"jest-html-reporters",
+				{
+					"publicPath": "./artifacts",
+					"filename": "report.html"
+				}
+			]
+		]
 	},
 	"config": {
 		"wp_org_slug": "storefront",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 		"eslint-plugin-import": "2.29.1",
 		"github-label-sync": "2.3.1",
 		"jest-puppeteer": "10.1.0",
-		"jest-html-reporters": "^3.1.4",
+		"jest-html-reporters": "^3.1.7",
 		"lodash": "4.17.21",
 		"node-wp-i18n": "1.2.7",
 		"onchange": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
 		"eslint-plugin-import": "2.29.1",
 		"github-label-sync": "2.3.1",
 		"jest-puppeteer": "10.1.0",
+		"jest-html-reporters": "^3.1.4",
 		"lodash": "4.17.21",
 		"node-wp-i18n": "1.2.7",
 		"onchange": "7.1.0",


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #

This PR updates the GitHub Actions workflow to use `actions/upload-artifact@v4` instead of v3, as v3 [will be deprecated on January 30, 2025](https://github.com/orgs/community/discussions/142581).

GitHub has [announced](https://github.com/orgs/community/discussions/142581) that artifact actions v3 will be closing down by January 30, 2025. After this date, using v3 of these actions will result in workflow failures.

The following workflows have been updated to use `actions/upload-artifact@v4`:
1. **JavaScript and CSS Linting workflow**
   - Updated "Upload ESLint report step to use `actions/upload-artifact@v4`
2. **End-to-End Tests workflow** 
   - Updated the debug artifacts upload step to use `actions/upload-artifact@v4`

#### Additional changes

While testing changes made in this PR, I made two more changes:

1. I have also updated "End-to-End Tests" workflow to use `ubuntu-22.04` because of the issue mentioned in [troubleshooting](https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu) section. This was failing on Ubuntu 23.10+. Probably we can use some [workarounds](https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md) but for now, I have decided to use Ubuntu 22.04 to fix the issue.

2. While testing "End-to-End Tests" workflow, I found that workflow wasn't generating any artifacts, even if tests were failing. I found out that we don't have reporters configured in `package.json`. I have added following to `package.json` to fix the issue.
```json
"reporters": [
			"default",
			[
				"jest-html-reporters",
				{
					"publicPath": "./artifacts",
					"filename": "report.html"
				}
			]
		]
```

I also added `jest-html-reporters` to `devDependencies` in `package.json`.

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Test "JavaScript and CSS Linting / Lint JavaScript" workflow
	- In this PR, verify that the workflow runs successfully
	- Verify that you can see file `eslint_report.json` in the "Artifacts" section of the workflow run
![image](https://github.com/user-attachments/assets/88464439-2176-4191-8ff0-0d712a6d46bf)


2. Test "End-to-End Tests" workflow
	- In this PR, verify that the workflow runs successfully and uploads debug artifacts using v4.
	- Testing generated HTML report
		- Create a pull request that triggers E2E tests.
		- Intentionally make a test fail to generate debug artifacts. For example, I tested in commit f9c3138.
		- Verify that `failures-artifacts` is available in the "Artifacts" section of the workflow run. Download and inspect the file to confirm it contains the expected content.


<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->


### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Update actions/upload-artifact from v3 to v4 to use the latest version. Also fix E2E test artifacts generation by configuring jest-html-reporters.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->