### PR TITLE
fix: always localize storefront-navigation script regardless of menu assignment

### DIFF
--- a/inc/class-storefront.php
+++ b/inc/class-storefront.php
@@ -350,14 +350,14 @@ if ( ! class_exists( 'Storefront' ) ) :
 
 			wp_enqueue_script( 'storefront-navigation', get_template_directory_uri() . '/assets/js/navigation' . $suffix . '.js', array(), $storefront_version, true );
 
-			if ( has_nav_menu( 'handheld' ) ) {
-				$storefront_l10n = array(
+			wp_localize_script(
+				'storefront-navigation',
+				'storefrontScreenReaderText',
+				array(
 					'expand'   => __( 'Expand child menu', 'storefront' ),
 					'collapse' => __( 'Collapse child menu', 'storefront' ),
-				);
-
-				wp_localize_script( 'storefront-navigation', 'storefrontScreenReaderText', $storefront_l10n );
-			}
+				)
+			);
 
 			if ( is_page_template( 'template-homepage.php' ) && has_post_thumbnail() ) {
 				wp_enqueue_script( 'storefront-homepage', get_template_directory_uri() . '/assets/js/homepage' . $suffix . '.js', array(), $storefront_version, true );


### PR DESCRIPTION
## What

`storefront-navigation.js` is always enqueued, but `wp_localize_script()` was only called inside `if ( has_nav_menu( 'handheld' ) )`. When the handheld menu location is registered but no menu is assigned, `has_nav_menu()` returns `false`, the `storefrontScreenReaderText` global is never defined, and the script throws a JavaScript error:

```
ReferenceError: storefrontScreenReaderText is not defined
```

This can happen on a fresh Storefront install before a menu is assigned to the handheld location, and on any setup where menus are managed outside of Appearance → Menus.

**Before:**
```php
wp_enqueue_script( 'storefront-navigation', ... );  // always

if ( has_nav_menu( 'handheld' ) ) {
    $storefront_l10n = array( 'expand' => ..., 'collapse' => ... );
    wp_localize_script( 'storefront-navigation', 'storefrontScreenReaderText', $storefront_l10n );
}
```

**After:**
```php
wp_enqueue_script( 'storefront-navigation', ... );  // always

wp_localize_script(
    'storefront-navigation',
    'storefrontScreenReaderText',
    array( 'expand' => ..., 'collapse' => ... )
);  // always — matches script enqueue
```

The l10n strings are static translated values. There is no cost to outputting them whenever the script is enqueued. The `has_nav_menu()` guard was protecting something that doesn't need protecting.

Related to #2082

---
*Development and testing assisted by AI. All code reviewed and verified manually.*