### PR TITLE
Fix - `Filter by Price` block slider doesn't use theme accent color in LTR language

### DIFF
--- a/inc/customizer/class-storefront-customizer.php
+++ b/inc/customizer/class-storefront-customizer.php
@@ -1154,7 +1154,7 @@ if ( ! class_exists( 'Storefront_Customizer' ) ) :
 					color: ' . $storefront_theme_mods['hero_heading_color'] . ';
 				}
 
-				.wc-block-components-price-slider__range-input-progress,
+				div.wc-block-components-price-slider__range-input-progress,
 				.rtl .wc-block-components-price-slider__range-input-progress {
 					--range-color: ' . $storefront_theme_mods['accent_color'] . ';
 				}


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #2185 

This PR fixes an inconsistency in how the `Filter by Price` block's slider color is applied in the Storefront theme. Currently, the slider correctly uses the theme's accent color in RTL mode but fails to apply it in LTR mode, resulting in an inconsistent user experience when switching between languages.

The solution increases the CSS selector specificity by adding the tag name div to the selector, ensuring the accent color is properly applied in both LTR and RTL modes. This fix maintains the existing behavior for RTL languages while correcting it for LTR languages.

### Screenshots
| Before | After |
| ------ | ----- |
| ![before-storefront-filter-by-price](https://github.com/user-attachments/assets/e90fc81c-3510-4a1b-bdc9-fd4b1fa65eca) | ![after-storefront-filter-by-price](https://github.com/user-attachments/assets/1e136322-da9e-4b30-87a6-145950d9da59) |

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Set up Storefront theme with a custom accent color in Customizer (e.g., green or red)
2. Create a page with the `Filter by Price` and `Product Collection` blocks
3. Verify the slider color matches the accent color in LTR mode
4. Switch to an RTL language and verify the slider color still matches the accent color

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – `Filter by Price` slider now consistently uses the theme's accent color in both LTR and RTL languages.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
