### PR TITLE
Check object exists before calling getBoundingClientRect

### DIFF
--- a/assets/js/woocommerce/header-cart.js
+++ b/assets/js/woocommerce/header-cart.js
@@ -16,12 +16,15 @@
 		const cart = document.querySelector( '.site-header-cart' );
 
 		cart.addEventListener( 'mouseover', function () {
-			const windowHeight = window.outerHeight,
-				cartBottomPos =
+			const windowHeight = window.outerHeight;
+			const shoppingCartContent =
 					this.querySelector(
 						'.widget_shopping_cart_content'
-					).getBoundingClientRect().bottom + this.offsetHeight,
-				cartList = this.querySelector( '.cart_list' );
+					);
+			const cartBottomPos = (shoppingCartContent)
+                ? shoppingCartContent.getBoundingClientRect().bottom + this.offsetHeight
+                : 0;
+			const cartList = document.querySelector( '.cart_list' );
 
 			if ( cartBottomPos > windowHeight ) {
 				cartList.style.maxHeight = '15em';


### PR DESCRIPTION
Fixes #2192

Fixes issue where error is thrown calling getBoundingClientRect on null

Checks the object exists before calling getBoundingClientRect, if it does not exist cartBottomPost will be set to 0

### Screenshots
![image](https://github.com/user-attachments/assets/be648a45-4996-4d4c-8b74-2a78684379e9)

### How to test the changes in this Pull Request:

- Load a page which has the cart icon displayed
- View the console in inspector
- Hover over the cart icon with the mouse
- Error will not be displayed

### Changelog

Fix – getBoundingClientRect error being thrown on cart hover  https://github.com/woocommerce/storefront/issues/2192
