### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/approved-with-labels.yml
+++ b/.github/workflows/approved-with-labels.yml
@@ -4,6 +4,7 @@ jobs:
   labelWhenApproved:
     name: Label when approved
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: Label when approved
       uses: pullreminders/label-when-approved-action@09b41ee798957cb258b29e12f7619bf18d229109 #v1.0.7

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,6 +7,7 @@ jobs:
     Setup:
         name: Setup for Jobs
         runs-on: ubuntu-latest
+        timeout-minutes: 5
 
         steps:
             - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
@@ -26,6 +27,7 @@ jobs:
         name: Lint JavaScript
         needs: Setup
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
             - name: Cache node modules
@@ -64,6 +66,7 @@ jobs:
         name: Lint CSS
         needs: Setup
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
             - name: Cache node modules
@@ -84,6 +87,7 @@ jobs:
         name: Validate Build
         needs: Setup
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
             - name: Cache node modules

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -24,6 +24,7 @@ jobs:
     phpcs:
         name: PHP coding standards
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             - name: Checkout repository
               uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -12,6 +12,7 @@ jobs:
     phpunit:
         name: PHP Unit Tests (WP ${{ matrix.wordpress.name }})
         runs-on: ubuntu-22.04
+        timeout-minutes: 10
         strategy:
             matrix:
                 wordpress:


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `approved-with-labels.yml` / `labelWhenApproved` | no successful run in 30d | no successful run in 30d | 5 |
| `linting.yml` / `Setup` | 0.4 min | 0.5 min | 5 |
| `linting.yml` / `eslint` | 0.4 min | 0.4 min | 5 |
| `linting.yml` / `stylelint` | 0.3 min | 0.4 min | 5 |
| `linting.yml` / `build` | 0.5 min | 0.6 min | 5 |
| `php-coding-standards.yml` / `phpcs` | 0.3 min | 0.4 min | 5 |
| `php-unit-tests.yml` / `phpunit` | 2.4 min | 4.4 min | 10 |

Part of TESTOPS-272