### PR TITLE
Fix: Remove hardcoded font size in editor to respect browser defaults

### DIFF
--- a/assets/css/base/gutenberg-editor.scss
+++ b/assets/css/base/gutenberg-editor.scss
@@ -20,8 +20,6 @@
 // Base typography
 body {
 	font-family: $base-font;
-	font-size: 16px;
-	line-height: 1.618;
 }
 
 // Post title


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #1337 

<!-- Briefly describe the issue or problem that this PR solves. -->
- This PR resolves the font size inconsistency between the `editor` and `frontend` when users change their browser's default font size. Currently, the `editor` has a **hardcoded font size of `16px`**, while the `frontend` respects the browser's font size settings, creating a mismatch in the content appearance.

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->
- The fix removes the hardcoded `font-size: 16px` and `line-height: 1.618` from the `gutenberg-editor.scss` styles, allowing the editor to inherit the browser's default font size just like the frontend does. This ensures visual parity between what users see in the editor and what appears on the live site.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
#### Before:
https://github.com/user-attachments/assets/1893c2e1-b1cc-408e-9516-6c2cd8ed0b6e

#### After:
https://github.com/user-attachments/assets/4278d801-edb3-48f1-bcd7-465a82075c70

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Change your browser's default font size (e.g., in Chrome: Settings > Appearance > Font size)
2. Create or edit a post/page
3. Compare the text size in the editor with the frontend preview
4. Verify that both now display the same font size
5. Test with different browser font size settings to ensure consistency

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix - Editor now respects browser default font size for consistency with frontend display.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
