### PR TITLE
fix: fix performance issue with adjacent product in 6.9

### DIFF
--- a/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
+++ b/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
@@ -152,10 +152,11 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 			* product when the published date of products is the same.
 			* We're using simple string replacement instead of regex to have the performance impact
 			* as minimal as possible and matching the exact clause provided by WordPress.
+			*
 			* @see https://github.com/WordPress/wordpress-develop/commit/70ca20bcbb3cbdef483050c4764259324c07359e.
 			*/
 			if ( strpos( $where, 'AND p.ID ' ) !== false ) {
-				$search  = sprintf('AND p.ID %s ', $this->previous ? '<' : '>');
+				$search  = sprintf( 'AND p.ID %s ', $this->previous ? '<' : '>' );
 				$target  = $search . $post->ID;
 				$replace = $search . $new->ID;
 

--- a/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
+++ b/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
@@ -146,6 +146,22 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 
 			$where = str_replace( $post->post_date, $new->post_date, $where );
 
+			/**
+			* In 6.9, the get_adjacent_post() function uses not only date but also ID to get the
+			* adjacent post. We need to replace the ID as well to avoid returning the same adjacent
+			* product when the published date of products is the same.
+			* We're using simple string replacement instead of regex to have the performance impact
+			* as minimal as possible and matching the exact clause provided by WordPress.
+			* @see https://github.com/WordPress/wordpress-develop/commit/70ca20bcbb3cbdef483050c4764259324c07359e.
+			*/
+			if ( strpos( $where, 'AND p.ID ' ) !== false ) {
+				$search  = sprintf('AND p.ID %s ', $this->previous ? '<' : '>');
+				$target  = $search . $post->ID;
+				$replace = $search . $new->ID;
+
+				$where = str_replace( $target, $replace, $where );
+			}
+
 			return $where;
 		}
 


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce/issues/62233

- WordPress 6.9 adds an `AND p.ID` fallback in `get_adjacent_post()`. When two products share the same publish date and the adjacent one is hidden, the query could repeat/hang because the ID wasn’t swapped in that clause. This PR fix this issue by altering the clause with not only date but also the current product ID.

### Screenshots
<!-- n/a -->

### How to test the changes in this Pull Request:
1. Use Storefront; open a product on the front end (e.g., `Polo`) and note its next product (e.g., `T-Shirt with Logo`).
2. Edit that next product (`T-Shirt with Logo`): set its publish date/time to exactly match the first product and set visibility to Hidden.
3. Reload the first product page; confirm it loads without timing out, and the prepared next/prev links do not point to the hidden product.

### Changelog
> Fix – Adjust the adjacent product query to address the change in WordPress 6.9, so identical publish dates with hidden products no longer cause timeouts - #2202