### PR TITLE
fix:prevent infinite loop and timeout in adjacent products query on WordPress 6.9

### DIFF
--- a/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
+++ b/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
@@ -83,9 +83,20 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 			$this->current_product = $post->ID;
 
 			// Try to get a valid product via `get_adjacent_post()`.
+			$iteration        = 0;
+			$limit_iteration  = apply_filters( 'storefront_woocommerce_adjacent_products_max_iterations', 10 );
+			$maybe_product_id = false;
+
 			// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			while ( $adjacent = $this->get_adjacent() ) {
-				$product = wc_get_product( $adjacent->ID );
+				$iteration++;
+
+				if ( $iteration > $limit_iteration || $maybe_product_id === $adjacent->ID ) {
+					break;
+				}
+
+				$maybe_product_id = $adjacent->ID;
+				$product          = wc_get_product( $maybe_product_id );
 
 				if ( $product && $product->is_visible() ) {
 					break;
@@ -145,6 +156,11 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 			$new = get_post( $this->current_product );
 
 			$where = str_replace( $post->post_date, $new->post_date, $where );
+			$where = preg_replace(
+				'/AND p.ID [<>=]+ \d+/',
+				'AND p.ID ' . ( $this->previous ? '<' : '>' ) . ' ' . $new->ID,
+				$where
+			);
 
 			return $where;
 		}

--- a/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
+++ b/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
@@ -81,22 +81,20 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 
 			$product               = false;
 			$this->current_product = $post->ID;
+			$iteration             = 0;
+			$limit                 = apply_filters( 'storefront_woocommerce_adjacent_products_max_iterations', 10 );
+			$seen_id               = false;
 
 			// Try to get a valid product via `get_adjacent_post()`.
-			$iteration        = 0;
-			$limit_iteration  = apply_filters( 'storefront_woocommerce_adjacent_products_max_iterations', 10 );
-			$maybe_product_id = false;
-
 			// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			while ( $adjacent = $this->get_adjacent() ) {
-				$iteration++;
-
-				if ( $iteration > $limit_iteration || $maybe_product_id === $adjacent->ID ) {
+				// Prevent infinite loops.
+				if ( ++$iteration > $limit || $seen_id === $adjacent->ID ) {
 					break;
 				}
 
-				$maybe_product_id = $adjacent->ID;
-				$product          = wc_get_product( $maybe_product_id );
+				$seen_id = $adjacent->ID;
+				$product = wc_get_product( $adjacent->ID );
 
 				if ( $product && $product->is_visible() ) {
 					break;
@@ -145,22 +143,24 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 		 * Filters the WHERE clause in the SQL for an adjacent post query, replacing the
 		 * date with date of the next post to consider.
 		 *
+		 * In WordPress 6.9, get_adjacent_post() also uses ID comparison. We need to replace
+		 * the ID to avoid returning the same product when dates are identical.
+		 * 
 		 * @since 2.4.3
 		 *
 		 * @param string $where The `WHERE` clause in the SQL.
-		 * @return WP_POST|false Post object if successful. False if no valid post is found.
+		 * @return string Modified WHERE clause.
 		 */
 		public function filter_post_where( $where ) {
 			global $post;
 
 			$new = get_post( $this->current_product );
 
-			$where = str_replace( $post->post_date, $new->post_date, $where );
-			$where = preg_replace(
-				'/AND p.ID [<>=]+ \d+/',
-				'AND p.ID ' . ( $this->previous ? '<' : '>' ) . ' ' . $new->ID,
-				$where
-			);
+			// Replace ID comparison for WP 6.9+ compatibility.
+			if ( false !== strpos( $where, 'AND p.ID ' ) ) {
+				$operator = $this->previous ? '<' : '>';
+				$where    = str_replace( "AND p.ID {$operator} {$post->ID}", "AND p.ID {$operator} {$new->ID}", $where );
+			}
 
 			return $where;
 		}


### PR DESCRIPTION

<!-- Reference any related issues or PRs here -->

Fixes #https://github.com/woocommerce/storefront/issues/2200 and https://github.com/woocommerce/woocommerce/issues/62233


### Description

This PR fixes a critical 504 Gateway Timeout issue that occurs on WooCommerce product pages when using WordPress 6.9, particularly affecting products with the first, last, or "Uncategorized" category assigned. The timeout was caused by an infinite loop in the adjacent products query when the `get_adjacent()` method repeatedly returned non-visible products or the same product ID.

The fix implements two key improvements:
1. **Loop Safety Guard**: Added iteration counter and duplicate ID detection to prevent infinite loops in the `get_product()` method. The loop now breaks when either the iteration limit (default: 10, filterable) is exceeded or when the same product ID is encountered twice.
2. **Enhanced WHERE Clause**: Improved the `filter_post_where()` method to properly handle ID comparisons when products share the same `post_date`, ensuring correct adjacent product selection by updating the SQL comparison operator based on direction (previous/next).

### Screenshots

N/A - This is a backend performance fix that prevents timeouts.

### How to test the changes in this Pull Request:

1. **Test with problematic categories:**
   - Update WordPress to version 6.9
   - Create or identify a product with the "Uncategorized" category assigned
   - Create or identify products with the first or last category in your category list
   - Visit the single product page for each of these products
   - Verify the page loads successfully without timeout (should load within normal time)

2. **Test adjacent product navigation:**
   - Navigate to a product page with adjacent products enabled
   - Click the "Previous" and "Next" product links
   - Verify the correct adjacent products are displayed
   - Test with products that have the same publication date to ensure correct ordering

3. **Test with visible/invisible products:**
   - Create a product that is not visible in catalog
   - Place it between two visible products
   - Navigate from one visible product to the next
   - Verify the navigation skips the invisible product correctly and doesn't timeout

4. **Verify backward compatibility:**
   - Test on WordPress versions prior to 6.9 to ensure no regressions
   - Test with various category configurations
   - Test with products in different categories and subcategories

<!-- Review the [flows & features doc](https://github.com/woocommerce/storefront/wiki/Testing-Storefront:-flows-and-features) and list any flows that might be impacted or improved -->

- Single product page navigation
- Adjacent product pagination
- Product category filtering

### Changelog

> Fix – Prevent infinite loop causing 504 timeouts on product pages with certain categories in WordPress 6.9. Added iteration limit and duplicate ID detection in adjacent products query, and improved WHERE clause handling for products with identical dates. #2200