### PR TITLE
Storefront_WooCommerce_Adjacent_Products: Add progress guard to loop

### DIFF
--- a/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
+++ b/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
@@ -82,9 +82,16 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 			$product               = false;
 			$this->current_product = $post->ID;
 
+			$seen = array();
+
 			// Try to get a valid product via `get_adjacent_post()`.
 			// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			while ( $adjacent = $this->get_adjacent() ) {
+				if ( isset( $seen[ $adjacent->ID ] ) ) {
+					break; // give up if we're not making progress
+				}
+				$seen[ $adjacent->ID ] = true;
+
 				$product = wc_get_product( $adjacent->ID );
 
 				if ( $product && $product->is_visible() ) {

--- a/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
+++ b/inc/woocommerce/class-storefront-woocommerce-adjacent-products.php
@@ -88,7 +88,7 @@ if ( ! class_exists( 'Storefront_WooCommerce_Adjacent_Products' ) ) :
 			// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			while ( $adjacent = $this->get_adjacent() ) {
 				if ( isset( $seen[ $adjacent->ID ] ) ) {
-					break; // give up if we're not making progress
+					break; // give up if we're not making progress.
 				}
 				$seen[ $adjacent->ID ] = true;
 


### PR DESCRIPTION
Adds a small guard to break out of possible infinite loops in the `Storefront_WooCommerce_Adjacent_Products::get_product()` function.  This doesn't solve any current issues (the recent one is fixed in #2202), this is more of a fail-safe to make sure that infinite loops can't happen again, since SQL filtering can be brittle.

https://en.wikipedia.org/wiki/Defense_in_depth_(computing) 

### References
* https://core.trac.wordpress.org/ticket/64390
* #2202




### Screenshots

### How to test the changes in this Pull Request:

Can undo the recent mitigations in #2202 and recreate an infinite loop by having WordPress 6.9 with three products in the same category, with the same post_date, and the middle one set to be hidden from catalog. This should also mitigate the same problem.

Additionally, regular back, forward arrows between products should continue to work.

### Changelog


> Enhancement - Protect the adjacent product query against future infinite loops originating from outside changes. #2203

