### PR TITLE
Increase rating stars target size

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -1814,6 +1814,7 @@ p.stars {
 		display: inline-block;
 		text-decoration: none;
 		font-weight: 400;
+		font-size: 24px;
 
 		&::before {
 			display: block;


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #2190

<!-- Briefly describe the issue or problem that this PR solves. -->

<!-- Explain your fix - how it addresses the problem, what else might be affected, any risks etc. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

**Before**
![image](https://github.com/user-attachments/assets/8af0c734-4eaf-40f1-ae8c-cb6eda1e1a90)

**After**
![image](https://github.com/user-attachments/assets/62659e54-d3c2-4a4c-9128-0a0d9591b843)


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Go to a product page.
2. Find the "Reviews" tab.
3. Verify the stars have 24x24 pixels.

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – Edit, reply and author icons are now displayed in comment list form. #1319

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
