### PR TITLE
Add outline to link that wraps image in the product gallery

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -462,6 +462,11 @@ ul.products,
 				text-align: center;
 			}
 
+			.woocommerce-product-gallery__image > a {
+				display: block;
+				outline-offset: -2px;
+			}
+
 			img {
 				margin: 0;
 			}


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #2187

<!-- Briefly describe the issue or problem that this PR solves. -->
This PR adds an outline indicator when the link that wraps the image in the product gallery is focused on.

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
**Before**
No outline indicator when focused on:
![Screenshot 2025-05-09 at 15 45 26](https://github.com/user-attachments/assets/b813c1da-5c41-445c-9c6a-5f8e6f5f6b6f)

**After**
The focus outline indicator is visible when the link that wraps the image is focused on.
![Screenshot 2025-05-09 at 15 46 25](https://github.com/user-attachments/assets/3dbb5aa2-4814-42d6-946f-59cb99582ed6)


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Open a product page with a gallery.
2. Tab navigate through the page until the image in the gallery is focus on.
3. Verify the focus outline indicator is visible.

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – Edit, reply and author icons are now displayed in comment list form. #1319

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
