### PR TITLE
[dev] Pin Github actions to full-commit SHA

### DIFF
--- a/.github/workflows/approved-with-labels.yml
+++ b/.github/workflows/approved-with-labels.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Label when approved
-      uses: pullreminders/label-when-approved-action@master
+      uses: pullreminders/label-when-approved-action@09b41ee798957cb258b29e12f7619bf18d229109 #v1.0.7
       env:
         APPROVALS: "1"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,7 +44,7 @@ jobs:
                   npm run test:e2e
 
             - name: Archive debug artifacts (screenshots, HTML snapshots)
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               if: always()
               with:
                   name: failures-artifacts

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -55,7 +55,7 @@ jobs:
                   path: eslint_report.json
             - if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
               name: Annotate Code Linting Results
-              uses: ataylorme/eslint-annotate-action@1.2.0
+              uses: ataylorme/eslint-annotate-action@a1bf7cb320a18aa53cb848a267ce9b7417221526 # v1.2.0
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   report-json: 'eslint_report.json'

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -42,7 +42,7 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-composer-
             - name: Set up PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.24.1
               with:
                   php-version: '7.4'
                   coverage: none


### PR DESCRIPTION
Closes [QAO-27](https://linear.app/a8c/issue/QAO-27/pin-github-actions-to-full-commit-shas)
Contributes to [QAO-23](https://linear.app/a8c/issue/QAO-23)

Pins Github actions to full commit SHAs as immutable references. Also bumped actions/upload-artifact to v4, the e2e-tests workflow was failing because v3 was deprecated (not sure why https://github.com/woocommerce/storefront/pull/2180 missed it). 
Skipped all official GitHub actions and only pinned other 3rd party ones.  
No version updates - used the latest commit in the tag that was already used, except the actions/upload-artifact mentioned above.

