### PR TITLE
Bump opacity on sale price to `.65` from `.5`.

### DIFF
--- a/assets/css/woocommerce/woocommerce.scss
+++ b/assets/css/woocommerce/woocommerce.scss
@@ -412,7 +412,7 @@ ul.products,
 .price {
 
 	del {
-		opacity: 0.5;
+		opacity: 0.65;
 		font-weight: 400;
 
 		& + ins {


### PR DESCRIPTION
Default original price when a product is on sale (in `del` tag) was set to have an opacity of `.5`, which was resulting in low contrast and deemed inaccessible by even AA standards.

Bumping it to `.65` ensures AAA-compliance.

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce/issues/59748

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
<img width="157" height="74" alt="Screenshot 2025-08-08 at 16 12 13" src="https://github.com/user-attachments/assets/18af4cb0-936d-4b78-9b8e-bc963f471a0d" />
<img width="684" height="410" alt="Screenshot 2025-08-08 at 16 12 32" src="https://github.com/user-attachments/assets/dd6c7bbb-50f6-446f-8225-385c971be1bb" />

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and confirm that it doesn't break any other features :) -->

1. Activate the Storefront theme.
2. Make sure you have at least one product on sale.
3. Go to the shop page and notice the original price on the on sale product. Run an accessibility contrast test on the default colors and ensure AAA compliance.

### Changelog

<!-- Add suggested changelog entry here. For example: -->

> Fix – Ensures an AAA-compliant contrast ratio for original price when products are on sale.

<!-- See [previous releases](https://github.com/woocommerce/storefront/releases) for more examples. -->
