### PR TITLE
package-lock: update version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "storefront",
-			"version": "4.6.0",
+			"version": "4.6.1",
 			"license": "GPL-3.0+",
 			"devDependencies": {
 				"@woocommerce/eslint-plugin": "2.3.0",


### PR DESCRIPTION
There appears to be two different versions in package-lock.json. This makes them both the same.


### Changelog

Make both 'version' entries in package-lock.json match.
