### PR TITLE
Add compatibility with WooCommerce Coming Soon

### DIFF
--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -8,11 +8,20 @@
 if ( ! function_exists( 'storefront_woo_cart_available' ) ) {
 	/**
 	 * Validates whether the Woo Cart instance is available in the request
+	 * Will also be `false` for logged-out users if the Coming Soon mode is enabled for store pages only.
 	 *
 	 * @since 2.6.0
 	 * @return bool
 	 */
 	function storefront_woo_cart_available() {
+		$coming_soon_helper_class = \Automattic\WooCommerce\Internal\ComingSoon\ComingSoonHelper::class;
+		if ( function_exists( 'wc_get_container' ) && class_exists( $coming_soon_helper_class ) ) {
+			$coming_soon_helper = wc_get_container()->get( $coming_soon_helper_class );
+			if ( ! is_user_logged_in() && $coming_soon_helper->is_store_coming_soon() ) {
+				return false;
+			}
+		}
+
 		$woo = WC();
 		return $woo instanceof \WooCommerce && $woo->cart instanceof \WC_Cart;
 	}


### PR DESCRIPTION
Related to WOOPLUG-2450 and https://github.com/woocommerce/woocommerce/issues/50194.

This PR ensures that the theme respects the Coming Soon setting for store-only pages, and doesn't render the mini cart for logged-out users. 

This PR is essentially a companion to https://github.com/woocommerce/woocommerce/pull/62388

### Screenshots

Before:

<img width="1113" height="169" alt="Screenshot 2025-12-11 at 10 35 16" src="https://github.com/user-attachments/assets/50d06e57-65d0-458a-bb7f-cd662490463f" />

After:

<img width="1118" height="171" alt="Screenshot 2025-12-11 at 10 35 27" src="https://github.com/user-attachments/assets/cf017dbb-44c7-4f3d-8d2a-d99dc6180cc9" />

### How to test the changes in this Pull Request:

If you wish, you can test in conjunction with https://github.com/woocommerce/woocommerce/pull/62388

* Start with a clean Woo with some products and using the Storefront theme.
* Go to WC Settings > Site Visibility
* Turn on the Coming Soon mode with restriction to store only
* Go to the frontend as a logged-in user.
* Verify you can see the mini cart.
* Go to the frontend as a logged-out user.
* Verify you don't see the mini cart.
* Verify the block still works well in the admin.

### Changelog

> Fix – Add compatibility with WooCommerce Coming Soon. #2204
